### PR TITLE
add windows compatibility

### DIFF
--- a/actions/parser.go
+++ b/actions/parser.go
@@ -38,7 +38,7 @@ func ParseWorkflows(workingDir string, workflowPath string) (Workflows, error) {
 	}
 	workflows.WorkingDir = workingDir
 	workflows.WorkflowPath = workflowPath
-	workflows.TempDir, err = ioutil.TempDir("/tmp", "act-")
+	workflows.TempDir, err = ioutil.TempDir("", "act-")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There is no `/tmp` on windows. Go will use the OS specific temporary directory if we pass no specific directory to `ioutil.TempDir`