### PR TITLE
Allow empty string secrets

### DIFF
--- a/actions/runner.go
+++ b/actions/runner.go
@@ -333,7 +333,7 @@ func (action *actionDef) applyEnvironmentSecrets(env *[]string) {
 					secretCache = make(map[string]string)
 				}
 
-				if secretCache[secret] == "" {
+				if _, ok := secretCache[secret]; !ok {
 					fmt.Printf("Provide value for '%s': ", secret)
 					val, err := gopass.GetPasswdMasked()
 					if err != nil {


### PR DESCRIPTION
Allow empty string secrets without repeatedly prompting for them if not provided in the environment