### PR TITLE
Go 1.11.4+ and Docker 18.09 pre-reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Want to contribute to act? Awesome! Check out the [contributing guidelines](CONT
 ## Building from source
 
 * Install Go tools 1.11.4+ - (https://golang.org/doc/install)
-* Have a working Docker v18.09.1+ client - local/Docker for Mac/Docker for Windows
 * Clone this repo `git clone git@github.com:nektos/act.git`
 * Run unit tests with `make check`
 * Build and install: `make install`

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Want to contribute to act? Awesome! Check out the [contributing guidelines](CONT
 
 ## Building from source
 
-* Install Go tools 1.11+ - (https://golang.org/doc/install)
+* Install Go tools 1.11.4+ - (https://golang.org/doc/install)
+* Have a working Docker v18.09.1+ client - local/Docker for Mac/Docker for Windows
 * Clone this repo `git clone git@github.com:nektos/act.git`
 * Run unit tests with `make check`
 * Build and install: `make install`


### PR DESCRIPTION
mention you need DOcker 18.09 - #14 (this is probably something that can change, but its true atm)
also suggest go 1.11.4 - with 1.11.3 and 1.11.1 I got version missmatch errors from `go mod` - see https://github.com/moby/moby/issues/38507#issuecomment-455959948

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>