### PR TITLE
Fix an install command for brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Let's see it in action with a [sample repo](https://github.com/cplee/github-acti
 # Installation
 To install with [Homebrew](https://brew.sh/), run: 
 
-```brew install nektos/tap/act```
+```brew tap nektos/tap && brew install nektos/tap/act```
 
 Alternatively, you can use the following: 
 


### PR DESCRIPTION
Your tool is nice! When I install it using brew, show error message with the following. So I fixed it.

```
❯ brew install nektos/tap/act
Updating Homebrew...
==> Auto-updated Homebrew!
Updated Homebrew from 0f270d811 to cbf049cc9.
Updated 2 taps (homebrew/core and homebrew/cask).
==> Updated Formulae
hugo ✔          crystal         logstash        pandoc          ucloud
mercurial ✔     cython          logtalk         phpunit         urbit
node ✔          dhall-json      mednafen        planck          v8
ruby ✔          direnv          mesa            prettier        verilator
zsh ✔           elasticsearch   meson           ruby-build      vert.x
aws-okta        enet            minimal-racket  sbcl            vim
azure-cli       eslint          mogenerator     ship            w3m
carthage        ethereum        node-build      skaffold        wtf
cmake           gibo            numpy           swiftgen        youtube-dl
conan           hyperscan       opam            tintin
conjure-up      juju-wait       oxipng          topgrade
cryfs           kakoune         packer          typescript

Error: No available formula with the name "nektos/tap/act"
Please tap it and then try again: brew tap nektos/tap
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
```

Adding `brew tap` command before` brew install` command successfully installed.
```
❯ brew tap nektos/tap && brew install nektos/tap/act
==> Tapping nektos/tap
Cloning into '/usr/local/Homebrew/Library/Taps/nektos/homebrew-tap'...
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 6 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), done.
Tapped 1 formula (32 files, 26.3KB).
==> Installing act from nektos/tap
==> Downloading https://github.com/nektos/act/releases/download/v0.0.5/act_Darwi
Already downloaded: /Users/Kentaro/Library/Caches/Homebrew/downloads/b9f279b288466c5eb8aff878abff27c7a1e0758f19215703e576d0660c776e0c--act_Darwin_x86_64.tar.gz
🍺  /usr/local/Cellar/act/0.0.5: 5 files, 13.7MB, built in 6 seconds
```