### PR TITLE
Regex tweaks

### DIFF
--- a/common/git_test.go
+++ b/common/git_test.go
@@ -25,6 +25,8 @@ func TestFindGitSlug(t *testing.T) {
 		{"git@github.com:nektos/act.git", "GitHub", "nektos/act"},
 		{"https://github.com/nektos/act.git", "GitHub", "nektos/act"},
 		{"http://github.com/nektos/act.git", "GitHub", "nektos/act"},
+		{"https://github.com/nektos/act", "GitHub", "nektos/act"},
+		{"http://github.com/nektos/act", "GitHub", "nektos/act"},
 		{"git+ssh://git@github.com/owner/repo.git", "GitHub", "owner/repo"},
 		{"http://myotherrepo.com/act.git", "", "http://myotherrepo.com/act.git"},
 	}


### PR DESCRIPTION
Made a few small changes to the git slug parsing:

- Moved (and properly renamed) regular expressions into vars
- Fixed failing test where github http regex was not matching `http://github.com/user/repo` without `.git` extension. 