### PR TITLE
Detect workflow event type

### DIFF
--- a/actions/runner.go
+++ b/actions/runner.go
@@ -55,18 +55,9 @@ func (runner *runnerImpl) setupWorkflows() error {
 	if err != nil {
 		return err
 	}
-
 	defer workflowReader.Close()
 
 	runner.workflowConfig, err = parser.Parse(workflowReader)
-	/*
-		if err != nil {
-			parserError := err.(*parser.ParserError)
-			for _, e := range parserError.Errors {
-				fmt.Fprintln(os.Stderr, e)
-			}
-		}
-	*/
 	return err
 }
 

--- a/actions/runner_test.go
+++ b/actions/runner_test.go
@@ -24,6 +24,7 @@ func TestRunEvent(t *testing.T) {
 		{"regex.workflow", "push", "exit with `NEUTRAL`: 78"},
 		{"gitref.workflow", "push", ""},
 		{"env.workflow", "push", ""},
+		{"detect_event.workflow", "", ""},
 	}
 	log.SetLevel(log.DebugLevel)
 

--- a/actions/testdata/detect_event.workflow
+++ b/actions/testdata/detect_event.workflow
@@ -1,0 +1,9 @@
+workflow "detect-event" {
+  on = "pull_request"
+  resolves = ["build"]
+}
+
+action "build" {
+  uses = "./action1"
+  args = "echo 'build'"
+}


### PR DESCRIPTION
So this is implementation for my latest comment in #32. 
Act will detect the event type from the workflow file only if there's a single workflow in the file.

```
workflow "test" {
  on = "pull_request"
  resolves = ["task"]
}

task "foo" {
  // ... details
}
```

When running `act` it will run all the tasks for the `pull_request` event. Will add tests as well. 