### PR TITLE
Add info about verbose-switch to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ act -n
 
 # Run in reuse mode to save state:
 act -r
+
+# Enable verbose-logging (can be used with any of the above commands)
+act -v
 ```
 
 # Support


### PR DESCRIPTION
Noticed this information wasn't provided in README, and I have been wondering how to see container logs until I "accidentally" discovered this switch.

Should atleast be documented IMO.