### PR TITLE
Use stdout for actionLogger

### DIFF
--- a/actions/log.go
+++ b/actions/log.go
@@ -32,6 +32,7 @@ const (
 func newActionLogger(actionName string, dryrun bool) *logrus.Entry {
 	logger := logrus.New()
 	logger.SetFormatter(formatter)
+	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logrus.GetLevel())
 	rtn := logger.WithFields(logrus.Fields{"action_name": actionName, "dryrun": dryrun})
 	return rtn


### PR DESCRIPTION
Closes #39 by configuring logrus in `newActionLogger` to send action logs to stdout, instead of stderr, which is the default.