### PR TITLE
Scaffold a new action with --init (-i) flag

### DIFF
--- a/actions/api.go
+++ b/actions/api.go
@@ -44,6 +44,8 @@ type RunnerConfig struct {
 	EventPath       string          // path to JSON file to use for event.json in containers, relative to WorkingDir
 	ReuseContainers bool            // reuse containers to maintain state
 	ForcePull       bool            // force pulling of the image, if already present
+	Init            bool            // init a new action
+	InitRepo        string          // git repo to pull template from
 }
 
 type environmentApplier interface {

--- a/common/file.go
+++ b/common/file.go
@@ -7,31 +7,29 @@ import (
 )
 
 // CopyFile copy file
-func CopyFile(source string, dest string) (err error) {
+func CopyFile(source string, dest string) error {
 	sourcefile, err := os.Open(source)
 	if err != nil {
 		return err
 	}
-
 	defer sourcefile.Close()
 
 	destfile, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
-
 	defer destfile.Close()
 
-	_, err = io.Copy(destfile, sourcefile)
-	if err == nil {
-		sourceinfo, err := os.Stat(source)
-		if err != nil {
-			_ = os.Chmod(dest, sourceinfo.Mode())
-		}
-
+	if _, err = io.Copy(destfile, sourcefile); err != nil {
+		return err
 	}
 
-	return
+	sourceinfo, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dest, sourceinfo.Mode())
 }
 
 // CopyDir recursive copy of directory

--- a/templates/push/action/Dockerfile
+++ b/templates/push/action/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/templates/push/action/entrypoint.sh
+++ b/templates/push/action/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Hello World"

--- a/templates/push/main.workflow
+++ b/templates/push/main.workflow
@@ -1,0 +1,8 @@
+workflow "basic workflow" {
+	on = "push"
+	resolves = ["example"]
+}
+
+action "example" {
+  uses = "docker://.github/action"
+}

--- a/templates/push/main.workflow
+++ b/templates/push/main.workflow
@@ -4,5 +4,5 @@ workflow "basic workflow" {
 }
 
 action "example" {
-  uses = "docker://.github/action"
+  uses = "./.github/action"
 }


### PR DESCRIPTION
I think `act` could be improved with a feature to help setting up a new workflow.

For any existing project running `act --init [push|pull-request|other event type]` will create a new workflow file and an example action template using dummy Dockerfile. It's not much but definitely enough to get rolling with github actions without all the manual work.

New command will only execute if user does not have a `.github` directory (or whatever is set with workspace dir). In order to get started with a new action using docker, one has to type 2 commands:

```
cd ~/projects/foobar
act --init
act
```

And then take it from there to develop and test whatever action they need.

`act --init` creates the following files in the current directory:

```
./.github
./.github/main.workflow
./.github/example-action
./.github/example-action/Dockerfile
./.github/example-action/entrypoint.sh
```

@nektos any thoughts?