### PR TITLE
Handle docker image build failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ export GITHUB_TOKEN = $(shell cat ~/.config/github/token)
 
 default: check
 
+test:
+	go test -cover -short ./...
+
 check:
 	$(ACT) -ra check
 

--- a/actions/runner_test.go
+++ b/actions/runner_test.go
@@ -21,6 +21,7 @@ func TestRunEvent(t *testing.T) {
 		{"basic.workflow", "push", ""},
 		{"pipe.workflow", "push", ""},
 		{"fail.workflow", "push", "exit with `FAILURE`: 1"},
+		{"buildfail.workflow", "push", "COPY failed"},
 		{"regex.workflow", "push", "exit with `NEUTRAL`: 78"},
 		{"gitref.workflow", "push", ""},
 		{"env.workflow", "push", ""},
@@ -42,7 +43,7 @@ func TestRunEvent(t *testing.T) {
 		if table.errorMessage == "" {
 			assert.NilError(t, err, table.workflowPath)
 		} else {
-			assert.Error(t, err, table.errorMessage)
+			assert.ErrorContains(t, err, table.errorMessage)
 		}
 	}
 }

--- a/actions/testdata/buildfail-action/Dockerfile
+++ b/actions/testdata/buildfail-action/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.8
+COPY foobar /foo/bar

--- a/actions/testdata/buildfail.workflow
+++ b/actions/testdata/buildfail.workflow
@@ -1,0 +1,8 @@
+workflow "test" {
+  on = "push"
+  resolves = ["test-action"]
+}
+
+action "test-action" {
+  uses = "./buildfail-action"
+}

--- a/container/docker_build.go
+++ b/container/docker_build.go
@@ -51,7 +51,8 @@ func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 
 		input.Logger.Debugf("Creating image from context dir '%s' with tag '%s'", input.ContextDir, input.ImageTag)
 		resp, err := cli.ImageBuild(input.Ctx, buildContext, options)
-		input.logDockerResponse(resp.Body, err != nil)
+
+		err = input.logDockerResponse(resp.Body, err != nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is related to #33 and #42. 

I initially thought that after i updated to latest `act` version my issue went away. Just confirmed that
that's not the case, and i was able to reproduce the error locally. 

When running act without `-v` flag and when the action's docker image fails to build, users see a cryptic message "docker image ... not found". The run should have been aborted but it's not, this has to do with the build process error handling. I added a conditional to `logDockerResponse` function to catch error message details if it's present. 

So now users will actually see the reason why the docker image build had failed. This change also fixed the issue when `act` runs the older docker image if the most recent one has failed to build. 