### PR TITLE
Ignore error, vet failure

### DIFF
--- a/container/docker_pull.go
+++ b/container/docker_pull.go
@@ -34,7 +34,7 @@ func NewDockerPullExecutor(input NewDockerPullExecutorInput) common.Executor {
 		cli.NegotiateAPIVersion(input.Ctx)
 
 		reader, err := cli.ImagePull(input.Ctx, imageRef, types.ImagePullOptions{})
-		input.logDockerResponse(reader, err != nil)
+		_ = input.logDockerResponse(reader, err != nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This doesn't change the functional behavior of act, but it resolves an error that was erroring when running vet. 

Adding the `_ =` before this line will resolve the following error on `make build`:

```
container/docker_pull.go:37:26: Error return value of `input.logDockerResponse` is not checked (errcheck)
                input.logDockerResponse(reader, err != nil)
                                       ^
Error: exit with `FAILURE`: 1
exit status 1
make[2]: *** [check] Error 1
make[1]: *** [act] Error 2
make: *** [build] Error 2
```