### PR TITLE
Render correct graph for non-default events

### DIFF
--- a/actions/runner.go
+++ b/actions/runner.go
@@ -104,7 +104,7 @@ func (runner *runnerImpl) ListEvents() []string {
 // GraphEvent builds an execution path
 func (runner *runnerImpl) GraphEvent(eventName string) ([][]string, error) {
 	log.Debugf("Listing actions for event '%s'", eventName)
-	resolves := runner.resolveEvent(runner.config.EventName)
+	resolves := runner.resolveEvent(eventName)
 	return newExecutionGraph(runner.workflowConfig, resolves...), nil
 }
 
@@ -140,7 +140,7 @@ func (runner *runnerImpl) Close() error {
 
 // get list of resolves for an event
 func (runner *runnerImpl) resolveEvent(eventName string) []string {
-	workflows := runner.workflowConfig.GetWorkflows(runner.config.EventName)
+	workflows := runner.workflowConfig.GetWorkflows(eventName)
 	resolves := make([]string, 0)
 	for _, workflow := range workflows {
 		for _, resolve := range workflow.Resolves {

--- a/actions/runner_test.go
+++ b/actions/runner_test.go
@@ -8,6 +8,25 @@ import (
 	"gotest.tools/assert"
 )
 
+func TestGraphEvent(t *testing.T) {
+	runnerConfig := &RunnerConfig{
+		Ctx:          context.Background(),
+		WorkflowPath: "multi.workflow",
+		WorkingDir:   "testdata",
+		EventName:    "push",
+	}
+	runner, err := NewRunner(runnerConfig)
+	assert.NilError(t, err)
+
+	graph, err := runner.GraphEvent("push")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, graph, [][]string{{"build"}})
+
+	graph, err = runner.GraphEvent("release")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, graph, [][]string{{"deploy"}})
+}
+
 func TestRunEvent(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/actions/testdata/multi.workflow
+++ b/actions/testdata/multi.workflow
@@ -1,0 +1,19 @@
+workflow "buildwf" {
+  on = "push"
+  resolves = ["build"]
+}
+
+action "build" {
+  uses = "./action1"
+  args = "echo 'build'"
+}
+
+workflow "deploywf" {
+  on = "release"
+  resolves = ["deploy"]
+}
+
+action "deploy" {
+  uses = "./action2"
+  runs = ["/bin/sh", "-c", "cat $GITHUB_EVENT_PATH"]
+}


### PR DESCRIPTION
(Thanks for the amazing project)

I noticed when running `act -l` for a workflow file that had multiple workflows, it would show the actions for `push` under each event.

I've submitted a fix for this as well as a test to prove correct output. Feel free to butcher this PR or replace it with your own work - just happy to try help :)