### PR TITLE
Use docker’s stdcopy to ensure we don’t emit garbage bytes to stdout

### DIFF
--- a/container/docker_common.go
+++ b/container/docker_common.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/docker/docker/pkg/stdcopy"
 	"io"
 	"os"
 
@@ -31,12 +32,10 @@ type dockerMessage struct {
 }
 
 func (i *DockerExecutorInput) logDockerOutput(dockerResponse io.Reader) {
-	scanner := bufio.NewScanner(dockerResponse)
-	if i.Logger == nil {
-		return
-	}
-	for scanner.Scan() {
-		i.Logger.Infof(scanner.Text())
+	w := i.Logger.Writer()
+	_, err := stdcopy.StdCopy(w, w, dockerResponse)
+	if err != nil {
+		i.Logger.Error(err)
 	}
 }
 

--- a/container/docker_run_test.go
+++ b/container/docker_run_test.go
@@ -1,0 +1,55 @@
+package container
+
+import (
+	"bytes"
+	"context"
+	"github.com/nektos/act/common"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"testing"
+)
+
+type rawFormatter struct{}
+
+func (f *rawFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return []byte(entry.Message), nil
+}
+
+func TestNewDockerRunExecutor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slower test")
+	}
+
+	noopLogger := logrus.New()
+	noopLogger.SetOutput(ioutil.Discard)
+
+	buf := &bytes.Buffer{}
+	logger := logrus.New()
+	logger.SetOutput(buf)
+	logger.SetFormatter(&rawFormatter{})
+
+	runner := NewDockerRunExecutor(NewDockerRunExecutorInput{
+		DockerExecutorInput: DockerExecutorInput{
+			Ctx:    context.TODO(),
+			Logger: logrus.NewEntry(logger),
+		},
+		Image: "hello-world",
+	})
+
+	puller := NewDockerPullExecutor(NewDockerPullExecutorInput{
+		DockerExecutorInput: DockerExecutorInput{
+			Ctx:    context.TODO(),
+			Logger: logrus.NewEntry(noopLogger),
+		},
+		Image: "hello-world",
+	})
+
+	pipeline := common.NewPipelineExecutor(puller, runner)
+	err := pipeline()
+	assert.NoError(t, err)
+
+	expected := `docker run image=hello-world entrypoint=[] cmd=[]Hello from Docker!`
+	actual := buf.String()
+	assert.Equal(t, expected, actual[:len(expected)])
+}


### PR DESCRIPTION
As per the [`ContainerAttach()` docs](https://github.com/docker/go-docker/blob/4daae26030ad00e348edddff9767924ae57a3b82/container_attach.go#L17-L33), a container _not_ using a TTY has stderr and stdout multiplexed into a single stream in a Docker-specific format.

When running `act` and its stdout is not a terminal (e.g. when it's redirected to a file), `DockerExecutorInput.logDockerOutput()` is invoked -- I've changed this to use `github.com/docker/docker/pkg/stdcopy.StdCopy` as per Docker's suggestion.

Right now the issue is the tests pass when output is redirected to a file and fail when run directly in a terminal! ❗️ This is because of the following two conflicting pieces:

https://github.com/nektos/act/blob/f2cb9e391e504b7b507bb75415da040d558e46ba/container/docker_run.go#L89-L97

https://github.com/nektos/act/blob/f2cb9e391e504b7b507bb75415da040d558e46ba/container/docker_run.go#L170-L171

Honestly, I'm not sure what the purpose of the `NORAW` env var is. If `NORAW` is passed in, the tests will fail in even more spectacular ways. I would _like_ to do the following, but wanted to run it by you first before submitting this PR:

* Instead of `terminal.IsTerminal()` in `attachContainer()`, we use the Docker API client to introspect the container and see if it is in TTY mode or not.
* Additionally, add `Tty *bool` to `NewDockerRunExecutorInput` and only fall back to `terminal.IsTerminal()` if it is nil.

What are your thoughts?

