### PR TITLE
fix #117 - handle whitespace in actrc secrets

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,7 @@ func readArgsFile(file string) []string {
 	for scanner.Scan() {
 		arg := scanner.Text()
 		if strings.HasPrefix(arg, "-") {
-			args = append(args, regexp.MustCompile("\\s").Split(arg, 2)...)
+			args = append(args, regexp.MustCompile(`\s`).Split(arg, 2)...)
 		}
 	}
 	return args

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/nektos/act/pkg/common"
@@ -74,7 +75,7 @@ func readArgsFile(file string) []string {
 	for scanner.Scan() {
 		arg := scanner.Text()
 		if strings.HasPrefix(arg, "-") {
-			args = append(args, strings.Fields(arg)...)
+			args = append(args, regexp.MustCompile("\\s").Split(arg, 2)...)
 		}
 	}
 	return args

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -14,7 +14,7 @@ type secrets map[string]string
 func newSecrets(secretList []string) secrets {
 	s := make(map[string]string)
 	for _, secretPair := range secretList {
-		secretPairParts := strings.Split(secretPair, "=")
+		secretPairParts := strings.SplitN(secretPair, "=", 2)
 		if len(secretPairParts) == 2 {
 			s[secretPairParts[0]] = secretPairParts[1]
 		} else if env, ok := os.LookupEnv(secretPairParts[0]); ok && env != "" {


### PR DESCRIPTION
Fixes #117 

Currently whitespaces in secrets provided via `.actrc` lead to problems, because `strings.Fields` splits on _all_ spaces. Now, only the first space is used for splitting. Same for `=` in the secret handling method.