### PR TITLE
Add support for step.working-directory (closes #149)

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -53,6 +53,7 @@ func TestRunEvent(t *testing.T) {
 		{"local-action-dockerfile", "push", ""},
 		{"matrix", "push", ""},
 		{"commands", "push", ""},
+		{"workdir", "push", ""},
 	}
 	log.SetLevel(log.DebugLevel)
 

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -110,6 +110,13 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 			return err
 		}
 
+		if step.WorkingDirectory != "" {
+			_, err = script.WriteString(fmt.Sprintf("cd %s\n", step.WorkingDirectory))
+			if err != nil {
+				return err
+			}
+		}
+
 		run := rc.ExprEval.Interpolate(step.Run)
 
 		if _, err = script.WriteString(run); err != nil {

--- a/pkg/runner/testdata/workdir/push.yml
+++ b/pkg/runner/testdata/workdir/push.yml
@@ -1,0 +1,16 @@
+name: workdir
+on: push
+
+jobs:
+  workdir:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: '[[ "$(pwd)" == "/github/workspace/workdir" ]]'
+      working-directory: workdir
+
+  noworkdir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: '[[ "$(pwd)" == "/github/workspace" ]]'


### PR DESCRIPTION
Let me know if you're unhappy with this approach and I'd be happy to change it. The main alternative I could think of was threading it through to `docker exec` itself, but that would be a substantial change to:

https://github.com/nektos/act/blob/25e1ad687d34102aa1508da38cef0e36a13a9b87/pkg/runner/step_context.go#L42

https://github.com/nektos/act/blob/25e1ad687d34102aa1508da38cef0e36a13a9b87/pkg/runner/step_context.go#L29

https://github.com/nektos/act/blob/25e1ad687d34102aa1508da38cef0e36a13a9b87/pkg/runner/run_context.go#L143

https://github.com/nektos/act/blob/25e1ad687d34102aa1508da38cef0e36a13a9b87/pkg/container/docker_run.go#L119

https://github.com/nektos/act/blob/25e1ad687d34102aa1508da38cef0e36a13a9b87/pkg/container/docker_run.go#L254

And of course all associated interfaces and structs. 