### PR TITLE
Add support for runs-on array form (closes #146)

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -56,7 +56,7 @@ func (w *Workflow) On() []string {
 type Job struct {
 	Name           string                    `yaml:"name"`
 	RawNeeds       yaml.Node                 `yaml:"needs"`
-	RunsOn         string                    `yaml:"runs-on"`
+	RawRunsOn      yaml.Node                 `yaml:"runs-on"`
 	Env            map[string]string         `yaml:"env"`
 	If             string                    `yaml:"if"`
 	Steps          []*Step                   `yaml:"steps"`
@@ -107,6 +107,28 @@ func (j *Job) Needs() []string {
 	case yaml.SequenceNode:
 		var val []string
 		err := j.RawNeeds.Decode(&val)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return val
+	}
+	return nil
+}
+
+// RunsOn list for Job
+func (j *Job) RunsOn() []string {
+
+	switch j.RawRunsOn.Kind {
+	case yaml.ScalarNode:
+		var val string
+		err := j.RawRunsOn.Decode(&val)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return []string{val}
+	case yaml.SequenceNode:
+		var val []string
+		err := j.RawRunsOn.Decode(&val)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -218,13 +218,13 @@ func (rc *RunContext) platformImage() string {
 	c := job.Container()
 	if c != nil {
 		return c.Image
-	} else {
-		for _, runnerLabel := range job.RunsOn() {
-			platformName := rc.ExprEval.Interpolate(runnerLabel)
-			image := rc.Config.Platforms[strings.ToLower(platformName)]
-			if image != "" {
-				return image
-			}
+	}
+
+	for _, runnerLabel := range job.RunsOn() {
+		platformName := rc.ExprEval.Interpolate(runnerLabel)
+		image := rc.Config.Platforms[strings.ToLower(platformName)]
+		if image != "" {
+			return image
 		}
 	}
 
@@ -240,7 +240,7 @@ func (rc *RunContext) isEnabled(ctx context.Context) bool {
 	}
 
 	img := rc.platformImage()
-	if  img == "" {
+	if img == "" {
 		log.Infof("\U0001F6A7  Skipping unsupported platform '%+v'", job.RunsOn())
 		return false
 	}

--- a/pkg/runner/testdata/runs-on/push.yml
+++ b/pkg/runner/testdata/runs-on/push.yml
@@ -8,3 +8,17 @@ jobs:
     - run: env
     - run: echo ${GITHUB_ACTOR} 
     - run: echo ${GITHUB_ACTOR} | grep nektos/act
+
+  many:
+    runs-on: [ubuntu-latest]
+    steps:
+      - run: env
+      - run: echo ${GITHUB_ACTOR}
+      - run: echo ${GITHUB_ACTOR} | grep nektos/act
+
+  selfmany:
+    runs-on: [self-hosted, ubuntu-latest]
+    steps:
+      - run: env
+      - run: echo ${GITHUB_ACTOR}
+      - run: echo ${GITHUB_ACTOR} | grep nektos/act


### PR DESCRIPTION
Implemented as per discussion in #146. I guess the "interesting" thing here is the tests. It was easy enough to see that the parser no longer crashes on the array form. I wasn't able to think of a test for the "no matching labels" case - right now it just logs a message and skips over it silently. This was the existing behaviour, so I guess that's not a problem?