### PR TITLE
Improved gitignore handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	gopkg.in/godo.v2 v2.0.9
 	gopkg.in/ini.v1 v1.41.0 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
-	gopkg.in/src-d/go-billy.v4 v4.3.0 // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.0
 	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.9.1
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71


### PR DESCRIPTION
I noticed that the tar file created and copied to the build container by `act` was taking a long time. I took a look and it was much bigger than I expected - it was including a whole lot of node_modules that should have been excluded. 

It appeared that my gitignore config wasn't being respected - I have `.gitignore` files that aren't at the root of the repo. I switched to a different library, which happened to already be part of `act`. This reduced the size of the tar by a few hundred MB and sped up operations a fair bit.

I'd be happy to add a test for this, but that would be easier if I factored out the actual copy-to-container functionality into a different method. If you'd like that, let me know and I'll submit a second PR. 

https://github.com/nektos/act/blob/4a4bd36cf65b36bb12ddad4d8379cd24b2384885/pkg/container/docker_run.go#L392-L395