### PR TITLE
Use go-git for looking up repository details

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/docker/docker v0.0.0-20200229013735-71373c6105e3
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
-	github.com/go-ini/ini v1.41.0
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/gorilla/mux v1.7.0 // indirect
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjr
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.1.1 h1:j3L6gSLQalDETeEg/Jg0mGY0/y/N6zI2xX1978P0Uqw=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/go-ini/ini v1.41.0 h1:526aoxDtxRHFQKMZfcX2OG9oOI8TJ5yPLM0Mkno/uTY=
-github.com/go-ini/ini v1.41.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/go-ini/ini"
 	log "github.com/sirupsen/logrus"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -116,25 +115,15 @@ func FindGithubRepo(file string) (string, error) {
 }
 
 func findGitRemoteURL(file string) (string, error) {
-	gitDir, err := findGitDirectory(file)
+	repository, err := git.PlainOpen(file)
 	if err != nil {
-		return "", err
+		return "", nil
 	}
-	log.Debugf("Loading slug from git directory '%s'", gitDir)
-
-	gitconfig, err := ini.InsensitiveLoad(fmt.Sprintf("%s/config", gitDir))
+	remote, err := repository.Remote("origin")
 	if err != nil {
-		return "", err
+		return "", nil
 	}
-	remote, err := gitconfig.GetSection("remote \"origin\"")
-	if err != nil {
-		return "", err
-	}
-	urlKey, err := remote.GetKey("url")
-	if err != nil {
-		return "", err
-	}
-	url := urlKey.String()
+	url := remote.Config().URLs[0]
 	return url, nil
 }
 

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -117,11 +117,11 @@ func FindGithubRepo(file string) (string, error) {
 func findGitRemoteURL(file string) (string, error) {
 	repository, err := git.PlainOpen(file)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	remote, err := repository.Remote("origin")
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	url := remote.Config().URLs[0]
 	return url, nil

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -28,30 +28,19 @@ var (
 
 // FindGitRevision get the current git revision
 func FindGitRevision(file string) (shortSha string, sha string, err error) {
-	gitDir, err := findGitDirectory(file)
+	repository, err := git.PlainOpen(file)
 	if err != nil {
 		return "", "", err
 	}
 
-	bts, err := ioutil.ReadFile(filepath.Join(gitDir, "HEAD"))
+	head, err := repository.Head()
 	if err != nil {
 		return "", "", err
 	}
 
-	var ref = strings.TrimSpace(strings.TrimPrefix(string(bts), "ref:"))
-	var refBuf []byte
-	if strings.HasPrefix(ref, "refs/") {
-		// load commitid ref
-		refBuf, err = ioutil.ReadFile(filepath.Join(gitDir, ref))
-		if err != nil {
-			return "", "", err
-		}
-	} else {
-		refBuf = []byte(ref)
-	}
-
-	log.Debugf("Found revision: %s", refBuf)
-	return string(refBuf[:7]), strings.TrimSpace(string(refBuf)), nil
+	hash := head.Hash().String()
+	log.Debugf("Found revision: %s", hash)
+	return hash[:7], hash, nil
 }
 
 // FindGitRef get the current git ref

--- a/pkg/common/git_test.go
+++ b/pkg/common/git_test.go
@@ -58,7 +58,9 @@ func TestFindGitRemoteURL(t *testing.T) {
 	err = gitCmd("config", "-f", fmt.Sprintf("%s/.git/config", basedir), "--add", "remote.origin.url", remoteURL)
 	assert.Nil(err)
 
-	u, err := findGitRemoteURL(basedir)
+	repository, err := FindGitRepository(basedir)
+	assert.Nil(err)
+	u, err := findGitRemoteURL(repository)
 	assert.Nil(err)
 	assert.Equal(remoteURL, u)
 }
@@ -139,7 +141,9 @@ func TestGitFindRef(t *testing.T) {
 			require.NoError(t, os.MkdirAll(dir, 0755))
 			require.NoError(t, gitCmd("-C", dir, "init"))
 			tt.Prepare(t, dir)
-			ref, err := FindGitRef(dir)
+			repository, err := FindGitRepository(dir)
+			require.NoError(t, err)
+			ref, err := FindGitRef(repository)
 			tt.Assert(t, ref, err)
 		})
 	}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -370,7 +370,6 @@ func (rc *RunContext) getGithubContext() *githubContext {
 	}
 
 	repoName, err := common.FindGithubRepoName(repository)
-	log.Warningf("unable to get git repoName: %v", repoPath)
 	if err != nil {
 		log.Warningf("unable to get git repository name: %v", err)
 	} else {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -363,21 +363,28 @@ func (rc *RunContext) getGithubContext() *githubContext {
 	}
 
 	repoPath := rc.Config.Workdir
-	repo, err := common.FindGithubRepo(repoPath)
+
+	repository, err := common.FindGitRepository(repoPath)
 	if err != nil {
-		log.Warningf("unable to get git repo: %v", err)
-	} else {
-		ghc.Repository = repo
+		log.Warningf("unable to get git repository: %v", err)
 	}
 
-	_, sha, err := common.FindGitRevision(repoPath)
+	repoName, err := common.FindGithubRepoName(repository)
+	log.Warningf("unable to get git repoName: %v", repoPath)
+	if err != nil {
+		log.Warningf("unable to get git repository name: %v", err)
+	} else {
+		ghc.Repository = repoName
+	}
+
+	_, sha, err := common.FindGitRevision(repository)
 	if err != nil {
 		log.Warningf("unable to get git revision: %v", err)
 	} else {
 		ghc.Sha = sha
 	}
 
-	ref, err := common.FindGitRef(repoPath)
+	ref, err := common.FindGitRef(repository)
 	if err != nil {
 		log.Warningf("unable to get git ref: %v", err)
 	} else {


### PR DESCRIPTION
**What was changed?**
This PR replaces all custom logic used to fetch Git metadata with `go-git` library.

**Why do we need the changes?**
While working on a project I noticed `act` is setting an incorrect repository name & reference in the event.
This is happening due to the repositories layout I'm using: a single repo containing a number of submodules, each of those define their own workflows. Since git submodules reside in `.git` folder of the parent repo, `act`'s logic of parsing `.git/config` wasn't working as it should.