### PR TITLE
Windows+Docker path reference fixes, mostly around the not relying on filepath.Separator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ NEW_VERSION ?= $(MAJOR_VERSION).$(MINOR_VERSION).$(shell echo $$(( $(PATCH_VERSI
 ACT ?= go run main.go
 export GITHUB_TOKEN = $(shell cat ~/.config/github/token)
 
-build: 
+build:
 	go build -ldflags "-X main.version=$(VERSION)" -o dist/local/act main.go
+
+go-install:
+	go install -ldflags "-X main.version=$(VERSION)" .
 
 test:
 	$(ACT)
@@ -23,7 +26,7 @@ installer:
 	@GO111MODULE=off go get github.com/goreleaser/godownloader
 	godownloader -r nektos/act -o install.sh
 
-promote: 
+promote:
 	@git fetch --tags
 	@echo "VERSION:$(VERSION) IS_SNAPSHOT:$(IS_SNAPSHOT) NEW_VERSION:$(NEW_VERSION)"
 ifeq (false,$(IS_SNAPSHOT))

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 )
 
 // CopyFile copy file
@@ -54,8 +54,8 @@ func CopyDir(source string, dest string) (err error) {
 	objects, err := directory.Readdir(-1)
 
 	for _, obj := range objects {
-		sourcefilepointer := filepath.Join(source, obj.Name())
-		destinationfilepointer := filepath.Join(dest, obj.Name())
+		sourcefilepointer := path.Join(source, obj.Name())
+		destinationfilepointer := path.Join(dest, obj.Name())
 
 		if obj.IsDir() {
 			// create sub-directories - recursively

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // CopyFile copy file
@@ -36,7 +37,6 @@ func CopyFile(source string, dest string) (err error) {
 
 // CopyDir recursive copy of directory
 func CopyDir(source string, dest string) (err error) {
-
 	// get properties of source dir
 	sourceinfo, err := os.Stat(source)
 	if err != nil {
@@ -44,7 +44,6 @@ func CopyDir(source string, dest string) (err error) {
 	}
 
 	// create dest dir
-
 	err = os.MkdirAll(dest, sourceinfo.Mode())
 	if err != nil {
 		return err
@@ -55,10 +54,8 @@ func CopyDir(source string, dest string) (err error) {
 	objects, err := directory.Readdir(-1)
 
 	for _, obj := range objects {
-
-		sourcefilepointer := source + "/" + obj.Name()
-
-		destinationfilepointer := dest + "/" + obj.Name()
+		sourcefilepointer := filepath.Join(source, obj.Name())
+		destinationfilepointer := filepath.Join(dest, obj.Name())
 
 		if obj.IsDir() {
 			// create sub-directories - recursively

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -5,14 +5,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"gopkg.in/src-d/go-billy.v4/helper/polyfill"
-	"gopkg.in/src-d/go-billy.v4/osfs"
-	"gopkg.in/src-d/go-git.v4/plumbing/format/gitignore"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/src-d/go-billy.v4/helper/polyfill"
+	"gopkg.in/src-d/go-billy.v4/osfs"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/gitignore"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -322,10 +322,8 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string) common.Exe
 		defer os.Remove(tarFile.Name())
 		tw := tar.NewWriter(tarFile)
 
-		srcPrefix := filepath.Dir(srcPath)
-		if !strings.HasSuffix(srcPrefix, string(filepath.Separator)) {
-			srcPrefix += string(filepath.Separator)
-		}
+		srcPrefix := filepath.Dir(srcPath)+"/"
+
 		log.Debugf("Stripping prefix:%s src:%s", srcPrefix, srcPath)
 
 		ps, err := gitignore.ReadPatterns(polyfill.New(osfs.New(srcPath)), nil)
@@ -340,8 +338,12 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string) common.Exe
 				return err
 			}
 
-			sansPrefix := strings.TrimPrefix(file, srcPrefix)
-			split := strings.Split(sansPrefix, string(filepath.Separator))
+			sansPrefix := strings.TrimPrefix(
+				filepath.ToSlash(file),
+				filepath.ToSlash(srcPrefix),
+			)
+			split := strings.Split(sansPrefix, "/")
+
 			if ignorer.Match(split, fi.IsDir()) {
 				if fi.IsDir() {
 					return filepath.SkipDir

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -117,7 +117,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.Remove().IfBool(!rc.Config.ReuseContainers),
 			rc.JobContainer.Create(),
 			rc.JobContainer.Start(false),
-			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+"/.").IfBool(copyWorkspace),
+			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir).IfBool(copyWorkspace),
 			rc.JobContainer.Copy("/github/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 644,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -108,7 +109,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 		var copyToPath string
 		if !rc.Config.BindWorkdir {
 			copyToPath, copyWorkspace = rc.localCheckoutPath()
-			copyToPath = filepath.Join("/github/workspace", copyToPath)
+			copyToPath = path.Join("/github/workspace", copyToPath)
 		}
 
 		return common.NewPipelineExecutor(
@@ -150,7 +151,7 @@ func (rc *RunContext) ActionCacheDir() string {
 	var ok bool
 	if xdgCache, ok = os.LookupEnv("XDG_CACHE_HOME"); !ok {
 		if home, ok := os.LookupEnv("HOME"); ok {
-			xdgCache = fmt.Sprintf("%s/.cache", home)
+			xdgCache = filepath.Join(home, ".cache")
 		}
 	}
 	return filepath.Join(xdgCache, "act")

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -267,7 +268,7 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 					return err
 				}
 			}
-			return rc.execJobContainer([]string{"node", filepath.Join(containerActionDir, actionName, actionPath, action.Runs.Main)}, sc.Env)(ctx)
+			return rc.execJobContainer([]string{"node", path.Join(containerActionDir, actionName, actionPath, action.Runs.Main)}, sc.Env)(ctx)
 		case model.ActionRunsUsingDocker:
 			var prepImage common.Executor
 			var image string
@@ -277,7 +278,7 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 				image = fmt.Sprintf("%s:%s", regexp.MustCompile("[^a-zA-Z0-9]").ReplaceAllString(actionName, "-"), "latest")
 				image = fmt.Sprintf("act-%s", strings.TrimLeft(image, "-"))
 				image = strings.ToLower(image)
-				contextDir := filepath.Join(actionDir, actionPath, action.Runs.Main)
+				contextDir := path.Join(actionDir, actionPath, action.Runs.Main)
 				prepImage = container.NewDockerBuildExecutor(container.NewDockerBuildExecutorInput{
 					ContextDir: contextDir,
 					ImageTag:   image,

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -246,14 +246,16 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 
 		actionName := ""
 		containerActionDir := "."
+
 		if step.Type() == model.StepTypeUsesActionLocal {
-			actionName = strings.TrimPrefix(strings.TrimPrefix(actionDir, rc.Config.Workdir), string(filepath.Separator))
+			actionName = strings.TrimPrefix(strings.TrimPrefix(actionDir, rc.Config.Workdir), "/")
 			containerActionDir = "/github/workspace"
 		} else if step.Type() == model.StepTypeUsesActionRemote {
-			actionName = strings.TrimPrefix(strings.TrimPrefix(actionDir, rc.ActionCacheDir()), string(filepath.Separator))
+			actionName = strings.TrimPrefix(strings.TrimPrefix(actionDir, rc.ActionCacheDir()), "/")
 			containerActionDir = "/actions"
 		}
 
+		actionName = strings.TrimPrefix(actionName, "\\")
 		if actionName == "" {
 			actionName = filepath.Base(actionDir)
 		}
@@ -263,7 +265,7 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 		switch action.Runs.Using {
 		case model.ActionRunsUsingNode12:
 			if step.Type() == model.StepTypeUsesActionRemote {
-				err := rc.JobContainer.CopyDir(containerActionDir+string(filepath.Separator), actionDir)(ctx)
+				err := rc.JobContainer.CopyDir(containerActionDir, actionDir)(ctx)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Updates path concatenation/usage to leverage `filepath.Separator` (often through `filepath.Join`) when referencing the host OS, but explicitly using `/` (often through `path.Join`) when referencing paths in docker containers/mounts.

__Update:__ In addition to the above, there is also a healthy amount of path normalization so that Windows paths can be compared to their Docker counterparts. This should still be cross-os friendly as well.

In theory, this should work bi-directional including when using Windows containers, as Windows is very lax with this, but I don't really have the time to test it.

Addresses #145 and possibly a chain of others related to it.

> Additionally adds a `go-install` to make as `/usr/local/bin` not available, or accessible in Git Bash. There's plenty of other ways of doing this, but this met my needs.

Please let me know if I need to update anything to meet contribution guidelines I didn't follow, or changes you'd like before merging.