### PR TITLE
Remove length constraint for container names

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -284,7 +284,7 @@ func createContainerName(parts ...string) string {
 			name = append(name, trimToLen(pattern.ReplaceAllString(part, "-"), partLen))
 		}
 	}
-	return trimToLen(strings.Trim(strings.Join(name, "-"), "-"), 30)
+	return strings.Trim(strings.Join(name, "-"), "-")
 }
 
 func trimToLen(s string, l int) string {


### PR DESCRIPTION
There is a 30 length hardcoded limit for containers name, which makes matrix builds with long job names unable to run due to conflicting container names (see https://github.com/nektos/act/issues/174)

Apparently docker does not imposes a constraint in the length of the container name, as seen in the engine code: https://github.com/docker/engine/blob/master/daemon/names.go#L59

Tested with `Docker version 19.03.8, build afacb8b`

Not sure if in previous versions of Docker this is a problem or not.