### PR TITLE
add support for ssh:// remote DOCKER_HOST

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
 	github.com/andreaskoch/go-fswatch v1.0.0
 	github.com/containerd/containerd v1.3.3 // indirect
+	github.com/docker/cli v0.0.0-20190822175708-578ab52ece34
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.0.0-20200229013735-71373c6105e3
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,9 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/cli v0.0.0-20190822175708-578ab52ece34 h1:H/dVI9lW9zuagcDsmBz2cj8E8paBX5FarjO7oQCpbVA=
+github.com/docker/cli v0.0.0-20190822175708-578ab52ece34/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v17.12.1-ce-rc2+incompatible h1:ESUycEAqvFuLglAHkUW66rCc2djYtd3i1x231svLq9o=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.0.0-20200229013735-71373c6105e3 h1:hq9QaRK9JJOg7GItpuSSA3MrBoEN3c3llxQappEq9Zo=

--- a/pkg/container/docker_build.go
+++ b/pkg/container/docker_build.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder/dockerignore"
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/nektos/act/pkg/common"
@@ -30,11 +29,10 @@ func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 			return nil
 		}
 
-		cli, err := client.NewClientWithOpts(client.FromEnv)
+		cli, err := GetDockerClient(ctx)
 		if err != nil {
 			return err
 		}
-		cli.NegotiateAPIVersion(ctx)
 
 		logger.Debugf("Building image from '%v'", input.ContextDir)
 

--- a/pkg/container/docker_images.go
+++ b/pkg/container/docker_images.go
@@ -5,17 +5,15 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
 )
 
 // ImageExistsLocally returns a boolean indicating if an image with the
 // requested name (and tag) exist in the local docker image store
 func ImageExistsLocally(ctx context.Context, imageName string) (bool, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := GetDockerClient(ctx)
 	if err != nil {
 		return false, err
 	}
-	cli.NegotiateAPIVersion(ctx)
 
 	filters := filters.NewArgs()
 	filters.Add("reference", imageName)

--- a/pkg/container/docker_pull.go
+++ b/pkg/container/docker_pull.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/nektos/act/pkg/common"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -48,11 +47,10 @@ func NewDockerPullExecutor(input NewDockerPullExecutorInput) common.Executor {
 		imageRef := cleanImage(input.Image)
 		logger.Debugf("pulling image '%v'", imageRef)
 
-		cli, err := client.NewClientWithOpts(client.FromEnv)
+		cli, err := GetDockerClient(ctx)
 		if err != nil {
 			return err
 		}
-		cli.NegotiateAPIVersion(ctx)
 
 		reader, err := cli.ImagePull(ctx, imageRef, types.ImagePullOptions{})
 		_ = logDockerResponse(logger, reader, err != nil)

--- a/pkg/container/docker_volume.go
+++ b/pkg/container/docker_volume.go
@@ -3,7 +3,6 @@ package container
 import (
 	"context"
 
-	"github.com/docker/docker/client"
 	"github.com/nektos/act/pkg/common"
 )
 
@@ -17,11 +16,10 @@ func NewDockerVolumeRemoveExecutor(volume string, force bool) common.Executor {
 			return nil
 		}
 
-		cli, err := client.NewClientWithOpts(client.FromEnv)
+		cli, err := GetDockerClient(ctx)
 		if err != nil {
 			return err
 		}
-		cli.NegotiateAPIVersion(ctx)
 
 		return cli.VolumeRemove(ctx, volume, force)
 	}


### PR DESCRIPTION
`DOCKER_HOST=ssh://tower-sl ../act/act` works so long as you can `ssh tower-sl` without needing any user action.

Thanks to the re-write, it was truely trivial this time :)