### PR TITLE
Add default error case for Runs.Using

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -306,8 +306,12 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 			).Finally(
 				stepContainer.Remove().IfBool(!rc.Config.ReuseContainers),
 			)(ctx)
+		default:
+			return fmt.Errorf(fmt.Sprintf("The runs.using key in action.yml must be one of: %v, got %s", []string{
+				model.ActionRunsUsingDocker,
+				model.ActionRunsUsingNode12,
+			}, action.Runs.Using))
 		}
-		return nil
 	}
 }
 


### PR DESCRIPTION
The string comparison in `step_context.go` is currently case sensitive. This commit adds an error that returns the valid options and tells the user what value they passed

This will be useful if values other than `docker` or `node12` are passed