### PR TITLE
Implement UnmarshalYAML for ActionRunsUsing

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -307,7 +307,7 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 				stepContainer.Remove().IfBool(!rc.Config.ReuseContainers),
 			)(ctx)
 		default:
-			return fmt.Errorf(fmt.Sprintf("The runs.using key in action.yml must be one of: %v, got %s", []string{
+			return fmt.Errorf(fmt.Sprintf("The runs.using key must be one of: %v, got %s", []string{
 				model.ActionRunsUsingDocker,
 				model.ActionRunsUsingNode12,
 			}, action.Runs.Using))


### PR DESCRIPTION
In #222 I added case normalisation to ReadAction() to ensure that Docker and docker are interpreted the same way.

I realised that this was being done at the wrong level and required multiple type conversions. By implementing `func (a ActionRunsUsing) UnmarshalYAML` we can lowercase the string as it's being unserialized

This has an added benefit that any time this type is hydrated the `runs.using` key will be lowercased, rather than relying on `ReadAction()`