### PR TITLE
Add support for changing the GITHUB_ACTOR

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -7,6 +7,7 @@ import (
 
 // Input contains the input for the root command
 type Input struct {
+	actor           string
 	workdir         string
 	workflowsPath   string
 	eventPath       string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().BoolVarP(&input.bindWorkdir, "bind", "b", false, "bind working directory to container, rather than copy")
 	rootCmd.Flags().BoolVarP(&input.forcePull, "pull", "p", false, "pull docker image(s) if already present")
 	rootCmd.Flags().StringVarP(&input.eventPath, "eventpath", "e", "", "path to event JSON file")
+	rootCmd.PersistentFlags().StringVarP(&input.actor, "actor", "a", "nektos/act", "user that triggered the event")
 	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow files")
 	rootCmd.PersistentFlags().StringVarP(&input.workdir, "directory", "C", ".", "working directory")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
@@ -156,6 +157,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 
 		// run the plan
 		config := &runner.Config{
+			Actor:           input.actor,
 			EventName:       eventName,
 			EventPath:       input.EventPath(),
 			ForcePull:       input.forcePull,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -357,11 +357,17 @@ func (rc *RunContext) getGithubContext() *githubContext {
 		Workflow:  rc.Run.Workflow.Name,
 		RunID:     "1",
 		RunNumber: "1",
-		Actor:     "nektos/act",
+		Actor:     rc.Config.Actor,
 		EventName: rc.Config.EventName,
 		Token:     token,
 		Workspace: "/github/workspace",
 		Action:    rc.CurrentStep,
+	}
+
+	// Backwards compatibility for configs that require
+	// a default rather than being run as a cmd
+	if ghc.Actor == "" {
+		ghc.Actor = "nektos/act"
 	}
 
 	repoPath := rc.Config.Workdir

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -17,6 +17,7 @@ type Runner interface {
 
 // Config contains the config for a new runner
 type Config struct {
+	Actor           string            // the user that triggered the event
 	Workdir         string            // path to working directory
 	BindWorkdir     bool              // bind the workdir to the job container
 	EventName       string            // name of event to run


### PR DESCRIPTION
This adds the `-a` flag when running `act` to change the username of the GITHUB_ACTOR environment variable