### PR TITLE
Mask secrets in job output

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -72,7 +72,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				}
 				stageExecutor = append(stageExecutor, func(ctx context.Context) error {
 					jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
-					return rc.Executor()(WithJobLogger(ctx, jobName))
+					return rc.Executor()(WithJobLogger(ctx, jobName, rc.Config.Secrets))
 				})
 			}
 		}


### PR DESCRIPTION
Previously secrets would be shown in log output as provided. This
commit updates the stepLogFormatter to replace any instance of the secret
string with "***", as GitHub Actions would

Known issues: If the secret is a generic string (such as "docker"), all
occurances of that string will be replaced in the output