### PR TITLE
Spelling

### DIFF
--- a/pkg/common/cartesian_test.go
+++ b/pkg/common/cartesian_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCartisianProduct(t *testing.T) {
+func TestCartesianProduct(t *testing.T) {
 	assert := assert.New(t)
 	input := map[string][]interface{}{
 		"foo": {1, 2, 3, 4},

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -422,7 +422,7 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string) common.Exe
 				return err
 			}
 
-			// manually close here after each file operation; defering would cause each file close
+			// manually close here after each file operation; deferring would cause each file close
 			// to wait until all operations have completed.
 			f.Close()
 

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -183,7 +183,7 @@ func vmToJSON(vm *otto.Otto) {
 	toJSON := func(o interface{}) string {
 		rtn, err := json.MarshalIndent(o, "", "  ")
 		if err != nil {
-			logrus.Errorf("Unable to marsal: %v", err)
+			logrus.Errorf("Unable to marshal: %v", err)
 			return ""
 		}
 		return string(rtn)


### PR DESCRIPTION
Misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling) -- note: the spell checker is *not* included in this PR.

It reported: https://github.com/jsoref/act/commit/7c7b5af22dbc742e44652a857141a301c6844058#commitcomment-39231984

And it validated that the changes in this PR made it happy: https://github.com/jsoref/act/commit/577abb39a8d51ccb7aa915d4d25f13ec98ce44a6