### PR TITLE
Fix using: node12 handling

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -271,7 +271,7 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 					return err
 				}
 			}
-			return rc.execJobContainer([]string{"node", filepath.Join(containerActionDir, actionName, actionPath, action.Runs.Main)}, sc.Env)(ctx)
+			return rc.execJobContainer([]string{"node", filepath.Join(containerActionDir, actionPath, action.Runs.Main)}, sc.Env)(ctx)
 		case model.ActionRunsUsingDocker:
 			var prepImage common.Executor
 			var image string


### PR DESCRIPTION
This probably fixes #220 

When I use 2f3187ebcd5e4bb64862e0df2af181771858011e (or act version 0.2.8 from brew) with:
https://github.com/check-spelling/check-spelling/commit/5f7f35b25e6bce7b1e5a8f226369a86ab19a623e
I get:
```node
$ act -b -v 2>&1 |grep -A10 'About to run action'
time="2020-05-17T08:12:32-04:00" level=debug msg="About to run action &{Check spelling jsoref Spell check commits map[bucket:{Container for spelling configuration true } debug:{Debug false } project:{Folder/Branch within bucket containing spelling configuration true } repo-token:{The GITHUB_TOKEN secret false }] map[] {node12 map[] trampoline.js  [] []} {red edit-3}}"
time="2020-05-17T08:12:32-04:00" level=debug msg="type=2 actionDir=/Users/jsoref/code/spelling-org/check-spelling.git Workdir=/Users/jsoref/code/spelling-org/check-spelling.git ActionCacheDir=/Users/jsoref/.cache/act actionName=check-spelling.git containerActionDir=/github/workspace"
[Spell checking/Spell checker] Exec command '[node /github/workspace/check-spelling.git/trampoline.js]'
[Spell checking/Spell checker]   | internal/modules/cjs/loader.js:628
[Spell checking/Spell checker]   |     throw err;
[Spell checking/Spell checker]   |     ^
[Spell checking/Spell checker]   |
[Spell checking/Spell checker]   | Error: Cannot find module '/github/workspace/check-spelling.git/trampoline.js'
[Spell checking/Spell checker]   |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:625:15)
[Spell checking/Spell checker]   |     at Function.Module._load (internal/modules/cjs/loader.js:527:27)
[Spell checking/Spell checker]   |     at Function.Module.runMain (internal/modules/cjs/loader.js:839:10)
```

With this change, I get:
```node
$ ~/code/nektos/act/dist/local/act -v -b 2>&1|grep -A10 'About to run action'
time="2020-05-17T08:14:12-04:00" level=debug msg="About to run action &{Check spelling jsoref Spell check commits map[bucket:{Container for spelling configuration true } debug:{Debug false } project:{Folder/Branch within bucket containing spelling configuration true } repo-token:{The GITHUB_TOKEN secret false }] map[] {node12 map[] trampoline.js  [] []} {red edit-3}}"
time="2020-05-17T08:14:12-04:00" level=debug msg="type=2 actionDir=/Users/jsoref/code/spelling-org/check-spelling.git Workdir=/Users/jsoref/code/spelling-org/check-spelling.git ActionCacheDir=/Users/jsoref/.cache/act actionName=check-spelling.git containerActionDir=/github/workspace"
[Spell checking/Spell checker] Exec command '[node /github/workspace/trampoline.js]'
[Spell checking/Spell checker]   | cwd: /github/workspace
[Spell checking/Spell checker]   | spellchecker: /github/workspace
[Spell checking/Spell checker]   ❓  ::add-matcher::.git/reporter.json
[Spell checking/Spell checker]   | Retrieving expect from .github/actions/spelling/expect/Dockerfile.txt
[Spell checking/Spell checker]   | .github/actions/spelling/expect/README.md.txt
[Spell checking/Spell checker]   | .github/actions/spelling/expect/action.yml.txt
[Spell checking/Spell checker]   | .github/actions/spelling/expect/check-pull-requests.sh.txt
[Spell checking/Spell checker]   | .github/actions/spelling/expect/common.sh.txt
```