### PR TITLE
Change -W command to accept a single file

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -51,7 +51,7 @@ func (i *Input) Workdir() string {
 	return i.resolve(".")
 }
 
-// WorkflowsPath returns path to workflows
+// WorkflowsPath returns path to workflow file(s)
 func (i *Input) WorkflowsPath() string {
 	return i.resolve(i.workflowsPath)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().BoolVarP(&input.forcePull, "pull", "p", false, "pull docker image(s) if already present")
 	rootCmd.Flags().StringVarP(&input.eventPath, "eventpath", "e", "", "path to event JSON file")
 	rootCmd.PersistentFlags().StringVarP(&input.actor, "actor", "a", "nektos/act", "user that triggered the event")
-	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow files")
+	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow file(s)")
 	rootCmd.PersistentFlags().StringVarP(&input.workdir, "directory", "C", ".", "working directory")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&input.noOutput, "quiet", "q", false, "disable logging of output from steps")

--- a/pkg/model/planner.go
+++ b/pkg/model/planner.go
@@ -46,10 +46,25 @@ func (r *Run) Job() *Job {
 	return r.Workflow.GetJob(r.JobID)
 }
 
-// NewWorkflowPlanner will load all workflows from a directory
-func NewWorkflowPlanner(dirname string) (WorkflowPlanner, error) {
-	log.Debugf("Loading workflows from '%s'", dirname)
-	files, err := ioutil.ReadDir(dirname)
+// NewWorkflowPlanner will load a specific workflow or all workflows from a directory
+func NewWorkflowPlanner(path string) (WorkflowPlanner, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []os.FileInfo
+	var dirname string
+
+	if fi.IsDir() {
+		log.Debugf("Loading workflows from '%s'", path)
+		dirname = path
+		files, err = ioutil.ReadDir(path)
+	} else {
+		log.Debugf("Loading workflow '%s'", path)
+		dirname, err = filepath.Abs(filepath.Dir(path))
+		files = []os.FileInfo{fi}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently setting workflows with the -W (--workflows) flag only accepts
a folder. It is not possible to run a single workflow.yml file.

This PR allows either a single file or a directory to be passed into
the workflows flag.

The change is quick and dirty and doesn't include support for a list (via globbing) or wildcard/globbing support.

Fixes #227