### PR TITLE
Container volumes sometimes reused even if configured not to

### DIFF
--- a/pkg/container/docker_volume.go
+++ b/pkg/container/docker_volume.go
@@ -3,11 +3,34 @@ package container
 import (
 	"context"
 
+	"github.com/docker/docker/api/types/filters"
 	"github.com/nektos/act/pkg/common"
 )
 
-// NewDockerVolumeRemoveExecutor function
 func NewDockerVolumeRemoveExecutor(volume string, force bool) common.Executor {
+	return func(ctx context.Context) error {
+		cli, err := GetDockerClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		list, err := cli.VolumeList(ctx, filters.NewArgs())
+		if err != nil {
+			return err
+		}
+
+		for _, vol := range list.Volumes {
+			if vol.Name == volume {
+				return removeExecutor(volume, force)(ctx)
+			}
+		}
+
+		// Volume not found - do nothing
+		return nil
+	}
+}
+
+func removeExecutor(volume string, force bool) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
 		logger.Debugf("%sdocker volume rm %s", logPrefix, volume)
@@ -23,5 +46,4 @@ func NewDockerVolumeRemoveExecutor(volume string, force bool) common.Executor {
 
 		return cli.VolumeRemove(ctx, volume, force)
 	}
-
 }

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -83,7 +83,6 @@ func TestEvaluate(t *testing.T) {
 		{"matrix.os", "Linux", ""},
 		{"matrix.foo", "bar", ""},
 		{"env.key", "value", ""},
-
 	}
 
 	for _, table := range tables {
@@ -121,8 +120,8 @@ func TestInterpolate(t *testing.T) {
 		},
 	}
 	ee := rc.NewExpressionEvaluator()
-	tables := []struct{
-		in string
+	tables := []struct {
+		in  string
 		out string
 	}{
 		{" ${{1}} to ${{2}} ", " 1 to 2 "},

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -115,7 +115,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 
 		return common.NewPipelineExecutor(
 			rc.JobContainer.Pull(rc.Config.ForcePull),
-			rc.JobContainer.Remove().IfBool(!rc.Config.ReuseContainers),
+			rc.stopJobContainer(),
 			rc.JobContainer.Create(),
 			rc.JobContainer.Start(false),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+"/.").IfBool(copyWorkspace),
@@ -136,6 +136,8 @@ func (rc *RunContext) execJobContainer(cmd []string, env map[string]string) comm
 		return rc.JobContainer.Exec(cmd, env)(ctx)
 	}
 }
+
+// stopJobContainer removes the job container (if it exists) and its volume (if it exists) if !rc.Config.ReuseContainers
 func (rc *RunContext) stopJobContainer() common.Executor {
 	return func(ctx context.Context) error {
 		if rc.JobContainer != nil && !rc.Config.ReuseContainers {

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -16,8 +16,8 @@ func TestRunContext_EvalBool(t *testing.T) {
 			Workdir: ".",
 		},
 		Env: map[string]string{
-			"TRUE":  "true",
-			"FALSE": "false",
+			"TRUE":      "true",
+			"FALSE":     "false",
 			"SOME_TEXT": "text",
 		},
 		Run: &model.Run{
@@ -52,8 +52,8 @@ func TestRunContext_EvalBool(t *testing.T) {
 	rc.ExprEval = rc.NewExpressionEvaluator()
 
 	tables := []struct {
-		in      string
-		out     bool
+		in  string
+		out bool
 	}{
 		// The basic ones
 		{"true", true},


### PR DESCRIPTION
This can occur even without the `-r` flag, but it's easier to reproduce like this.
`.github/workflows/workflow.yaml`:
```yaml
name: Example workflow

on: push

jobs:
  example:
    name: Example job
    runs-on: ubuntu-latest

    steps:
      - run: echo "Hello" >> file.txt
      - run: echo "World!" >> file.txt
      - run: cat file.txt
```
Now we run:
```sh
$ act -j example -r
...
| Hello
| World!
...
```
This is expected.
```sh
$ act -j example -r
...
| Hello
| World!
| Hello
| World!
...
```
This is also expected, as the `-r` flag means that the containers should be re-used; in other words, file.txt contains the original content from the last run, plus the new content from this run.
```sh
$ act -j example
...
| Hello
| World!
| Hello
| World!
| Hello
| World!
...
```
This is unexpected; the `-r` flag is no longer used, but the file system wasn't reset.
```sh
$ act -j example
...
| Hello
| World!
...
```
This is expected; after the run without `-r`, the volume was deleted from disk and this time we have a clean file system.

The same thing happens even when not using `-r` if the container clean-up doesn't run (eg. when `act` is terminated in the middle of a build); the file system will persist. In the code, there's a safeguard which performs an additional clean-up before every build, but this safeguard only removes the container itself, not the volume associated with it (which is not anonymous). This PR fixes that by calling `runContext.stopJobContainer(...)` instead of `container.Remove()` before the build, which removes both the container and the volume.