### PR TITLE
Rewrite contexts before evaluating them

### DIFF
--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -37,9 +37,21 @@ func TestEvaluate(t *testing.T) {
 			"foo": "bar",
 		},
 		StepResults: map[string]*stepResult{
-			"id1": {
+			"idwithnothing": {
 				Outputs: map[string]string{
-					"foo": "bar",
+					"foowithnothing": "barwithnothing",
+				},
+				Success: true,
+			},
+			"id-with-hyphens": {
+				Outputs: map[string]string{
+					"foo-with-hyphens": "bar-with-hyphens",
+				},
+				Success: true,
+			},
+			"id_with_underscores": {
+				Outputs: map[string]string{
+					"foo_with_underscores": "bar_with_underscores",
 				},
 				Success: true,
 			},
@@ -78,7 +90,9 @@ func TestEvaluate(t *testing.T) {
 		{"github.run_id", "1", ""},
 		{"github.run_number", "1", ""},
 		{"job.status", "success", ""},
-		{"steps.id1.outputs.foo", "bar", ""},
+		{"steps.idwithnothing.outputs.foowithnothing", "barwithnothing", ""},
+		{"steps.id-with-hyphens.outputs.foo-with-hyphens", "bar-with-hyphens", ""},
+		{"steps.id_with_underscores.outputs.foo_with_underscores", "bar_with_underscores", ""},
 		{"runner.os", "Linux", ""},
 		{"matrix.os", "Linux", ""},
 		{"matrix.foo", "bar", ""},
@@ -134,6 +148,48 @@ func TestInterpolate(t *testing.T) {
 		t.Run(table.in, func(t *testing.T) {
 			out := ee.Interpolate(table.in)
 			assert.Equal(table.out, out, table.in)
+		})
+	}
+}
+
+func TestRewrite(t *testing.T) {
+	assert := a.New(t)
+
+	rc := &RunContext{
+		Config: &Config{},
+		Run: &model.Run{
+			JobID: "job1",
+			Workflow: &model.Workflow{
+				Jobs: map[string]*model.Job{
+					"job1": {},
+				},
+			},
+		},
+	}
+	ee := rc.NewExpressionEvaluator()
+
+	tables := []struct {
+		in string
+		re string
+	}{
+		{"ecole", "ecole"},
+		{"ecole.centrale", "ecole['centrale']"},
+		{"ecole['centrale']", "ecole['centrale']"},
+		{"ecole.centrale.paris", "ecole['centrale']['paris']"},
+		{"ecole['centrale'].paris", "ecole['centrale']['paris']"},
+		{"ecole.centrale['paris']", "ecole['centrale']['paris']"},
+		{"ecole['centrale']['paris']", "ecole['centrale']['paris']"},
+		{"ecole.centrale-paris", "ecole['centrale-paris']"},
+		{"ecole['centrale-paris']", "ecole['centrale-paris']"},
+		{"ecole.centrale_paris", "ecole['centrale_paris']"},
+		{"ecole['centrale_paris']", "ecole['centrale_paris']"},
+	}
+
+	for _, table := range tables {
+		table := table
+		t.Run(table.in, func(t *testing.T) {
+			re := ee.Rewrite(table.in)
+			assert.Equal(table.re, re, table.in)
 		})
 	}
 }

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -121,7 +121,9 @@ func TestInterpolate(t *testing.T) {
 			Workdir: ".",
 		},
 		Env: map[string]string{
-			"key": "value",
+			"keywithnothing": "valuewithnothing",
+			"key-with-hyphens": "value-with-hyphens",
+			"key_with_underscores": "value_with_underscores",
 		},
 		Run: &model.Run{
 			JobID: "job1",
@@ -139,7 +141,9 @@ func TestInterpolate(t *testing.T) {
 		out string
 	}{
 		{" ${{1}} to ${{2}} ", " 1 to 2 "},
-		{" ${{ env.key }} ", " value "},
+		{" ${{ env.keywithnothing }} ", " valuewithnothing "},
+		{" ${{ env.key-with-hyphens }} ", " value-with-hyphens "},
+		{" ${{ env.key_with_underscores }} ", " value_with_underscores "},
 		{"${{ env.unknown }}", ""},
 	}
 


### PR DESCRIPTION
## Description 

This PR aims to fix https://github.com/nektos/act/issues/104. In a nutshell, `act` uses a [javascript virtual machine](https://github.com/robertkrimen/otto) to interpret and evaluate expressions in github actions. It works pretty well, except for expressions like `object.property-with-hyphens` which are correctly handled by github action runners, but not by the javascript vm.

This solution is heavily inspired by https://github.com/nektos/act/issues/104#issuecomment-636213788 written by @Shadowfiend, although the implementation diverged a little bit from the initial proposal. The idea is to tweak just a little bit the expression and transform it into `object['property-with-hyphens']` which is both github actions and javascript compliant.

To do so, we introduce the `Rewrite` method which job is exactly the one described above, and we call it just before evaluating the expression in the javascript vm.

## Explanations

⚠️ The current implementation relies on a regex hackery ( see [here](https://regex101.com/r/Xm1Y0I) to test it online ), which is fairly ugly and hard to maintain. In the future, we should invest some time to implement a proper lexer/parser and a proper term rewriter. But in the short-term, this regex works.

That being said, using regex for this rewriting is really hard to get right !


<details>
<summary>
Here is a snapshot of what I tried...
</summary>
<p>

```regex
^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_-]*|\[.+\])*$
^\w+(?:\[.+\])*(\.[\w-]+)?
^(\w+(\[.+\])*)(\.[\w-]+)?
^(\w+(?:\[.+\])*)(\.[\w-]+)?
^(\w+(?:\[.+\])*)(?:\.([\w-]+))?
^(\w+(?:\[.+\])*)(?:\.([\w-]+))?(.*)$
^(?P<object>\w+(\[.+\])*)(\.(?P<property>[\w-]+))?(?P<trailing>.*)$
```

</p>
</details>

One thing to keep in mind is that not all `.` nor not all `-` are bad. For instance we do not want to rewrite filenames with extension.
But also, we would need to identify strings, escaped characters, already-bracketed expressions, recursive expressions, etc.

So let's keep it simple for now. We choose to only rewrite contexts, which is a subset of expressions
https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contexts

The pattern defines three groups, as described below :

```regex
^(\w+(?:\[.+\])*)(?:\.([\w-]+))?(.*)$
  \            /       \    /    \/
   '-----.----'         \  /      Remaining characters
         |               \/
         |                First level of property using dots
         |
         Current object
         Potentially nested object, but using the bracket notation
```

Here is the execution of the method step by step with `in := "ecole.centrale.paris"`. See also <https://play.golang.org/p/bu2rO817ycU>

0. Before entering the loop

    | Variable | Value |
    |:---:|:---:|
    | `re` | `"ecole.centrale.paris"` |

1. First iteration

    | Variable | Value |
    |:---:|:---:|
    | `matches[0]` | `"ecole.centrale.paris"` |
    | `matches[1]` | `"ecole"` |
    | `matches[2]` | `"centrale"` |
    | `matches[3]` | `".paris"` |
    | `re` | `"ecole['centrale'].paris"` |

2. Second iteration

    | Variable | Value |
    |:---:|:---:|
    | `matches[0]` | `"ecole['centrale'].paris"` |
    | `matches[1]` | `"ecole['centrale']"` |
    | `matches[2]` | `"paris"` |
    | `matches[3]` | `""` |
    | `re` | `"ecole['centrale']['paris']"` |

3. Third iteration

    | Variable | Value |
    |:---:|:---:|
    | `matches[0]` | `"ecole['centrale']['paris']"` |
    | `matches[1]` | `"ecole['centrale']['paris']"` |
    | `matches[2]` | `""` |
    | `matches[3]` | `""` |
    | `re` | `"ecole['centrale']['paris']"` |

    Here we trigger the break condition and the function returns

## Testing

Before the fix : 

```bash
$ act --version
act version 0.2.9

$ act -P ubuntu-latest=node:12.6-buster-slim -W pkg/runner/testdata/issue-104
[Test stuff/Testing Testing] 🚀  Start image=node:12.6-buster-slim
[Test stuff/Testing Testing]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Test stuff/Testing Testing] ⭐  Run hello
[Test stuff/Testing Testing]   ☁  git clone 'https://github.com/actions/hello-world-docker-action' # ref=master
ERRO[0001] Unable to interpolate string '${{ inputs.who-to-greet }}' - [ReferenceError: 'to' is not defined]
[Test stuff/Testing Testing]   🐳  docker build -t act-actions-hello-world-docker-action-master:latest /Users/ayaz.badouraly/.cache/act/actions-hello-world-docker-action@master
[Test stuff/Testing Testing]   🐳  docker run image=act-actions-hello-world-docker-action-master:latest entrypoint=[] cmd=[""]
| Hello
[Test stuff/Testing Testing]   ⚙  ::set-output:: time=Sun Jun 21 17:15:37 UTC 2020
[Test stuff/Testing Testing]   ✅  Success - hello
```

After the fix : 

```bash
$ go run . -P ubuntu-latest=node:12.6-buster-slim -W pkg/runner/testdata/issue-104
[Test stuff/Testing Testing] 🚀  Start image=node:12.6-buster-slim
[Test stuff/Testing Testing]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Test stuff/Testing Testing] ⭐  Run hello
[Test stuff/Testing Testing]   ☁  git clone 'https://github.com/actions/hello-world-docker-action' # ref=master
[Test stuff/Testing Testing]   🐳  docker build -t act-actions-hello-world-docker-action-master:latest /Users/ayaz.badouraly/.cache/act/actions-hello-world-docker-action@master
[Test stuff/Testing Testing]   🐳  docker run image=act-actions-hello-world-docker-action-master:latest entrypoint=[] cmd=["World"]
| Hello World
[Test stuff/Testing Testing]   ⚙  ::set-output:: time=Sun Jun 21 17:16:33 UTC 2020
[Test stuff/Testing Testing]   ✅  Success - hello
```

## References 

- [Expressions in github actions](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions)
- [Dot notation vs. bracket notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Description)
- [Test the regex online](https://regex101.com/r/Xm1Y0I)
- [Test the rewrite function online](https://play.golang.org/p/bu2rO817ycU)
- [École Centrale Paris](https://en.wikipedia.org/wiki/%C3%89cole_Centrale_Paris)