### PR TITLE
remove .gitignore before docker cp

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -53,6 +53,7 @@ func TestRunEvent(t *testing.T) {
 		{"matrix", "push", ""},
 		{"commands", "push", ""},
 		{"workdir", "push", ""},
+		{"issue-228", "push", ""}, // TODO [igni]: Remove this once everything passes
 	}
 	log.SetLevel(log.DebugLevel)
 

--- a/pkg/runner/testdata/issue-228/main.yaml
+++ b/pkg/runner/testdata/issue-228/main.yaml
@@ -7,7 +7,7 @@ jobs:
   kind:
     runs-on: ubuntu-latest
     steps:
-      - run: apt install git -y # setup git credentials will fail otherwise
+      - run: apt-get update -y && apt-get install git -y # setup git credentials will fail otherwise
       - name: Setup git credentials
         uses: fusion-engineering/setup-git-credentials@v2
         with:

--- a/pkg/runner/testdata/issue-228/main.yaml
+++ b/pkg/runner/testdata/issue-228/main.yaml
@@ -1,0 +1,14 @@
+name: issue-228
+
+on:
+  - push
+
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+      - run: apt install git -y # setup git credentials will fail otherwise
+      - name: Setup git credentials
+        uses: fusion-engineering/setup-git-credentials@v2
+        with:
+          credentials: https://test@github.com/


### PR DESCRIPTION
Will hopefully fix #228 

This patch checks for the presence of a `.gitignore` file in a remote repository action, and removes it before running `docker cp`.

I'm not too aware of how the project works and its structure, I'm not even sure that's the way you'd like to address this issue, so please let me know how you feel about it, and feel free to discard it or ask me for edits :)

Thanks again for your time