### PR TITLE
use t.Cleanup and prefer assert.NoError over .Nil

### DIFF
--- a/pkg/common/git_test.go
+++ b/pkg/common/git_test.go
@@ -35,39 +35,39 @@ func TestFindGitSlug(t *testing.T) {
 	for _, tt := range slugTests {
 		provider, slug, err := findGitSlug(tt.url)
 
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.Equal(tt.provider, provider)
 		assert.Equal(tt.slug, slug)
 	}
 
 }
 
+func testDir(t *testing.T) string {
+	basedir, err := ioutil.TempDir("", "act-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(basedir) })
+	return basedir
+}
+
 func TestFindGitRemoteURL(t *testing.T) {
 	assert := assert.New(t)
 
-	basedir, err := ioutil.TempDir("", "act-test")
-	defer os.RemoveAll(basedir)
-
-	assert.Nil(err)
-
+	basedir := testDir(t)
 	gitConfig()
-	err = gitCmd("init", basedir)
-	assert.Nil(err)
+	err := gitCmd("init", basedir)
+	assert.NoError(err)
 
 	remoteURL := "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/my-repo-name"
 	err = gitCmd("config", "-f", fmt.Sprintf("%s/.git/config", basedir), "--add", "remote.origin.url", remoteURL)
-	assert.Nil(err)
+	assert.NoError(err)
 
 	u, err := findGitRemoteURL(basedir)
-	assert.Nil(err)
+	assert.NoError(err)
 	assert.Equal(remoteURL, u)
 }
 
 func TestGitFindRef(t *testing.T) {
-	basedir, err := ioutil.TempDir("", "act-test")
-	defer os.RemoveAll(basedir)
-	assert.NoError(t, err)
-
+	basedir := testDir(t)
 	gitConfig()
 
 	for name, tt := range map[string]struct {


### PR DESCRIPTION
testify has a method [NoError](https://godoc.org/github.com/stretchr/testify/assert#NoError) that is specifically for asserting that the err you have is nil. If failed it emits a message about the unexpected error. https://github.com/stretchr/testify/blob/master/assert/assertions.go#L1332

go 1.14 introduced [t.Cleanup](https://golang.org/pkg/testing/#B.Cleanup) its useful when you need to do something at the end of a test. Like cleaning up files. 