### PR TITLE
fix: add default values in vmInput

### DIFF
--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -296,6 +296,14 @@ func (sc *StepContext) vmEnv() func(*otto.Otto) {
 
 func (sc *StepContext) vmInputs() func(*otto.Otto) {
 	inputs := make(map[string]string)
+
+	// Set Defaults
+	if sc.Action != nil {
+		for k, input := range sc.Action.Inputs {
+			inputs[k] = input.Default
+		}
+	}
+
 	for k, v := range sc.Step.With {
 		inputs[k] = v
 	}

--- a/pkg/runner/testdata/remote-action-docker/push.yml
+++ b/pkg/runner/testdata/remote-action-docker/push.yml
@@ -5,6 +5,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/hello-world-docker-action@master
+    - uses: actions/hello-world-docker-action@main
       with:
         who-to-greet: 'Mona the Octocat'


### PR DESCRIPTION
This PR fixes an issue caused by a missing interpretation of the default values.  
  
The default values are now interpreted and this workflow works as expected:  
  
```yaml
# This is a basic workflow to help you get started with Actions

name: CI

# Controls when the action will run. Triggers the workflow on push or pull request
# events but only for the master branch
on:
  push:
    branches: 
      - "*"
  pull_request:
    branches:
      - "*"

# A workflow run is made up of one or more jobs that can run sequentially or in parallel
jobs:
  # This workflow contains a single job called "build"
  build:
    # The type of runner that the job will run on
    runs-on: ubuntu-latest

    # Steps represent a sequence of tasks that will be executed as part of the job
    steps:
    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
    - name: LaTeX compilation
      uses: dante-ev/latex-action@v0.2.0
      with:
        # The root LaTeX file to be compiled
        root_file: "$GITHUB_WORKSPACE/document.tex"
```