### PR TITLE
Fix to fail GitHub Actions test

### DIFF
--- a/pkg/runner/testdata/remote-action-js/push.yml
+++ b/pkg/runner/testdata/remote-action-js/push.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/hello-world-javascript-action@master
+    - uses: actions/hello-world-javascript-action@v1
       with:
         who-to-greet: 'Mona the Octocat'
 


### PR DESCRIPTION
in https://github.com/actions/hello-world-javascript-action/issues/14 , they changed the default branch of `actions/hello-world-javascript-action`. 

The new default branch name is `main`. `master` has deprecated.

This PR change to use stable tag `v1`. maybe become stable CI.