### PR TITLE
fix file permission for non root user docker image

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -122,11 +122,11 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+"/.").IfBool(copyWorkspace),
 			rc.JobContainer.Copy("/github/", &container.FileEntry{
 				Name: "workflow/event.json",
-				Mode: 644,
+				Mode: 0644,
 				Body: rc.EventJSON,
 			}, &container.FileEntry{
 				Name: "home/.act",
-				Mode: 644,
+				Mode: 0644,
 				Body: "",
 			}),
 		)(ctx)

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -45,6 +45,7 @@ func TestRunEvent(t *testing.T) {
 		{"fail", "push", "exit with `FAILURE`: 1"},
 		{"runs-on", "push", ""},
 		{"job-container", "push", ""},
+		{"job-container-non-root", "push", ""},
 		{"uses-docker-url", "push", ""},
 		{"remote-action-docker", "push", ""},
 		{"remote-action-js", "push", ""},

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -129,7 +129,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		sc.Cmd = strings.Fields(strings.Replace(step.ShellCommand(), "{0}", containerPath, 1))
 		return rc.JobContainer.Copy("/github/", &container.FileEntry{
 			Name: scriptName,
-			Mode: 755,
+			Mode: 0755,
 			Body: script.String(),
 		})(ctx)
 	}

--- a/pkg/runner/testdata/job-container-non-root/push.yml
+++ b/pkg/runner/testdata/job-container-non-root/push.yml
@@ -1,0 +1,10 @@
+name: job-container
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: 
+      image: ocaml/opam2:debian-9-opam
+    steps:
+      - run: echo PASS


### PR DESCRIPTION
File permission bits requires octal literals. So I prepend `0` simply.

I used `go test -run '^TestRunEvent$/job-container-non-root' ./...` for test.
