### PR TITLE
Set the default branch inside the event data

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -20,6 +20,7 @@ type Input struct {
 	noOutput        bool
 	envfile         string
 	secretfile      string
+	defaultBranch   string
 	privileged      bool
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().BoolVarP(&input.bindWorkdir, "bind", "b", false, "bind working directory to container, rather than copy")
 	rootCmd.Flags().BoolVarP(&input.forcePull, "pull", "p", false, "pull docker image(s) if already present")
 	rootCmd.Flags().StringVarP(&input.eventPath, "eventpath", "e", "", "path to event JSON file")
+	rootCmd.Flags().StringVar(&input.defaultBranch, "defaultbranch", "", "the name of the main branch")
 	rootCmd.Flags().BoolVar(&input.privileged, "privileged", false, "use privileged mode")
 	rootCmd.PersistentFlags().StringVarP(&input.actor, "actor", "a", "nektos/act", "user that triggered the event")
 	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow file(s)")
@@ -156,11 +157,18 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			return drawGraph(plan)
 		}
 
+		// check to see if the main branch was defined
+		defaultbranch, err := cmd.Flags().GetString("defaultbranch")
+		if err != nil {
+			return err
+		}
+
 		// run the plan
 		config := &runner.Config{
 			Actor:           input.actor,
 			EventName:       eventName,
 			EventPath:       input.EventPath(),
+			DefaultBranch:   defaultbranch,
 			ForcePull:       input.forcePull,
 			ReuseContainers: input.reuseContainers,
 			Workdir:         input.Workdir(),

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -461,12 +461,12 @@ func nestedMapLookup(m map[string]interface{}, ks ...string) (rval interface{}) 
 
 func withDefaultBranch(b string, event map[string]interface{}) map[string]interface{} {
 	repoI, ok := event["repository"]
-	if ok == false {
+	if !ok {
 		repoI = make(map[string]interface{})
 	}
 
 	repo, ok := repoI.(map[string]interface{})
-	if ok == false {
+	if !ok {
 		log.Warnf("unable to set default branch to %v", b)
 		return event
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -22,6 +22,7 @@ type Config struct {
 	BindWorkdir     bool              // bind the workdir to the job container
 	EventName       string            // name of event to run
 	EventPath       string            // path to JSON file to use for event.json in containers
+	DefaultBranch   string            // name of the main branch for this repository
 	ReuseContainers bool              // reuse containers to maintain state
 	ForcePull       bool              // force pulling of the image, if already present
 	LogOutput       bool              // log the output from docker run


### PR DESCRIPTION
This sets the `${{github.event.repository.default_branch}}` to `master` by default or the value specified in a new `--defaultbranch` flag. This could also be extended to lookup the value from the git setting `git config --get init.defaultBranch` if the working directory is in a git repo. 