### PR TITLE
Fix copyDir to normalize file paths in tar archive

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -400,7 +400,7 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string) common.Exe
 			}
 
 			// update the name to correctly reflect the desired destination when untaring
-			header.Name = sansPrefix
+			header.Name = filepath.ToSlash(sansPrefix)
 			header.Mode = int64(fi.Mode())
 			header.ModTime = fi.ModTime()
 


### PR DESCRIPTION
#359 