### PR TITLE
Add CI=true environment variable

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -491,6 +491,7 @@ func withDefaultBranch(b string, event map[string]interface{}) map[string]interf
 
 func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	github := rc.getGithubContext()
+	env["CI"] = "true"
 	env["HOME"] = "/github/home"
 	env["GITHUB_WORKFLOW"] = github.Workflow
 	env["GITHUB_RUN_ID"] = github.RunID


### PR DESCRIPTION
fixes #333

`CI=true` should be defined in the env to match GitHub Actions environment.

docs: [default-environment-variables](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables)