### PR TITLE
Fix Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let's see it in action with a [sample repo](https://github.com/cplee/github-acti
 
 To install with [Homebrew](https://brew.sh/), run:
 
-`brew install nektos/tap/act`
+`brew install act`
 
 Alternatively, you can use the following:
 


### PR DESCRIPTION
As act is now included in Homebrew-core (https://github.com/Homebrew/homebrew-core/pull/58193) the command to install act with Homebrew has changed slightly. This PR updates the documentation.