### PR TITLE
Fix test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 
 .PHONY: test
 test:
-	$(ACT) -W examples/workflows --verbose
+	$(ACT)
 
 .PHONY: install
 install: build

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 
 .PHONY: test
 test:
+	go test ./...
 	$(ACT)
 
 .PHONY: install


### PR DESCRIPTION
This PR:
* Removes stray code added in #369 (presumably added accidentally: `examples/workflows` does not exist).
* Adds `go test ./...` to the `test` target.

Note that the test fail on my Ubuntu machine:
```
[push/lint    ] 🚀  Start image=node:12.6-buster-slim
[push/test    ] 🚀  Start image=node:12.6-buster-slim
[push/test    ]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[push/lint    ]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[push/test    ]   🐳  docker cp src=/home/twp/src/github.com/nektos/act/. dst=/github/workspace
[push/lint    ]   🐳  docker cp src=/home/twp/src/github.com/nektos/act/. dst=/github/workspace
[push/test    ] ⭐  Run actions/checkout@v2
[push/test    ]   ✅  Success - actions/checkout@v2
[push/test    ] ⭐  Run actions/setup-go@v1
[push/test    ]   ☁  git clone 'https://github.com/actions/setup-go' # ref=v1
[push/test    ] Unable to resolve v1: reference not found
[push/test    ]   ❌  Failure - actions/setup-go@v1
Error: reference not found
exit status 1
```
I think this is due to issue #311.