### PR TITLE
Remove confusing message about symlinks

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -418,7 +418,7 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string) common.Exe
 			// copy file data into tar writer
 			if _, err := io.Copy(tw, f); err != nil {
 				if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-					logger.Warnf("Unable to copy link %s --> %s", fi.Name(), linkName)
+					// symlinks don't need to be copied, ignore this error
 					err = nil
 				}
 				return err


### PR DESCRIPTION
Fixes #209 

It turns out that `act` _does_ copy symlinks. I've setup a test case here:

https://github.com/lyleunderwood/github-actions-demo/commit/d904f63b1b4bdc2d96ff0d6953581a39ff83f4db

Below is the output. Notice the message, "Unable to copy link test --> README.md" followed shortly by the description and usage of the corresponding symlink that exists within the workspace.

```
lyle@lyle-t410:~/dev/github-actions-demo$ act
[CI/test] 🚀  Start image=node:12.6-buster-slim
[CI/test]   🐳  docker run image=node:12.6-buster-slim entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[CI/test]   🐳  docker cp src=/home/lyle/dev/github-actions-demo/. dst=/github/workspace
[CI/test] Unable to copy link test --> README.md
[CI/test] ⭐  Run actions/checkout@v2
[CI/test]   ✅  Success - actions/checkout@v2
[CI/test] ⭐  Run ls -l ./test
| lrwxrwxrwx 1 node node 9 Oct  2 23:51 ./test -> README.md
[CI/test]   ✅  Success - ls -l ./test
[CI/test] ⭐  Run head ./test
| # Overview
| Simple Node.js application to demonstrate the use of GitHub Actions
| 
| # Look Ma, no Makefile!
| All the tasks necessary for testing, building and deploying this code is already defined in `.github/workflows/` so why would you want to also create a `Makefile` for local development?  Now you can use [act](https://github.com/nektos/act) to run the actions locally!
| 
| Try these:
| 
| * `act -j lint` - run the linter
| * `act -j test` - run the tests
[CI/test]   ✅  Success - head ./test
```