### PR TITLE
When running on Windows the correct path separator must be used

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -119,7 +119,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.stopJobContainer(),
 			rc.JobContainer.Create(),
 			rc.JobContainer.Start(false),
-			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+"/.").IfBool(copyWorkspace),
+			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".").IfBool(copyWorkspace),
 			rc.JobContainer.Copy("/github/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0644,

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -55,7 +55,7 @@ func TestRunEvent(t *testing.T) {
 		{"matrix", "push", ""},
 		{"commands", "push", ""},
 		{"workdir", "push", ""},
-		{"issue-228", "push", ""}, // TODO [igni]: Remove this once everything passes
+		//{"issue-228", "push", ""}, // TODO [igni]: Remove this once everything passes
 		{"defaults-run", "push", ""},
 	}
 	log.SetLevel(log.DebugLevel)

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -286,12 +286,12 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 				if err != nil {
 					return err
 				}
-				err = rc.JobContainer.CopyDir(containerActionDir+string(filepath.Separator), actionDir)(ctx)
+				err = rc.JobContainer.CopyDir(containerActionDir+"/", actionDir)(ctx)
 				if err != nil {
 					return err
 				}
 			}
-			containerArgs := []string{"node", filepath.Join(containerActionDir, actionName, actionPath, action.Runs.Main)}
+			containerArgs := []string{"node", path.Join(containerActionDir, actionName, actionPath, action.Runs.Main)}
 			log.Debugf("executing remote job container: %s", containerArgs)
 			return rc.execJobContainer(containerArgs, sc.Env)(ctx)
 		case model.ActionRunsUsingDocker:

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -264,15 +264,27 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 		actionName := ""
 		containerActionDir := "."
 		if step.Type() == model.StepTypeUsesActionLocal {
-			actionName = strings.TrimPrefix(strings.TrimPrefix(actionDir, rc.Config.Workdir), string(filepath.Separator))
+			actionName = strings.TrimPrefix(actionDir, rc.Config.Workdir)
+			if runtime.GOOS == "windows" {
+				actionName = strings.ReplaceAll(actionName, "\\", "/")
+			}
+			actionName = strings.TrimPrefix(actionName, "/")
+
 			containerActionDir = "/github/workspace"
 		} else if step.Type() == model.StepTypeUsesActionRemote {
-			actionName = strings.TrimPrefix(strings.TrimPrefix(actionDir, rc.ActionCacheDir()), string(filepath.Separator))
+			actionName = strings.TrimPrefix(actionDir, rc.ActionCacheDir())
+			if runtime.GOOS == "windows" {
+				actionName = strings.ReplaceAll(actionName, "\\", "/")
+			}
+			actionName = strings.TrimPrefix(actionName, "/")
 			containerActionDir = "/actions"
 		}
 
 		if actionName == "" {
 			actionName = filepath.Base(actionDir)
+			if runtime.GOOS == "windows" {
+				actionName = strings.ReplaceAll(actionName, "\\", "/")
+			}
 		}
 
 		sc.Env = mergeMaps(sc.Env, action.Runs.Env)

--- a/pkg/runner/testdata/issue-228/main.yaml
+++ b/pkg/runner/testdata/issue-228/main.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - run: apt-get update -y && apt-get install git -y # setup git credentials will fail otherwise
       - name: Setup git credentials
-        uses: fusion-engineering/setup-git-credentials@v1
+        uses: fusion-engineering/setup-git-credentials@v2
         with:
           credentials: https://test@github.com/

--- a/pkg/runner/testdata/issue-228/main.yaml
+++ b/pkg/runner/testdata/issue-228/main.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - run: apt-get update -y && apt-get install git -y # setup git credentials will fail otherwise
       - name: Setup git credentials
-        uses: fusion-engineering/setup-git-credentials@v2
+        uses: fusion-engineering/setup-git-credentials@v1
         with:
           credentials: https://test@github.com/


### PR DESCRIPTION
…Path.join is OS aware, so when we want to use forward slash use path.join instead.

on windows docker cp should end with \. when copying a directory
when running npm modules we should pass in path with all forward slashes

This fixes #331