### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ or in a shell by running
 # Commands
 
 ```
-# List the actions
+# Command structure:
+act [event name to run] [flags]
+
+# List the actions for the default event:
 act -l
+
+# List the actions for a specific event:
+act workflow_dispatch -l
 
 # Run the default (`push`) event:
 act


### PR DESCRIPTION
Add the command structure and another example for a non-default event command to make the usage more clear.

Of course, a user can run `act --help` to see the information but I think it would be beneficial to directly state that in the documentation 🙂 