### PR TITLE
Special handling of cmake scripts

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -106,10 +106,13 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 	step := sc.Step
 	return func(ctx context.Context) error {
 		var script strings.Builder
+		var err error
 
-		_, err := script.WriteString(fmt.Sprintf("PATH=\"%s:${PATH}\"\n", strings.Join(rc.ExtraPath, ":")))
-		if err != nil {
-			return err
+		if !strings.HasPrefix(step.ShellCommand(), "cmake") {
+			_, err = script.WriteString(fmt.Sprintf("PATH=\"%s:${PATH}\"\n", strings.Join(rc.ExtraPath, ":")))
+			if err != nil {
+				return err
+			}
 		}
 
 		if step.WorkingDirectory == "" {


### PR DESCRIPTION
This fix only works with cmake, but I suspect other scripting languages
would have similar problems. I'm hoping there is a better solution, but
something like this does work for my particular problem.

The problem is having the first line of scripts be: Path="xxx:${PATH}"
where xxx is rc.ExtraPath, does not work for all scripting languages.
For example: 'cmake -P {0}' is used by Cristian Adam HelloWorld:
  https://github.com/cristianadam/HelloWorld/blob/master/.github/workflows/build_cmake.yml#:~:text=shell:

Here is some test code:

 name: CMake Build Matrix

 on: [push, pull_request]

 env:
  CMAKE_VERSION: 3.18.3
  NINJA_VERSION: 1.10.1
  BUILD_TYPE: Release
  CCACHE_VERSION: 3.7.7

 jobs:
  build:
    name: ${{ matrix.config.name }}
    runs-on: ${{ matrix.config.os }}
    strategy:
      fail-fast: false
      matrix:
        config:
          - {
              name: "Ubuntu Latest GCC",
              artifact: "Linux.7z",
              os: ubuntu-latest,
              cc: "gcc",
              cxx: "g++",
            }

    steps:
      - uses: actions/checkout@v1

      - name: Test bash
        shell: bash
        run: |
          echo Using host CMake version: ${CMAKE_VERSION}

      - name: Test cmake
        shell: cmake -P {0}
        run: |
          message(STATUS "hello from cmake script")


Executing the above results in the following error:

  $ ~/prgs/nektos/forks/act/act
  [CMake Build Matrix/Ubuntu Latest GCC] 🧪  Matrix: map[config:map[artifact:Linux.7z cc:gcc cxx:g++ name:Ubuntu Latest GCC os:ubuntu-latest]]
  [CMake Build Matrix/Ubuntu Latest GCC] 🚀  Start image=ubuntu-with-hello
  [CMake Build Matrix/Ubuntu Latest GCC]   🐳  docker run image=ubuntu-with-hello entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
  [CMake Build Matrix/Ubuntu Latest GCC]   🐳  docker cp src=/home/wink/prgs/cmake/projects/gha-cmake-HelloWorld/. dst=/github/workspace
  [CMake Build Matrix/Ubuntu Latest GCC] ⭐  Run actions/checkout@v1
  [CMake Build Matrix/Ubuntu Latest GCC]   ✅  Success - actions/checkout@v1
  [CMake Build Matrix/Ubuntu Latest GCC] ⭐  Run Test bash
  | Using host CMake version: 3.18.3
  [CMake Build Matrix/Ubuntu Latest GCC]   ✅  Success - Test bash
  [CMake Build Matrix/Ubuntu Latest GCC] ⭐  Run Test cmake
  | CMake Error at /github/workflow/2:1:
  |   Parse error.  Expected a command name, got unquoted argument with text
  |   "PATH=":${PATH}"".
  |
  |
  | CMake Error: Error processing file: /github/workflow/2
  [CMake Build Matrix/Ubuntu Latest GCC]   ❌  Failure - Test cmake
  Error: exit with `FAILURE`: 1

With this change the output is:

  $ ~/prgs/nektos/forks/act/act
  [CMake Build Matrix/Ubuntu Latest GCC] 🧪  Matrix: map[config:map[artifact:Linux.7z cc:gcc cxx:g++ name:Ubuntu Latest GCC os:ubuntu-latest]]
  [CMake Build Matrix/Ubuntu Latest GCC] 🚀  Start image=ubuntu-with-hello
  [CMake Build Matrix/Ubuntu Latest GCC]   🐳  docker run image=ubuntu-with-hello entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
  [CMake Build Matrix/Ubuntu Latest GCC]   🐳  docker cp src=/home/wink/prgs/cmake/projects/gha-cmake-HelloWorld/. dst=/github/workspace
  [CMake Build Matrix/Ubuntu Latest GCC] ⭐  Run actions/checkout@v1
  [CMake Build Matrix/Ubuntu Latest GCC]   ✅  Success - actions/checkout@v1
  [CMake Build Matrix/Ubuntu Latest GCC] ⭐  Run Test bash
  | Using host CMake version: 3.18.3
  [CMake Build Matrix/Ubuntu Latest GCC]   ✅  Success - Test bash
  [CMake Build Matrix/Ubuntu Latest GCC] ⭐  Run Test cmake
  | -- hello from cmake script
  [CMake Build Matrix/Ubuntu Latest GCC]   ✅  Success - Test cmake