### PR TITLE
Use PathListSeparator

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -94,7 +94,7 @@ func (sc *StepContext) setupEnv() common.Executor {
 
 		if (rc.ExtraPath != nil) && (len(rc.ExtraPath) > 0) {
 			s := append(rc.ExtraPath, os.Getenv("PATH"))
-			env["PATH"] = strings.Join(s, string(os.PathSeparator))
+			env["PATH"] = strings.Join(s, string(os.PathListSeparator))
 		}
 
 		for k, v := range env {


### PR DESCRIPTION
In PR #406 I used PathSeparator and I should have used PathListSeparator.
 See: https://golang.org/pkg/os/#pkg-constants