### PR TITLE
Add variadic version of hashFiles

### DIFF
--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -236,11 +236,15 @@ func vmFromJSON(vm *otto.Otto) {
 
 func (rc *RunContext) vmHashFiles() func(*otto.Otto) {
 	return func(vm *otto.Otto) {
-		_ = vm.Set("hashFiles", func(path string) string {
-			files, _, err := glob.Glob([]string{filepath.Join(rc.Config.Workdir, path)})
-			if err != nil {
-				logrus.Errorf("Unable to glob.Glob: %v", err)
-				return ""
+		_ = vm.Set("hashFiles", func(paths ...string) string {
+			files := []*glob.FileAsset{}
+			for i := range paths {
+				newFiles, _, err := glob.Glob([]string{filepath.Join(rc.Config.Workdir, paths[i])})
+				if err != nil {
+					logrus.Errorf("Unable to glob.Glob: %v", err)
+					return ""
+				}
+				files = append(files, newFiles...)
 			}
 			hasher := sha256.New()
 			for _, file := range files {

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -83,6 +83,7 @@ func TestEvaluate(t *testing.T) {
 		{"(fromJSON('{\"foo\":\"bar\"}')).foo", "bar", ""},
 		{"(fromJson('{\"foo\":\"bar\"}')).foo", "bar", ""},
 		{"hashFiles('**/non-extant-files')", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", ""},
+		{"hashFiles('**/non-extant-files', '**/more-non-extant-files')", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", ""},
 		{"success()", "true", ""},
 		{"failure()", "false", ""},
 		{"always()", "true", ""},


### PR DESCRIPTION
fixes #324

I don't know any Go, so double check this.

No idea if this needs some file dedup or if the hashes match the GitHub Actions version, this is just to make sure the same *.yaml code doesn't fail in act while it works in the GH Actions runner