### PR TITLE
Adds ability to use container images from matrices.

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -222,7 +222,7 @@ func (rc *RunContext) platformImage() string {
 
 	c := job.Container()
 	if c != nil {
-		return c.Image
+		return rc.ExprEval.Interpolate(c.Image)
 	}
 
 	for _, runnerLabel := range job.RunsOn() {


### PR DESCRIPTION
Uses `rc.ExprEval.Interpolate` on container image.

- fixes #376 

Tested using my own matrix job, which worked nicely :)