### PR TITLE
Fixes include when using matrix and strategy build.

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -176,15 +177,11 @@ func (j *Job) GetMatrixes() []map[string]interface{} {
 					continue MATRIX
 				}
 			}
-			for _, include := range includes {
-				if commonKeysMatch(matrix, include) {
-					log.Debugf("Setting add'l values on matrix '%v' due to include '%v'", matrix, include)
-					for k, v := range include {
-						matrix[k] = v
-					}
-				}
-			}
 			matrixes = append(matrixes, matrix)
+		}
+		for _, include := range includes {
+			log.Debugf("Adding include '%v'", include)
+			matrixes = append(matrixes, include)
 		}
 
 	} else {
@@ -195,7 +192,7 @@ func (j *Job) GetMatrixes() []map[string]interface{} {
 
 func commonKeysMatch(a map[string]interface{}, b map[string]interface{}) bool {
 	for aKey, aVal := range a {
-		if bVal, ok := b[aKey]; ok && aVal != bVal {
+		if bVal, ok := b[aKey]; ok && ! reflect.DeepEqual(aVal, bVal) {
 			return false
 		}
 	}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -246,7 +246,10 @@ func (rc *RunContext) isEnabled(ctx context.Context) bool {
 
 	img := rc.platformImage()
 	if img == "" {
-		l.Infof("\U0001F6A7  Skipping unsupported platform '%+v'", job.RunsOn())
+		for _, runnerLabel := range job.RunsOn() {
+			platformName := rc.ExprEval.Interpolate(runnerLabel)
+			l.Infof("\U0001F6A7  Skipping unsupported platform '%+v'", platformName)
+		}
 		return false
 	}
 	return true

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -73,66 +73,34 @@ func TestRunEvent(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	tables := []struct {
-		workflowPath string
-		eventName    string
-		errorMessage string
-	}{
-		{"basic", "push", ""},
-		{"fail", "push", "exit with `FAILURE`: 1"},
-		{"runs-on", "push", ""},
-		{"job-container", "push", ""},
-		{"job-container-non-root", "push", ""},
-		{"uses-docker-url", "push", ""},
-		{"remote-action-docker", "push", ""},
-		{"remote-action-js", "push", ""},
-		{"local-action-docker-url", "push", ""},
-		{"local-action-dockerfile", "push", ""},
-		{"local-action-js", "push", ""},
-		{"matrix", "push", ""},
-		{"matrix-include-exclude", "push", ""},
-		{"commands", "push", ""},
-		{"workdir", "push", ""},
-		//{"issue-228", "push", ""}, // TODO [igni]: Remove this once everything passes
-		{"defaults-run", "push", ""},
+	platforms := map[string]string{
+		"ubuntu-latest": "node:12.6-buster-slim",
+	}
+	tables := []TestJobFileInfo{
+		{"testdata", "basic", "push", "", platforms},
+		{"testdata", "fail", "push", "exit with `FAILURE`: 1", platforms},
+		{"testdata", "runs-on", "push", "", platforms},
+		{"testdata", "job-container", "push", "", platforms},
+		{"testdata", "job-container-non-root", "push", "", platforms},
+		{"testdata", "uses-docker-url", "push", "", platforms},
+		{"testdata", "remote-action-docker", "push", "", platforms},
+		{"testdata", "remote-action-js", "push", "", platforms},
+		{"testdata", "local-action-docker-url", "push", "", platforms},
+		{"testdata", "local-action-dockerfile", "push", "", platforms},
+		{"testdata", "local-action-js", "push", "", platforms},
+		{"testdata", "matrix", "push", "", platforms},
+		{"testdata", "matrix-include-exclude", "push", "", platforms},
+		{"testdata", "commands", "push", "", platforms},
+		{"testdata", "workdir", "push", "", platforms},
+		//{"testdata", "issue-228", "push", "", platforms}, // TODO [igni]: Remove this once everything passes
+		{"testdata", "defaults-run", "push", "", platforms},
 	}
 	log.SetLevel(log.DebugLevel)
 
 	ctx := context.Background()
 
 	for _, table := range tables {
-		table := table
-		t.Run(table.workflowPath, func(t *testing.T) {
-			platforms := map[string]string{
-				"ubuntu-latest": "node:12.6-buster-slim",
-				"ubuntu-18.04": "node:12.6-buster-slim",
-				"ubuntu-16.04": "node:12.6-stretch-slim",
-			}
-
-			workdir, err := filepath.Abs("testdata")
-			assert.NilError(t, err, table.workflowPath)
-			runnerConfig := &Config{
-				Workdir:         workdir,
-				BindWorkdir:     true,
-				EventName:       table.eventName,
-				Platforms:       platforms,
-				ReuseContainers: false,
-			}
-			runner, err := New(runnerConfig)
-			assert.NilError(t, err, table.workflowPath)
-
-			planner, err := model.NewWorkflowPlanner(fmt.Sprintf("testdata/%s", table.workflowPath))
-			assert.NilError(t, err, table.workflowPath)
-
-			plan := planner.PlanEvent(table.eventName)
-
-			err = runner.NewPlanExecutor(plan)(ctx)
-			if table.errorMessage == "" {
-				assert.NilError(t, err, table.workflowPath)
-			} else {
-				assert.ErrorContains(t, err, table.errorMessage)
-			}
-		})
+		runTestJobFile(ctx, t, table)
 	}
 }
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -53,6 +53,7 @@ func TestRunEvent(t *testing.T) {
 		{"local-action-dockerfile", "push", ""},
 		{"local-action-js", "push", ""},
 		{"matrix", "push", ""},
+		{"matrix-include-exclude", "push", ""},
 		{"commands", "push", ""},
 		{"workdir", "push", ""},
 		//{"issue-228", "push", ""}, // TODO [igni]: Remove this once everything passes

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -68,6 +68,8 @@ func TestRunEvent(t *testing.T) {
 		t.Run(table.workflowPath, func(t *testing.T) {
 			platforms := map[string]string{
 				"ubuntu-latest": "node:12.6-buster-slim",
+				"ubuntu-18.04": "node:12.6-buster-slim",
+				"ubuntu-16.04": "node:12.6-stretch-slim",
 			}
 
 			workdir, err := filepath.Abs("testdata")

--- a/pkg/runner/testdata/matrix-include-exclude/push.yml
+++ b/pkg/runner/testdata/matrix-include-exclude/push.yml
@@ -1,0 +1,31 @@
+name: matrix-include-exclude
+on: push
+
+jobs:
+  build:
+    name: PHP ${{ matrix.os }} ${{ matrix.node}}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: echo ${NODE_VERSION} | grep ${{ matrix.node }}
+        env:
+          NODE_VERSION: ${{ matrix.node }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+        node: [4, 6, 8, 10]
+        exclude:
+          - os: macos-latest
+            node: 4
+        include:
+          - os: ubuntu-20.04
+            node: 10
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [8.x, 10.x, 12.x, 13.x]
+    steps:
+      - run: echo ${NODE_VERSION} | grep ${{ matrix.node }}
+        env:
+          NODE_VERSION: ${{ matrix.node }}

--- a/pkg/runner/testdata/matrix-include-exclude/push.yml
+++ b/pkg/runner/testdata/matrix-include-exclude/push.yml
@@ -17,7 +17,7 @@ jobs:
           - os: macos-latest
             node: 4
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-16.04
             node: 10
 
   test:


### PR DESCRIPTION
The `include` of the matrix strategy was incorrectly handled.
This simply appends the provided includes to the matrix product, s.t. this works (taken from [the official doc](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations))
```yaml
runs-on: ${{ matrix.os }}
strategy:
  matrix:
    os: [macos-latest, windows-latest, ubuntu-18.04]
    node: [4, 6, 8, 10]
    include:
      # includes a new variable of npm with a value of 2
      # for the matrix leg matching the os and version
      - os: windows-latest
        node: 4
        npm: 2
```

Also replaces the comparison of the `commonKeysMatch()` with a `reflect.DeepEqual` to be able to compare maps.
Potentially the entire loop could be replaced that way`

PS:
I do not know how testing works in this project, so I cannot easily add one. But I have seen, that neither `include` nor `exclude` appears to be tested.