### PR TITLE
Change setupEnv to return an ExpressionEvaluator

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -202,15 +202,11 @@ func (rc *RunContext) newStepExecutor(step *model.Step) common.Executor {
 			Outputs: make(map[string]string),
 		}
 
-		_ = sc.setupEnv()(ctx)
-
-		if sc.Env != nil {
-			err := rc.JobContainer.UpdateFromGithubEnv(&sc.Env)(ctx)
-			if err != nil {
-				return err
-			}
+		exprEval, err := sc.setupEnv(ctx)
+		if err != nil {
+			return err
 		}
-		rc.ExprEval = sc.NewExpressionEvaluator()
+		rc.ExprEval = exprEval;
 
 		runStep, err := rc.EvalBool(sc.Step.If)
 		if err != nil {


### PR DESCRIPTION
This is a solution to issue #416 where environment variables created or
changed in the previous step are not usable in the next step because
the rc.ExprEval is from the beginning of the previous step.

This change refactors setupEnv so that before interpolating the environment
variables a NewExpressionEvaluator is created.

Fixes: 416