### PR TITLE
EvalBool and Interpolation fixes

### DIFF
--- a/.github/workflows/test-expressions.yml
+++ b/.github/workflows/test-expressions.yml
@@ -1,0 +1,82 @@
+
+name: "Test how expressions are handled on Github"
+on: push
+
+env:
+  KEYWITHNOTHING: valuewithnothing
+  KEY-WITH-HYPHENS: value-with-hyphens
+  KEY_WITH_UNDERSCORES: value_with_underscores
+  SOMETHING_TRUE: true
+  SOMETHING_FALSE: false
+
+
+jobs:
+  test-espressions:
+    runs-on: ubuntu-latest
+    steps:
+
+     - name:  €{{ 1 }} to €{{ 2 }}  ->  ${{1}} to ${{2}}  should be equal to  1 to 2 
+       run: echo "Done "
+
+     - name:  €{{ env.KEYWITHNOTHING }}  ->  ${{ env.KEYWITHNOTHING }}  should be equal to  valuewithnothing 
+       run: echo "Done "
+
+     - name:  €{{ env.KEY-WITH-HYPHENS }}  ->  ${{ env.KEY-WITH-HYPHENS }}  should be equal to  value-with-hyphens 
+       run: echo "Done "
+
+     - name:  €{{ env.KEY_WITH_UNDERSCORES }}  ->  ${{ env.KEY_WITH_UNDERSCORES }}  should be equal to  value_with_underscores 
+       run: echo "Done "
+
+     - name: €{{ env.UNKNOWN }} -> ${{ env.UNKNOWN }} should be equal to 
+       run: echo "Done "
+
+     - name: €{{ env.SOMETHING_TRUE }} -> ${{ env.SOMETHING_TRUE }} should be equal to true
+       run: echo "Done "
+
+     - name: €{{ env.SOMETHING_FALSE }} -> ${{ env.SOMETHING_FALSE }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_TRUE }} -> ${{ !env.SOMETHING_TRUE }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_FALSE }} -> ${{ !env.SOMETHING_FALSE }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_TRUE && true }} -> ${{ !env.SOMETHING_TRUE && true }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_FALSE && true }} -> ${{ !env.SOMETHING_FALSE && true }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ env.SOMETHING_TRUE && true }} -> ${{ env.SOMETHING_TRUE && true }} should be equal to true
+       run: echo "Done "
+
+     - name: €{{ env.SOMETHING_FALSE && true }} -> ${{ env.SOMETHING_FALSE && true }} should be equal to true
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_TRUE || true }} -> ${{ !env.SOMETHING_TRUE || true }} should be equal to true
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_FALSE || true }} -> ${{ !env.SOMETHING_FALSE || true }} should be equal to true
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_TRUE && false }} -> ${{ !env.SOMETHING_TRUE && false }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_FALSE && false }} -> ${{ !env.SOMETHING_FALSE && false }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_TRUE || false }} -> ${{ !env.SOMETHING_TRUE || false }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ !env.SOMETHING_FALSE || false }} -> ${{ !env.SOMETHING_FALSE || false }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ env.SOMETHING_TRUE || false }} -> ${{ env.SOMETHING_TRUE || false }} should be equal to true
+       run: echo "Done "
+
+     - name: €{{ env.SOMETHING_FALSE || false }} -> ${{ env.SOMETHING_FALSE || false }} should be equal to false
+       run: echo "Done "
+
+     - name: €{{ env.SOMETHING_FALSE }} && €{{ env.SOMETHING_TRUE }} -> ${{ env.SOMETHING_FALSE }} && ${{ env.SOMETHING_TRUE }} should be equal to false && true
+       run: echo "Done "

--- a/.github/workflows/test-if.yml
+++ b/.github/workflows/test-if.yml
@@ -1,0 +1,391 @@
+
+name: "Test what expressions result in true and false on Github"
+on: push
+
+env:
+  SOME_TEXT: text
+  SOMETHING_TRUE: true
+  SOMETHING_FALSE: false
+
+
+jobs:
+  test-ifs-and-buts:
+    runs-on: ubuntu-latest
+    steps:
+
+     - name: "❌ I should not run, expr: failure()"
+       id: step0
+       if: failure()
+       run: echo "failure() should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: success()"
+       id: step1
+       if: success()
+       run: echo OK
+
+     - name: "Double checking expr: success()"
+       if: steps.step1.conclusion == 'skipped'
+       run: echo "success() should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: cancelled()"
+       id: step2
+       if: cancelled()
+       run: echo "cancelled() should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: always()"
+       id: step3
+       if: always()
+       run: echo OK
+
+     - name: "Double checking expr: always()"
+       if: steps.step3.conclusion == 'skipped'
+       run: echo "always() should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: true"
+       id: step4
+       if: true
+       run: echo OK
+
+     - name: "Double checking expr: true"
+       if: steps.step4.conclusion == 'skipped'
+       run: echo "true should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: false"
+       id: step5
+       if: false
+       run: echo "false should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: 1 != 0"
+       id: step8
+       if: 1 != 0
+       run: echo OK
+
+     - name: "Double checking expr: 1 != 0"
+       if: steps.step8.conclusion == 'skipped'
+       run: echo "1 != 0 should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: 1 != 1"
+       id: step9
+       if: 1 != 1
+       run: echo "1 != 1 should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: €{{ 1 != 0 }}"
+       id: step10
+       if: ${{ 1 != 0 }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ 1 != 0 }}"
+       if: steps.step10.conclusion == 'skipped'
+       run: echo "${{ 1 != 0 }} should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: €{{ 1 != 1 }}"
+       id: step11
+       if: ${{ 1 != 1 }}
+       run: echo "${{ 1 != 1 }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: 1 == 0"
+       id: step12
+       if: 1 == 0
+       run: echo "1 == 0 should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: 1 == 1"
+       id: step13
+       if: 1 == 1
+       run: echo OK
+
+     - name: "Double checking expr: 1 == 1"
+       if: steps.step13.conclusion == 'skipped'
+       run: echo "1 == 1 should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: 1 > 2"
+       id: step14
+       if: 1 > 2
+       run: echo "1 > 2 should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: 1 < 2"
+       id: step15
+       if: 1 < 2
+       run: echo OK
+
+     - name: "Double checking expr: 1 < 2"
+       if: steps.step15.conclusion == 'skipped'
+       run: echo "1 < 2 should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: true && false"
+       id: step16
+       if: true && false
+       run: echo "true && false should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: true && 1 < 2"
+       id: step17
+       if: true && 1 < 2
+       run: echo OK
+
+     - name: "Double checking expr: true && 1 < 2"
+       if: steps.step17.conclusion == 'skipped'
+       run: echo "true && 1 < 2 should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: false || 1 < 2"
+       id: step18
+       if: false || 1 < 2
+       run: echo OK
+
+     - name: "Double checking expr: false || 1 < 2"
+       if: steps.step18.conclusion == 'skipped'
+       run: echo "false || 1 < 2 should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: false || false"
+       id: step19
+       if: false || false
+       run: echo "false || false should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: env.UNKNOWN == 'true'"
+       id: step20
+       if: env.UNKNOWN == 'true'
+       run: echo "env.UNKNOWN == 'true' should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: env.UNKNOWN"
+       id: step21
+       if: env.UNKNOWN
+       run: echo "env.UNKNOWN should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: env.SOME_TEXT"
+       id: step22
+       if: env.SOME_TEXT
+       run: echo OK
+
+     - name: "Double checking expr: env.SOME_TEXT"
+       if: steps.step22.conclusion == 'skipped'
+       run: echo "env.SOME_TEXT should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: env.SOME_TEXT == 'text'"
+       id: step23
+       if: env.SOME_TEXT == 'text'
+       run: echo OK
+
+     - name: "Double checking expr: env.SOME_TEXT == 'text'"
+       if: steps.step23.conclusion == 'skipped'
+       run: echo "env.SOME_TEXT == 'text' should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: env.SOMETHING_TRUE == 'true'"
+       id: step24
+       if: env.SOMETHING_TRUE == 'true'
+       run: echo OK
+
+     - name: "Double checking expr: env.SOMETHING_TRUE == 'true'"
+       if: steps.step24.conclusion == 'skipped'
+       run: echo "env.SOMETHING_TRUE == 'true' should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: env.SOMETHING_FALSE == 'true'"
+       id: step25
+       if: env.SOMETHING_FALSE == 'true'
+       run: echo "env.SOMETHING_FALSE == 'true' should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: env.SOMETHING_TRUE"
+       id: step26
+       if: env.SOMETHING_TRUE
+       run: echo OK
+
+     - name: "Double checking expr: env.SOMETHING_TRUE"
+       if: steps.step26.conclusion == 'skipped'
+       run: echo "env.SOMETHING_TRUE should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: env.SOMETHING_FALSE"
+       id: step27
+       if: env.SOMETHING_FALSE
+       run: echo OK
+
+     - name: "Double checking expr: env.SOMETHING_FALSE"
+       if: steps.step27.conclusion == 'skipped'
+       run: echo "env.SOMETHING_FALSE should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: €{{ !env.SOMETHING_TRUE }}"
+       id: step30
+       if: ${{ !env.SOMETHING_TRUE }}
+       run: echo "${{ !env.SOMETHING_TRUE }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: €{{ !env.SOMETHING_FALSE }}"
+       id: step31
+       if: ${{ !env.SOMETHING_FALSE }}
+       run: echo "${{ !env.SOMETHING_FALSE }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: €{{ ! env.SOMETHING_TRUE }}"
+       id: step32
+       if: ${{ ! env.SOMETHING_TRUE }}
+       run: echo "${{ ! env.SOMETHING_TRUE }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: €{{ ! env.SOMETHING_FALSE }}"
+       id: step33
+       if: ${{ ! env.SOMETHING_FALSE }}
+       run: echo "${{ ! env.SOMETHING_FALSE }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_TRUE }}"
+       id: step34
+       if: ${{ env.SOMETHING_TRUE }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_TRUE }}"
+       if: steps.step34.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_TRUE }} should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_FALSE }}"
+       id: step35
+       if: ${{ env.SOMETHING_FALSE }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_FALSE }}"
+       if: steps.step35.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_FALSE }} should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: €{{ !env.SOMETHING_TRUE }}"
+       id: step36
+       if: ${{ !env.SOMETHING_TRUE }}
+       run: echo "${{ !env.SOMETHING_TRUE }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: €{{ !env.SOMETHING_FALSE }}"
+       id: step37
+       if: ${{ !env.SOMETHING_FALSE }}
+       run: echo "${{ !env.SOMETHING_FALSE }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: €{{ !env.SOMETHING_TRUE && true }}"
+       id: step38
+       if: ${{ !env.SOMETHING_TRUE && true }}
+       run: echo "${{ !env.SOMETHING_TRUE && true }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: €{{ !env.SOMETHING_FALSE && true }}"
+       id: step39
+       if: ${{ !env.SOMETHING_FALSE && true }}
+       run: echo "${{ !env.SOMETHING_FALSE && true }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: €{{ !env.SOMETHING_TRUE || true }}"
+       id: step40
+       if: ${{ !env.SOMETHING_TRUE || true }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ !env.SOMETHING_TRUE || true }}"
+       if: steps.step40.conclusion == 'skipped'
+       run: echo "${{ !env.SOMETHING_TRUE || true }} should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: €{{ !env.SOMETHING_FALSE || false }}"
+       id: step41
+       if: ${{ !env.SOMETHING_FALSE || false }}
+       run: echo "${{ !env.SOMETHING_FALSE || false }} should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_TRUE && true }}"
+       id: step42
+       if: ${{ env.SOMETHING_TRUE && true }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_TRUE && true }}"
+       if: steps.step42.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_TRUE && true }} should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_FALSE || true }}"
+       id: step43
+       if: ${{ env.SOMETHING_FALSE || true }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_FALSE || true }}"
+       if: steps.step43.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_FALSE || true }} should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_FALSE || false }}"
+       id: step44
+       if: ${{ env.SOMETHING_FALSE || false }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_FALSE || false }}"
+       if: steps.step44.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_FALSE || false }} should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_TRUE == 'true' }}"
+       id: step46
+       if: ${{ env.SOMETHING_TRUE == 'true'}}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_TRUE == 'true' }}"
+       if: steps.step46.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_TRUE == 'true'}} should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: €{{ env.SOMETHING_FALSE == 'true' }}"
+       id: step47
+       if: ${{ env.SOMETHING_FALSE == 'true'}}
+       run: echo "${{ env.SOMETHING_FALSE == 'true'}} should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_FALSE == 'false' }}"
+       id: step48
+       if: ${{ env.SOMETHING_FALSE == 'false'}}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_FALSE == 'false' }}"
+       if: steps.step48.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_FALSE == 'false'}} should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_FALSE }} && €{{ env.SOMETHING_TRUE }}"
+       id: step49
+       if: ${{ env.SOMETHING_FALSE }} && ${{ env.SOMETHING_TRUE }}
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_FALSE }} && €{{ env.SOMETHING_TRUE }}"
+       if: steps.step49.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_FALSE }} && ${{ env.SOMETHING_TRUE }} should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: false || env.SOMETHING_TRUE == 'true'"
+       id: step50
+       if: false || env.SOMETHING_TRUE == 'true'
+       run: echo OK
+
+     - name: "Double checking expr: false || env.SOMETHING_TRUE == 'true'"
+       if: steps.step50.conclusion == 'skipped'
+       run: echo "false || env.SOMETHING_TRUE == 'true' should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: true || env.SOMETHING_FALSE == 'true'"
+       id: step51
+       if: true || env.SOMETHING_FALSE == 'true'
+       run: echo OK
+
+     - name: "Double checking expr: true || env.SOMETHING_FALSE == 'true'"
+       if: steps.step51.conclusion == 'skipped'
+       run: echo "true || env.SOMETHING_FALSE == 'true' should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: true && env.SOMETHING_TRUE == 'true'"
+       id: step52
+       if: true && env.SOMETHING_TRUE == 'true'
+       run: echo OK
+
+     - name: "Double checking expr: true && env.SOMETHING_TRUE == 'true'"
+       if: steps.step52.conclusion == 'skipped'
+       run: echo "true && env.SOMETHING_TRUE == 'true' should have been true, but wasn't"
+
+     - name: "❌ I should not run, expr: false && env.SOMETHING_TRUE == 'true'"
+       id: step53
+       if: false && env.SOMETHING_TRUE == 'true'
+       run: echo "false && env.SOMETHING_TRUE == 'true' should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: env.SOMETHING_FALSE == 'true' && env.SOMETHING_TRUE == 'true'"
+       id: step54
+       if: env.SOMETHING_FALSE == 'true' && env.SOMETHING_TRUE == 'true'
+       run: echo "env.SOMETHING_FALSE == 'true' && env.SOMETHING_TRUE == 'true' should be false, but was evaluated to true;" exit 1;
+
+     - name: "❌ I should not run, expr: env.SOMETHING_FALSE == 'true' && true"
+       id: step55
+       if: env.SOMETHING_FALSE == 'true' && true
+       run: echo "env.SOMETHING_FALSE == 'true' && true should be false, but was evaluated to true;" exit 1;
+
+     - name: "✅ I should run, expr: €{{ env.SOMETHING_FALSE == 'true' }} && true"
+       id: step56
+       if: ${{ env.SOMETHING_FALSE == 'true' }} && true
+       run: echo OK
+
+     - name: "Double checking expr: €{{ env.SOMETHING_FALSE == 'true' }} && true"
+       if: steps.step56.conclusion == 'skipped'
+       run: echo "${{ env.SOMETHING_FALSE == 'true' }} && true should have been true, but wasn't"
+
+     - name: "✅ I should run, expr: true && €{{ env.SOMETHING_FALSE == 'true' }}"
+       id: step57
+       if: true && ${{ env.SOMETHING_FALSE == 'true' }}
+       run: echo OK
+
+     - name: "Double checking expr: true && €{{ env.SOMETHING_FALSE == 'true' }}"
+       if: steps.step57.conclusion == 'skipped'
+       run: echo "true && ${{ env.SOMETHING_FALSE == 'true' }} should have been true, but wasn't"

--- a/.github/workflows/test-if.yml
+++ b/.github/workflows/test-if.yml
@@ -3,9 +3,9 @@ name: "Test what expressions result in true and false on Github"
 on: push
 
 env:
-  SOME_TEXT: text
   SOMETHING_TRUE: true
   SOMETHING_FALSE: false
+  SOME_TEXT: text
 
 
 jobs:

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -272,7 +272,6 @@ func (rc *RunContext) EvalBool(expr string) (bool, error) {
 		splitPattern := regexp.MustCompile(fmt.Sprintf(`%s|%s|\S+`, expressionPattern.String(), operatorPattern.String()))
 
 		parts := splitPattern.FindAllString(expr, -1)
-		fmt.Printf("PARTS: %s\n", strings.Join(parts, "-"))
 		var evaluatedParts []string
 		for i, part := range parts {
 			if operatorPattern.MatchString(part) {
@@ -281,7 +280,6 @@ func (rc *RunContext) EvalBool(expr string) (bool, error) {
 			}
 
 			interpolatedPart, isString := rc.ExprEval.InterpolateWithStringCheck(part)
-			fmt.Printf("interpolatedPart: %s isString: %v\n", interpolatedPart, isString)
 
 			// This peculiar transformation has to be done because the Github parser
 			// treats false retured from contexts as a string, not a boolean.
@@ -300,7 +298,6 @@ func (rc *RunContext) EvalBool(expr string) (bool, error) {
 		}
 
 		joined := strings.Join(evaluatedParts, " ")
-		fmt.Printf("Joined: %s\n", joined)
 		v, _, err := rc.ExprEval.Evaluate(fmt.Sprintf("Boolean(%s)", joined))
 		if err != nil {
 			return false, nil


### PR DESCRIPTION
I had take another stab at fixing the Interpolation and EvalBool functions so their results match the somewhat weird ones performed by live Github actions.

I've added some auto generated workflows that verifies that the assumptions we make about how Github evaluates stuff is actually true. So the EvalBool test in `run_context_test.go` no checks that act evaluates expression and booleans the same as Github does.
<img width="343" alt="Screenshot 2020-11-16 at 23 36 46" src="https://user-images.githubusercontent.com/4453/99316395-9b2a1880-2864-11eb-8052-384fdd0c4546.png">

I had to make some really weird exceptions to make it work though, to me it seems that the expression parser that the Github actions runner either has some bugs or the developers has made some strange design choices.
I've tried to explain the weirdness in the comments here: https://github.com/unacast/act/blob/eval_and_interpolation/pkg/runner/run_context.go#L289

The `test-expressions.yml` and `test-if.yml` workflow files are auto generated every time the expression and run_context tests are run, to make sure that future changes to the tests (because the code has changed) or to the Github actions runner are detected.

Some of the issues that this PR tries to solve are described in #353 and #366 

Fixes #353
Fixes #366 
