### PR TITLE
Fix/a small confusion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you need an environment that works just like the corresponding GitHub runner 
 To use a different image for the runner, use the `-P` option:
 
 ```
-act -P ubuntu-latest=nektos/act-environments-ubuntu:18.04
+act -P ubuntu-18.04=nektos/act-environments-ubuntu:18.04
 ```
 
 # Secrets

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can provide default configuration flags to `act` by either creating a `./.ac
 
 ```
 # sample .actrc file
--P ubuntu-latest=nektos/act-environments-ubuntu:18.04
+-P ubuntu-18.04=nektos/act-environments-ubuntu:18.04
 ```
 
 Additionally, act supports loading environment variables from an `.env` file. The default is to look in the working directory for the file but can be overridden by:


### PR DESCRIPTION
Hello,

In the current readme I found a little confusion in these two sections

[https://github.com/nektos/act#use-an-alternative-runner-image](use-an-alternative-runner-image)
[https://github.com/nektos/act#configuration](configuration) 

The image is named `ubuntu-latest` while it actually uses at the end the `ubuntu-18.04`

the current command

`act -P ubuntu-latest=nektos/act-environments-ubuntu:18.04`

My fix

`act -P ubuntu-18.04=nektos/act-environments-ubuntu:18.04`

its a small  change but I think it fix the small confusion

Thanks
