### PR TITLE
Make stale bot action less aggressive

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,12 +11,13 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Issue is stale and will be closed in 7 days unless there is new activity'
-        stale-pr-message: 'PR is stale and will be closed in 7 days unless there is new activity'
+        stale-issue-message: 'Issue is stale and will be closed in 14 days unless there is new activity'
+        stale-pr-message: 'PR is stale and will be closed in 14 days unless there is new activity'
         stale-issue-label: 'meta/stale'
         exempt-issue-label: 'meta/stale-exempt'
         stale-pr-label: 'meta/stale'
         exempt-pr-label: 'meta/stale-exempt'
         remove-stale-when-updated: 'True'
         operations-per-run: 500
-
+        days-before-stale: 30
+        days-before-close: 14


### PR DESCRIPTION
Make stale bot action less aggressive
Days before marking issues/PRs as stale: 30
Days before closing stale issues/PRs: 14

Currently it closes/marks as stale many issues/PRs because there is no one to work on those or review them.