### PR TITLE
Fix Cartesian product to return empty set if empty set is given

### DIFF
--- a/pkg/common/cartesian.go
+++ b/pkg/common/cartesian.go
@@ -27,7 +27,7 @@ func cartN(a ...[]interface{}) [][]interface{} {
 	for _, a := range a {
 		c *= len(a)
 	}
-	if c == 0 {
+	if c == 0 || len(a) == 0 {
 		return nil
 	}
 	p := make([][]interface{}, c)

--- a/pkg/common/cartesian_test.go
+++ b/pkg/common/cartesian_test.go
@@ -25,4 +25,16 @@ func TestCartesianProduct(t *testing.T) {
 		assert.Contains(v, "baz")
 	}
 
+  input = map[string][]interface{}{
+		"foo": {1, 2, 3, 4},
+		"bar": {},
+		"baz": {false, true},
+  }
+  output = CartesianProduct(input)
+  assert.Len(output, 0)
+
+  input = map[string][]interface{}{}
+  output = CartesianProduct(input)
+  assert.Len(output, 0)
 }
+


### PR DESCRIPTION
This fixes #499, where a matrix strategy with only `include` keys ends up
causing multiple builds.  This bug appears to have been introduced in #415,
when extra `include` keys are added in the matrix strategy.  The cause
seems to be because the CartesianProduct function returns an item with
empty keys, instead of returning an empty set, when given an empty set.