### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ GitHub Actions offers managed [virtual environments](https://help.github.com/en/
 | -------------- | ----------------------------------------------------------------- |
 | ubuntu-latest  | [node:12.6-buster-slim](https://hub.docker.com/_/buildpack-deps)  |
 | ubuntu-20.04   | [node:12.6-buster-slim](https://hub.docker.com/_/buildpack-deps)  |
-| ubuntu-18.04   | [node:12.6-buster-slim](https://hub.docker.com/_/buildpack-deps)  |
+| ubuntu-18.04   | [node:12-buster](https://hub.docker.com/_/buildpack-deps)  |
 | ubuntu-16.04   | [node:12.6-stretch-slim](https://hub.docker.com/_/buildpack-deps) |
 | windows-latest | `unsupported`                                                     |
 | windows-2019   | `unsupported`                                                     |


### PR DESCRIPTION
The README says the docker image for ubuntu-18.04 is `node:12.6-buster-slim`, but isn't it correctly `node:12-buster`?
<img width="802" alt="screenshot_ 2021-01-27 23 08 28" src="https://user-images.githubusercontent.com/17779386/106002578-a61ae800-60f4-11eb-87aa-1181b5da3f3c.png">

Sorry if i'm wrong! Thanks for the nice tool.