### PR TITLE
Add lacking environment variables.

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -583,6 +583,9 @@ func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	env["GITHUB_SHA"] = github.Sha
 	env["GITHUB_REF"] = github.Ref
 	env["GITHUB_TOKEN"] = github.Token
+	env["GITHUB_SERVER_URL"] = "https://github.com"
+	env["GITHUB_API_URL"] = "https://api.github.com"
+	env["GITHUB_GRAPHQL_URL"] = "https://api.github.com/graphql"
 	return env
 }
 


### PR DESCRIPTION
According to [the document](https://docs.github.com/en/actions/reference/environment-variables), there are environment variables called:

* GITHUB_SERVER_URL
* GITHUB_API_URL
* GITHUB_GRAPHQL_URL

I added it.