### PR TITLE
Fixed `reference not found` error when using commit hash.

### DIFF
--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -244,8 +244,14 @@ func NewGitCloneExecutor(input NewGitCloneExecutorInput) Executor {
 		refType := "tag"
 		rev := plumbing.Revision(path.Join("refs", "tags", input.Ref))
 		if _, err := r.Tag(input.Ref); errors.Is(err, git.ErrTagNotFound) {
-			refType = "branch"
-			rev = plumbing.Revision(path.Join("refs", "remotes", "origin", input.Ref))
+			rName := plumbing.ReferenceName(path.Join("refs", "remotes", "origin", input.Ref))
+			if _, err := r.Reference(rName, false); errors.Is(err, plumbing.ErrReferenceNotFound) {
+				refType = "sha"
+				rev = plumbing.Revision(input.Ref)
+			} else {
+				refType = "branch"
+				rev = plumbing.Revision(rName)
+			}
 		}
 		hash, err := r.ResolveRevision(rev)
 		if err != nil {

--- a/pkg/common/git_test.go
+++ b/pkg/common/git_test.go
@@ -186,6 +186,11 @@ func TestGitCloneExecutor(t *testing.T) {
 			Ref: "act-fails",
 			Err: nil,
 		},
+		"sha": {
+			URL: "https://github.com/actions/checkout",
+			Ref: "5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f", // v2
+			Err: nil,
+		},
 	} {
 		tt := tt
 		name := name


### PR DESCRIPTION
Hi,

This is a fix for an error that occurred when using commit hash in `use`

fixes #506 
