### PR TITLE
Add --userns flag to support Docker daemon that enables user namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ It will save that information to `~/.actrc`, please refer to [Configuration](#co
   -r, --reuse                  reuse action containers to maintain state
   -s, --secret stringArray     secret to make available to actions with optional value (e.g. -s mysecret=foo or -s mysecret)
       --secret-file string     file with list of secrets to read from (e.g. --secret-file .secrets) (default ".secrets")
+      --userns string          user namespace to use
   -v, --verbose                verbose output
       --version                version for act
   -w, --watch                  watch the contents of the local repo and run when files change

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -25,6 +25,7 @@ type Input struct {
 	insecureSecrets bool
 	defaultBranch   string
 	privileged      bool
+	usernsMode      string
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().StringVarP(&input.eventPath, "eventpath", "e", "", "path to event JSON file")
 	rootCmd.Flags().StringVar(&input.defaultBranch, "defaultbranch", "", "the name of the main branch")
 	rootCmd.Flags().BoolVar(&input.privileged, "privileged", false, "use privileged mode")
+	rootCmd.Flags().StringVar(&input.usernsMode, "userns", "", "user namespace to use")
 	rootCmd.PersistentFlags().StringVarP(&input.actor, "actor", "a", "nektos/act", "user that triggered the event")
 	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow file(s)")
 	rootCmd.PersistentFlags().StringVarP(&input.workdir, "directory", "C", ".", "working directory")
@@ -260,6 +261,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			InsecureSecrets: input.insecureSecrets,
 			Platforms:       input.newPlatforms(),
 			Privileged:      input.privileged,
+			UsernsMode:      input.usernsMode,
 		}
 		r, err := runner.New(config)
 		if err != nil {

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -44,6 +44,7 @@ type NewContainerInput struct {
 	Stderr      io.Writer
 	NetworkMode string
 	Privileged  bool
+	UsernsMode  string
 }
 
 // FileEntry is a file to copy to a container
@@ -271,6 +272,7 @@ func (cr *containerReference) create() common.Executor {
 			Mounts:      mounts,
 			NetworkMode: container.NetworkMode(input.NetworkMode),
 			Privileged:  input.Privileged,
+			UsernsMode:  container.UsernsMode(input.UsernsMode),
 		}, nil, input.Name)
 		if err != nil {
 			return errors.WithStack(err)

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -106,6 +106,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			Stdout:      logWriter,
 			Stderr:      logWriter,
 			Privileged:  rc.Config.Privileged,
+			UsernsMode:  rc.Config.UsernsMode,
 		})
 
 		var copyWorkspace bool

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -31,6 +31,7 @@ type Config struct {
 	InsecureSecrets bool              // switch hiding output when printing to terminal
 	Platforms       map[string]string // list of platforms
 	Privileged      bool              // use privileged mode
+	UsernsMode      string            // user namespace to use
 }
 
 type runnerImpl struct {

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -233,6 +233,7 @@ func (sc *StepContext) newStepContainer(ctx context.Context, image string, cmd [
 		Stdout:      logWriter,
 		Stderr:      logWriter,
 		Privileged:  rc.Config.Privileged,
+		UsernsMode:  rc.Config.UsernsMode,
 	})
 	return stepContainer
 }


### PR DESCRIPTION
Hello. I got an error like this after hitting `act` command.

> Error: Error response from daemon: cannot share the host's network namespace when user namespaces are enabled

According to the document ([link](https://docs.docker.com/engine/security/userns-remap/#user-namespace-known-limitations)), when user namespaces are enabled on the Docker daemon, neither host network mode and `--privileged` work without `--userns=host`. Since `act` uses host network mode to match GitHub Actions runners, it cannot run jobs when user namespaces are enabled. So I added the flag.
