### PR TITLE
properly parse arguments to Docker container steps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/joho/godotenv v1.3.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/mgutz/str v1.2.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect


### PR DESCRIPTION
At present, act uses `strings.Fields` to split up `args` passed to a `docker://` step. This completely ignores any sort of quoting and instead splits the string at every single space.

Example workflow:
```yaml
on: [push, pull_request]

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - uses: docker://ubuntu:latest
      with:
        args: bash -c "echo test"
```

Currently it results with:
```none
[test.yaml/build]   🐳  docker run image=ubuntu:latest entrypoint=[] cmd=["bash" "-c" "\"echo" "test\""]
| test": -c: line 0: unexpected EOF while looking for matching `"'
| test": -c: line 1: syntax error: unexpected end of file
[test.yaml/build]   ❌  Failure - docker://ubuntu:latest
```

Meanwhile Github parses the args as `["bash" "-c" "echo test"]`. This PR introduces proper quotation parsing using `github.com/kballard/go-shellquote`. Resulting behavior:
```none
[test.yaml/build]   🐳  docker run image=ubuntu:latest entrypoint=[] cmd=["bash" "-c" "echo test"]
| test
[test.yaml/build]   ✅  Success - docker://ubuntu:latest
```