### PR TITLE
Add more context to MODULE_NOT_FOUND errors and how to fix it

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,25 @@ It will save that information to `~/.actrc`, please refer to [Configuration](#co
 
 # Known Issues
 
-MODULE_NOT_FOUND during `docker cp` command [#228](https://github.com/nektos/act/issues/228)
+A `MODULE_NOT_FOUND` during `docker cp` command [#228](https://github.com/nektos/act/issues/228) can happen if you are relying on local changes that have not been pushed. This can get triggered if the action is using a path, like:
+
+```yaml
+
+    - name: test action locally
+      uses: ./
+```
+
+In this case, you _must_ use `actions/checkout@v2` with a path that _has the same name as your repository_. If your repository is called _my-action_, then your checkout step would look like:
 
 ```yaml
 steps:
   - name: Checkout
     uses: actions/checkout@v2
     with:
-      path: "your-action-root-directory"
+      path: "my-action"
 ```
+
+If the `path:` value doesn't match the name of the repository, a `MODULE_NOT_FOUND` will be thrown.
 
 # Runners
 


### PR DESCRIPTION
This update follows many comments on related issues that don't really follow what `"your-action-root-directory"` is. In my case, I stumbled on this before, and couldn't remember what the fix was a few months later. 

The PR gives more context as to what exactly is needed to make this work for running local actions that are getting copied over.

Related comments:

* https://github.com/nektos/act/issues/228#issuecomment-753375358
* https://github.com/nektos/act/issues/228#issuecomment-744428603