### PR TITLE
Set step results to map more closely to reality

### DIFF
--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -46,19 +46,19 @@ func TestEvaluate(t *testing.T) {
 				Outputs: map[string]string{
 					"foowithnothing": "barwithnothing",
 				},
-				Success: true,
+				Outcome: "success",
 			},
 			"id-with-hyphens": {
 				Outputs: map[string]string{
 					"foo-with-hyphens": "bar-with-hyphens",
 				},
-				Success: true,
+				Outcome: "success",
 			},
 			"id_with_underscores": {
 				Outputs: map[string]string{
 					"foo_with_underscores": "bar_with_underscores",
 				},
-				Success: true,
+				Outcome: "success",
 			},
 		},
 	}

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -49,7 +49,7 @@ func TestRunContext_EvalBool(t *testing.T) {
 				Outputs: map[string]string{
 					"foo": "bar",
 				},
-				Success: true,
+				Outcome: "success",
 			},
 		},
 	}

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/kballard/go-shellquote"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"


### PR DESCRIPTION
This partially addresses #465 by setting the outcome to "success" or "failure" depending whether a step passes or fails (see https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context)

I don't know enough Go to address the conclusion part of the output, but this is an improvement on what we have before.