### PR TITLE
Fix tests on Windows

### DIFF
--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -98,7 +98,8 @@ func findGitPrettyRef(head, root, sub string) (string, error) {
 		}
 		var pointsTo = strings.TrimSpace(string(bts))
 		if head == pointsTo {
-			name = strings.TrimPrefix(strings.Replace(path, root, "", 1), "/")
+			// On Windows paths are separated with backslash character so they should be replaced to provide proper git refs format
+			name = strings.TrimPrefix(strings.ReplaceAll(strings.Replace(path, root, "", 1), `\`, `/`), "/")
 			log.Debugf("HEAD matches %s", name)
 		}
 		return nil

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/robertkrimen/otto"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/godo.v2/glob"
 )
 
 var expressionPattern, operatorPattern *regexp.Regexp
@@ -319,9 +318,9 @@ func vmFromJSON(vm *otto.Otto) {
 func (rc *RunContext) vmHashFiles() func(*otto.Otto) {
 	return func(vm *otto.Otto) {
 		_ = vm.Set("hashFiles", func(paths ...string) string {
-			var files []*glob.FileAsset
+			var files []string
 			for i := range paths {
-				newFiles, _, err := glob.Glob([]string{filepath.Join(rc.Config.Workdir, paths[i])})
+				newFiles, err := filepath.Glob(filepath.Join(rc.Config.Workdir, paths[i]))
 				if err != nil {
 					log.Errorf("Unable to glob.Glob: %v", err)
 					return ""
@@ -330,7 +329,7 @@ func (rc *RunContext) vmHashFiles() func(*otto.Otto) {
 			}
 			hasher := sha256.New()
 			for _, file := range files {
-				f, err := os.Open(file.Path)
+				f, err := os.Open(file)
 				if err != nil {
 					log.Errorf("Unable to os.Open: %v", err)
 				}


### PR DESCRIPTION
- Paths on Windows use backslash (`\`) as directory separator and this breaks `TestGitFindRef()`. Replacing `\` with `/` in git ref fixes that issue.
- Replace external dependency lib with std lib. 