### PR TITLE
Use project dir instead of /github/workspace

### DIFF
--- a/pkg/runner/testdata/basic/push.yml
+++ b/pkg/runner/testdata/basic/push.yml
@@ -16,8 +16,8 @@ jobs:
           args: echo ${INPUT_SOMEKEY} | grep somevalue
       - run: ls
       - run: echo 'hello world' 
-      - run: echo ${GITHUB_SHA} >> /github/sha.txt
-      - run: cat /github/sha.txt | grep ${GITHUB_SHA}
+      - run: echo ${GITHUB_SHA} >> $(dirname "${GITHUB_WORKSPACE}")/sha.txt
+      - run: cat $(dirname "${GITHUB_WORKSPACE}")/sha.txt | grep ${GITHUB_SHA}
   build:
     runs-on: ubuntu-latest
     needs: [check]

--- a/pkg/runner/testdata/workdir/push.yml
+++ b/pkg/runner/testdata/workdir/push.yml
@@ -6,12 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: ls -alFt /github/workspace/workdir
-    - run: '[[ "$(pwd)" == "/github/workspace/workdir" ]]'
+    - run: ls -alFt "${GITHUB_WORKSPACE}/workdir"
+    - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}/workdir" ]]'
       working-directory: workdir
 
   noworkdir:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: '[[ "$(pwd)" == "/github/workspace" ]]'
+      - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}" ]]'


### PR DESCRIPTION
As stated [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#file-systems), there is no guaranty that `/github` will be the directory used and actions should not use hard coded `/github` but use the equivalent env var instead.

Using the project dir allow us to mimic this case and in the same way allow users to mount the project dir from inside the container without problem.

Solve #555 
Should works for #551 / #410  too

Also, running `go run main.go` run successfully now.