### PR TITLE
CI: Add snapshot artifacts to PR builds

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,15 +39,18 @@ jobs:
       with:
         version: latest
         args: release --snapshot --rm-dist
-    - uses: actions/upload-artifact@v2
+    - name: Capture Linux Binary
+      uses: actions/upload-artifact@v2
       with:
         name: act-linux
         path: dist/act_linux_amd64/act
-    - uses: actions/upload-artifact@v2
+    - name: Capture Windows Binary
+      uses: actions/upload-artifact@v2
       with:
         name: act-windows
         path: dist/act_windows_amd64/act.exe
-    - uses: actions/upload-artifact@v2
+    - name: Capture MacOS Binary
+      uses: actions/upload-artifact@v2
       with:
         name: act-macos
         path: dist/act_darwin_amd64/act

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,9 +41,16 @@ jobs:
         args: release --snapshot --rm-dist
     - uses: actions/upload-artifact@v2
       with:
-        name: act-snapshot-binaries
-        path: |
-          dist/act*
+        name: act-linux
+        path: dist/act_linux_amd64/act
+    - uses: actions/upload-artifact@v2
+      with:
+        name: act-windows
+        path: dist/act_windows_amd64/act.exe
+    - uses: actions/upload-artifact@v2
+      with:
+        name: act-macos
+        path: dist/act_darwin_amd64/act
 
   release:
     name: Release

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,8 +39,11 @@ jobs:
       with:
         version: latest
         args: release --snapshot --rm-dist
-      env:
-        SNAPSHOT_VERSION: "v0.0.0"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: act-snapshot-binaries
+        path: |
+          dist/act*
 
   release:
     name: Release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,8 +13,6 @@ builds:
   - 386
 checksum:
   name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ .Env.SNAPSHOT_VERSION }}"
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
     replacements:


### PR DESCRIPTION
This adds Github snapshot artifact binaries, so people can test PRs without needing to download and run the entire build environment locally allowing for wider testing of items such as the new Composite Actions PR.

Demo:
1. Go to the `Checks` tab on this PR or go to https://github.com/nektos/act/pull/574/checks
2. Click the Artifacts button in the upper right
![image](https://user-images.githubusercontent.com/15258962/112191705-83bcbc80-8bc3-11eb-8d4b-8c69be564ca1.png)

3. Download zip for the platform you want to test
4. Extract and test. Version will include the commit.
![image](https://user-images.githubusercontent.com/15258962/112191027-d053c800-8bc2-11eb-95c6-6ea5d6701f77.png)
