### PR TITLE
fix: pass `sc.Env` through `common.Logger` to hide secrets

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -129,7 +129,7 @@ func (sc *StepContext) setupEnv(ctx context.Context) (ExpressionEvaluator, error
 	evaluator := sc.NewExpressionEvaluator()
 	sc.interpolateEnv(evaluator)
 
-	log.Debugf("setupEnv: %v", sc.Env)
+	common.Logger(ctx).Debugf("setupEnv => %v", sc.Env)
 	return evaluator, nil
 }
 


### PR DESCRIPTION
Currently all secrets are exposed when running with `--verbose`/`-v` option