### PR TITLE
Remove HOME environment variable

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -580,7 +580,6 @@ func withDefaultBranch(b string, event map[string]interface{}) map[string]interf
 func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	github := rc.getGithubContext()
 	env["CI"] = "true"
-	env["HOME"] = fmt.Sprintf("%s/%s", filepath.Dir(rc.Config.Workdir), "home")
 	env["GITHUB_ENV"] = fmt.Sprintf("%s/%s", filepath.Dir(rc.Config.Workdir), "workflow/envs.txt")
 	env["GITHUB_WORKFLOW"] = github.Workflow
 	env["GITHUB_RUN_ID"] = github.RunID


### PR DESCRIPTION
Since #567 there is no reason to keep `HOME` variable, and it's probably causing more issues.
Default `HOME` from image should be equal to path specified in `/etc/passwd`
Fixes #554
Fixes #584