### PR TITLE
Add various GitHub environment variables

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -469,6 +469,7 @@ type githubContext struct {
 	Token      string                 `json:"token"`
 	Workspace  string                 `json:"workspace"`
 	Action     string                 `json:"action"`
+	ActionPath string                 `json:"action_path"`
 }
 
 func (rc *RunContext) getGithubContext() *githubContext {
@@ -487,17 +488,19 @@ func (rc *RunContext) getGithubContext() *githubContext {
 		runNumber = "1"
 	}
 
+	actionPath := rc.Config.Env["GITHUB_ACTION_PATH"]
 	ghc := &githubContext{
-		Event:     make(map[string]interface{}),
-		EventPath: "/tmp/workflow/event.json",
-		Workflow:  rc.Run.Workflow.Name,
-		RunID:     runID,
-		RunNumber: runNumber,
-		Actor:     rc.Config.Actor,
-		EventName: rc.Config.EventName,
-		Token:     token,
-		Workspace: rc.Config.ContainerWorkdir(),
-		Action:    rc.CurrentStep,
+		Event:      make(map[string]interface{}),
+		EventPath:  "/tmp/workflow/event.json",
+		Workflow:   rc.Run.Workflow.Name,
+		RunID:      runID,
+		RunNumber:  runNumber,
+		Actor:      rc.Config.Actor,
+		EventName:  rc.Config.EventName,
+		Token:      token,
+		Workspace:  rc.Config.ContainerWorkdir(),
+		Action:     rc.CurrentStep,
+		ActionPath: actionPath,
 	}
 
 	// Backwards compatibility for configs that require
@@ -637,6 +640,9 @@ func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	env["GITHUB_RUN_ID"] = github.RunID
 	env["GITHUB_RUN_NUMBER"] = github.RunNumber
 	env["GITHUB_ACTION"] = github.Action
+	if github.ActionPath != "" {
+		env["GITHUB_ACTION_PATH"] = github.ActionPath
+	}
 	env["GITHUB_ACTIONS"] = "true"
 	env["GITHUB_ACTOR"] = github.Actor
 	env["GITHUB_REPOSITORY"] = github.Repository

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -33,6 +33,7 @@ type RunContext struct {
 	ExprEval       ExpressionEvaluator
 	JobContainer   container.Container
 	OutputMappings map[MappableOutput]MappableOutput
+	JobName        string
 }
 
 type MappableOutput struct {
@@ -473,6 +474,7 @@ type githubContext struct {
 	ActionRef        string                 `json:"action_ref"`
 	ActionRepository string                 `json:"action_repository"`
 	Job              string                 `json:"job"`
+	JobName          string                 `json:"job_name"`
 	RepositoryOwner  string                 `json:"repository_owner"`
 	RetentionDays    string                 `json:"retention_days"`
 	RunnerPerflog    string                 `json:"runner_perflog"`
@@ -685,6 +687,7 @@ func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	env["GITHUB_ACTION_REPOSITORY"] = github.ActionRepository
 	env["GITHUB_BASE_REF"] = github.BaseRef
 	env["GITHUB_HEAD_REF"] = github.HeadRef
+	env["GITHUB_JOB"] = rc.JobName
 	env["GITHUB_REPOSITORY_OWNER"] = github.RepositoryOwner
 	env["GITHUB_RETENTION_DAYS"] = github.RetentionDays
 	env["RUNNER_PERFLOG"] = github.RunnerPerflog

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -482,53 +482,40 @@ type githubContext struct {
 }
 
 func (rc *RunContext) getGithubContext() *githubContext {
-	token, ok := rc.Config.Secrets["GITHUB_TOKEN"]
-	if !ok {
-		token = os.Getenv("GITHUB_TOKEN")
-	}
-
-	runID := rc.Config.Env["GITHUB_RUN_ID"]
-	if runID == "" {
-		runID = "1"
-	}
-
-	runNumber := rc.Config.Env["GITHUB_RUN_NUMBER"]
-	if runNumber == "" {
-		runNumber = "1"
-	}
-
-	actionPath := rc.Config.Env["GITHUB_ACTION_PATH"]
-	actionRef := rc.Config.Env["RUNNER_ACTION_REF"]
-	actionRepository := rc.Config.Env["RUNNER_ACTION_REPOSITORY"]
-	repositoryOwner := rc.Config.Env["GITHUB_REPOSITORY_OWNER"]
-	retentionDays := rc.Config.Env["GITHUB_RETENTION_DAYS"]
-	if retentionDays == "" {
-		retentionDays = "0"
-	}
-	runnerPerfLog := rc.Config.Env["RUNNER_PERFLOG"]
-	if runnerPerfLog == "" {
-		runnerPerfLog = "/dev/null"
-	}
-	runnerTrackingID := rc.Config.Env["RUNNER_TRACKING_ID"]
-
 	ghc := &githubContext{
 		Event:            make(map[string]interface{}),
 		EventPath:        "/tmp/workflow/event.json",
 		Workflow:         rc.Run.Workflow.Name,
-		RunID:            runID,
-		RunNumber:        runNumber,
+		RunID:            rc.Config.Env["GITHUB_RUN_ID"],
+		RunNumber:        rc.Config.Env["GITHUB_RUN_NUMBER"],
 		Actor:            rc.Config.Actor,
 		EventName:        rc.Config.EventName,
-		Token:            token,
 		Workspace:        rc.Config.ContainerWorkdir(),
 		Action:           rc.CurrentStep,
-		ActionPath:       actionPath,
-		ActionRef:        actionRef,
-		ActionRepository: actionRepository,
-		RepositoryOwner:  repositoryOwner,
-		RetentionDays:    retentionDays,
-		RunnerPerflog:    runnerPerfLog,
-		RunnerTrackingID: runnerTrackingID,
+		Token:            rc.Config.Secrets["GITHUB_TOKEN"],
+		ActionPath:       rc.Config.Env["GITHUB_ACTION_PATH"],
+		ActionRef:        rc.Config.Env["RUNNER_ACTION_REF"],
+		ActionRepository: rc.Config.Env["RUNNER_ACTION_REPOSITORY"],
+		RepositoryOwner:  rc.Config.Env["GITHUB_REPOSITORY_OWNER"],
+		RetentionDays:    rc.Config.Env["GITHUB_RETENTION_DAYS"],
+		RunnerPerflog:    rc.Config.Env["RUNNER_PERFLOG"],
+		RunnerTrackingID: rc.Config.Env["RUNNER_TRACKING_ID"],
+	}
+
+	if ghc.RunID == "" {
+		ghc.RunID = "1"
+	}
+
+	if ghc.RunNumber == "" {
+		ghc.RunNumber = "1"
+	}
+
+	if ghc.RetentionDays == "" {
+		ghc.RetentionDays = "0"
+	}
+
+	if ghc.RunnerPerflog == "" {
+		ghc.RunnerPerflog = "/dev/null"
 	}
 
 	// Backwards compatibility for configs that require

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -530,6 +530,9 @@ func (rc *RunContext) getGithubContext() *githubContext {
 		log.Warningf("unable to get git repo: %v", err)
 	} else {
 		ghc.Repository = repo
+		if ghc.RepositoryOwner == "" {
+			ghc.RepositoryOwner = strings.Split(repo, "/")[0]
+		}
 	}
 
 	_, sha, err := common.FindGitRevision(repoPath)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -116,6 +116,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 
 			for i, matrix := range matrixes {
 				rc := runner.newRunContext(run, matrix)
+				rc.JobName = rc.Name
 				if len(matrixes) > 1 {
 					rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
 				}

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -557,7 +557,12 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 			}
 		}
 
-		stepClone.Run = strings.ReplaceAll(stepClone.Run, "${{ github.action_path }}", filepath.Join(containerActionDir, actionName))
+		if stepClone.Env == nil {
+			stepClone.Env = make(map[string]string)
+		}
+		actionPath := filepath.Join(containerActionDir, actionName)
+		stepClone.Env["GITHUB_ACTION_PATH"] = actionPath
+		stepClone.Run = strings.ReplaceAll(stepClone.Run, "${{ github.action_path }}", actionPath)
 
 		stepContext := StepContext{
 			RunContext: rcClone,

--- a/pkg/runner/testdata/uses-composite/composite_action/action.yml
+++ b/pkg/runner/testdata/uses-composite/composite_action/action.yml
@@ -41,6 +41,15 @@ runs:
         fi
       shell: bash
 
+    - run: |
+        if [ -z "$GITHUB_ACTION_PATH" ]; then
+          exit 1
+        fi
+        if [ -z "${{ github.action_path }}" ]; then
+          exit 2
+        fi
+      shell: bash
+
     # Let's send up an output to test
     - run: echo "::set-output name=test_output::test_output_value"
       shell: bash


### PR DESCRIPTION
Using a tool I wrote for something else... https://github.com/jsoref/gha-debug/runs/2017914814?check_suite_focus=true

<details><summary>
GitHub
</summary>

```
AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
ANDROID_HOME=/usr/local/lib/android/sdk
ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk-bundle
ANDROID_NDK_ROOT=/usr/local/lib/android/sdk/ndk-bundle
ANDROID_SDK_ROOT=/usr/local/lib/android/sdk
ANT_HOME=/usr/share/ant
AZURE_EXTENSION_DIR=/opt/az/azcliextensions
BOOST_ROOT_1_72_0=/opt/hostedtoolcache/boost/1.72.0/x64
BOOTSTRAP_HASKELL_NONINTERACTIVE=1
CHROMEWEBDRIVER=/usr/local/share/chrome_driver
CHROME_BIN=/usr/bin/google-chrome
CI=true
CONDA=/usr/share/miniconda
DEBIAN_FRONTEND=noninteractive
DEPLOYMENT_BASEPATH=/opt/runner
DOTNET_MULTILEVEL_LOOKUP=0
DOTNET_NOLOGO=1
DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
GECKOWEBDRIVER=/usr/local/share/gecko_driver
GITHUB_ACTION=run2
GITHUB_ACTIONS=true
GITHUB_ACTION_REF=
GITHUB_ACTION_REPOSITORY=
GITHUB_ACTOR=jsoref
GITHUB_API_URL=https://api.github.com
GITHUB_BASE_REF=
GITHUB_ENV=/home/runner/work/_temp/_runner_file_commands/set_env_b9659a7c-aad0-4984-83d7-702fbfbb212b
GITHUB_EVENT_NAME=push
GITHUB_EVENT_PATH=/home/runner/work/_temp/_github_workflow/event.json
GITHUB_GRAPHQL_URL=https://api.github.com/graphql
GITHUB_HEAD_REF=
GITHUB_JOB=build
GITHUB_PATH=/home/runner/work/_temp/_runner_file_commands/add_path_b9659a7c-aad0-4984-83d7-702fbfbb212b
GITHUB_REF=refs/heads/main
GITHUB_REPOSITORY=jsoref/gha-debug
GITHUB_REPOSITORY_OWNER=jsoref
GITHUB_RETENTION_DAYS=90
GITHUB_RUN_ID=615846162
GITHUB_RUN_NUMBER=8
GITHUB_SERVER_URL=https://github.com
GITHUB_SHA=4982c105c248122f310cf05c11fd050b3293d229
GITHUB_WORKFLOW=Debug
GITHUB_WORKSPACE=/home/runner/work/gha-debug/gha-debug
GOROOT=/opt/hostedtoolcache/go/1.15.8/x64
GOROOT_1_13_X64=/opt/hostedtoolcache/go/1.13.15/x64
GOROOT_1_14_X64=/opt/hostedtoolcache/go/1.14.15/x64
GOROOT_1_15_X64=/opt/hostedtoolcache/go/1.15.8/x64
GRADLE_HOME=/usr/share/gradle
HOME=/home/runner
HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar"
HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS=3650
HOMEBREW_NO_AUTO_UPDATE=1
HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew"
INVOCATION_ID=cf44682287d6431da649601ec0fc1a87
ImageOS=ubuntu18
ImageVersion=20210219.1
JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
JAVA_HOME_11_X64=/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64
JAVA_HOME_12_X64=/usr/lib/jvm/adoptopenjdk-12-hotspot-amd64
JAVA_HOME_8_X64=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
JOURNAL_STREAM=9:20111
LANG=C.UTF-8
LEIN_HOME=/usr/local/lib/lein
LEIN_JAR=/usr/local/lib/lein/self-installs/leiningen-2.9.5-standalone.jar
PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/opt/pipx_bin:/usr/share/rust/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
PERFLOG_LOCATION_SETTING=RUNNER_PERFLOG
PIPX_BIN_DIR=/opt/pipx_bin
PIPX_HOME=/opt/pipx
POWERSHELL_DISTRIBUTION_CHANNEL=GitHub-Actions-ubuntu18
RUNNER_OS=Linux
RUNNER_PERFLOG=/home/runner/perflog
RUNNER_TEMP=/home/runner/work/_temp
RUNNER_TOOL_CACHE=/opt/hostedtoolcache
RUNNER_TRACKING_ID=github_c5f7f2be-3b74-4305-b493-08b9e3b4b8a9
RUNNER_USER=runner
RUNNER_WORKSPACE=/home/runner/work/gha-debug
SELENIUM_JAR_PATH=/usr/share/java/selenium-server-standalone.jar
SHLVL=1
SWIFT_PATH=/usr/share/swift/usr/bin
USER=runner
VCPKG_INSTALLATION_ROOT=/usr/local/share/vcpkg
_=/usr/bin/env
```
</details>

<details>
<summary>Act</summary>

```
ACT=true
CI=true
GITHUB_ACTION=1
GITHUB_ACTIONS=true
GITHUB_ACTOR=nektos/act
GITHUB_API_URL=https://api.github.com
GITHUB_ENV=/Users/jsoref/code/spelling-org/workflow/envs.txt
GITHUB_EVENT_NAME=push
GITHUB_EVENT_PATH=/Users/jsoref/code/spelling-org/workflow/event.json
GITHUB_GRAPHQL_URL=https://api.github.com/graphql
GITHUB_REF=refs/heads/main
GITHUB_REPOSITORY=jsoref/gha-debug
GITHUB_RUN_ID=1
GITHUB_RUN_NUMBER=1
GITHUB_SERVER_URL=https://github.com
GITHUB_SHA=4982c105c248122f310cf05c11fd050b3293d229
GITHUB_TOKEN=
GITHUB_WORKFLOW=Debug
GITHUB_WORKSPACE=/Users/jsoref/code/spelling-org/gha-debug
HOME=/root
HOSTNAME=docker-desktop
ImageOS=ubuntu18.04
NODE_VERSION=12.20.1
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/Users/jsoref/code/spelling-org/gha-debug
RUNNER_OS=Linux
RUNNER_TEMP=/tmp
RUNNER_TOOL_CACHE=/opt/hostedtoolcache
SHLVL=1
YARN_VERSION=1.22.5
_=/usr/bin/env
```
</details>

<details>
<summary>
GitHub additions
</summary>

```
AGENT_TOOLSDIRECTORY
ANDROID_HOME
ANDROID_NDK_HOME
ANDROID_NDK_ROOT
ANDROID_SDK_ROOT
ANT_HOME
AZURE_EXTENSION_DIR
BOOST_ROOT_1_72_0
BOOTSTRAP_HASKELL_NONINTERACTIVE
CHROMEWEBDRIVER
CHROME_BIN
CONDA
DEBIAN_FRONTEND
DEPLOYMENT_BASEPATH
DOTNET_MULTILEVEL_LOOKUP
DOTNET_NOLOGO
DOTNET_SKIP_FIRST_TIME_EXPERIENCE
GECKOWEBDRIVER
GITHUB_ACTION_REF
GITHUB_ACTION_REPOSITORY
GITHUB_BASE_REF
GITHUB_HEAD_REF
GITHUB_JOB
GITHUB_PATH
GITHUB_REPOSITORY_OWNER
GITHUB_RETENTION_DAYS
GOROOT
GOROOT_1_13_X64
GOROOT_1_14_X64
GOROOT_1_15_X64
GRADLE_HOME
HOMEBREW_CELLAR
HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS
HOMEBREW_NO_AUTO_UPDATE
HOMEBREW_PREFIX
HOMEBREW_REPOSITORY
INVOCATION_ID
ImageVersion
JAVA_HOME
JAVA_HOME_11_X64
JAVA_HOME_12_X64
JAVA_HOME_8_X64
JOURNAL_STREAM
LANG
LEIN_HOME
LEIN_JAR
PERFLOG_LOCATION_SETTING
PIPX_BIN_DIR
PIPX_HOME
POWERSHELL_DISTRIBUTION_CHANNEL
RUNNER_PERFLOG
RUNNER_TRACKING_ID
RUNNER_USER
RUNNER_WORKSPACE
SELENIUM_JAR_PATH
SWIFT_PATH
USER
VCPKG_INSTALLATION_ROOT
```
</details>

<details>
<summary>
Act additions
</summary>

```
ACT
GITHUB_TOKEN
HOSTNAME
NODE_VERSION
PWD
YARN_VERSION
```
</details>

Offhand, I think this is what I'd want:

Var | Value
-|-
GITHUB_ACTION_PATH | = set if there's an action running
GITHUB_ACTION_REF | `''`
GITHUB_ACTION_REPOSITORY | `''`
GITHUB_BASE_REF | `''`
GITHUB_HEAD_REF | `''`
GITHUB_JOB | = parse from workflow (it's the active child of the top level `jobs`)
GITHUB_REPOSITORY_OWNER | = guess from `origin`
GITHUB_RETENTION_DAYS | `0`
RUNNER_PERFLOG | `/dev/null`
RUNNER_TRACKING_ID
RUNNER_WORKSPACE | = GITHUB_WORKSPACE

fixes #603

Notes:
* `USER`/`RUNNER_USER` might be more a matter of the image -- @catthehacker is going to fix this in their images
  *  It's possible to write some hacky code to use `whoami` (or `echo $USER`) to calculate and fill in a `RUNNER_USER`, but it's unclear whether that's the right thing to do in general, and, again, it's hacky.
* `GITHUB_PATH` is #566