### PR TITLE
Handle tagless versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX ?= /usr/local
-VERSION ?= $(shell git describe --tags --dirty --always | cut -c 2-)
+VERSION ?= $(shell git describe --tags --dirty --always | sed -e 's/^v//')
 IS_SNAPSHOT = $(if $(findstring -, $(VERSION)),true,false)
 MAJOR_VERSION = $(word 1, $(subst ., ,$(VERSION)))
 MINOR_VERSION = $(word 2, $(subst ., ,$(VERSION)))


### PR DESCRIPTION
I'm a troublemaker. I don't generally fetch tags/branches (and I actively remove them from my forks before I start working).

Average case:
git describe --tags
v0.2.9-130-g47e1ba1
git describe --tags --dirty --always | cut -c 2-
0.2.9-130-g47e1ba1
git describe --tags --dirty --always | sed -e s/^v//
47e1ba1

Edge case (no tags):
git describe --tags --dirty --always
47e1ba1
git describe --tags --dirty --always | cut -c 2-
7e1ba1
-- this is undesirable