### PR TITLE
fix: rework container architecture flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ It will save that information to `~/.actrc`, please refer to [Configuration](#co
 ```none
   -a, --actor string                    user that triggered the event (default "nektos/act")
   -b, --bind                            bind working directory to container, rather than copy
-      --container-architecture string   Architecture which should be used to run containers, e.g.: linux/amd64. Defaults to linux/<your machine architecture> [linux/amd64]. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.
+      --container-architecture string   Architecture which should be used to run containers, e.g.: linux/amd64. If not specified, will use host default architecture. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.
       --defaultbranch string            the name of the main branch
       --detect-event                    Use first event type from workflow as event that triggered the workflow
   -C, --directory string                working directory (default ".")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/nektos/act/pkg/common"
@@ -59,7 +58,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().StringVarP(&input.secretfile, "secret-file", "", ".secrets", "file with list of secrets to read from (e.g. --secret-file .secrets)")
 	rootCmd.PersistentFlags().BoolVarP(&input.insecureSecrets, "insecure-secrets", "", false, "NOT RECOMMENDED! Doesn't hide secrets while printing logs.")
 	rootCmd.PersistentFlags().StringVarP(&input.envfile, "env-file", "", ".env", "environment file to read and use as env in the containers")
-	rootCmd.PersistentFlags().StringVarP(&input.containerArchitecture, "container-architecture", "", "", "Architecture which should be used to run containers, e.g.: linux/amd64. Defaults to linux/<your machine architecture> [linux/"+runtime.GOARCH+"]. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.")
+	rootCmd.PersistentFlags().StringVarP(&input.containerArchitecture, "container-architecture", "", "", "Architecture which should be used to run containers, e.g.: linux/amd64. If not specified, will use host default architecture. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.")
 	rootCmd.SetArgs(args())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/pkg/container/docker_images.go
+++ b/pkg/container/docker_images.go
@@ -29,7 +29,7 @@ func ImageExistsLocally(ctx context.Context, imageName string, platform string) 
 	}
 
 	if len(images) > 0 {
-		if platform == "any" {
+		if platform == "any" || platform == "" {
 			return true, nil
 		}
 		for _, v := range images {
@@ -48,9 +48,9 @@ func ImageExistsLocally(ctx context.Context, imageName string, platform string) 
 	return false, nil
 }
 
-// DeleteImage removes image from local store, the function is used to run different
+// RemoveImage removes image from local store, the function is used to run different
 // container image architectures
-func DeleteImage(ctx context.Context, imageName string) (bool, error) {
+func RemoveImage(ctx context.Context, imageName string, force bool, pruneChildren bool) (bool, error) {
 	if exists, err := ImageExistsLocally(ctx, imageName, "any"); !exists {
 		return false, err
 	}
@@ -75,8 +75,8 @@ func DeleteImage(ctx context.Context, imageName string) (bool, error) {
 	if len(images) > 0 {
 		for _, v := range images {
 			if _, err = cli.ImageRemove(ctx, v.ID, types.ImageRemoveOptions{
-				Force:         true,
-				PruneChildren: true,
+				Force:         force,
+				PruneChildren: pruneChildren,
 			}); err != nil {
 				return false, err
 			}

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -293,7 +293,7 @@ func (cr *containerReference) create() common.Executor {
 		}
 
 		var platSpecs *specs.Platform
-		if supportsContainerImagePlatform(cr.cli) {
+		if supportsContainerImagePlatform(cr.cli) && cr.input.Platform != "" {
 			desiredPlatform := strings.SplitN(cr.input.Platform, `/`, 2)
 
 			if len(desiredPlatform) != 2 {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -96,10 +96,6 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			binds = append(binds, fmt.Sprintf("%s:%s%s", rc.Config.Workdir, rc.Config.Workdir, bindModifiers))
 		}
 
-		if rc.Config.ContainerArchitecture == "" {
-			rc.Config.ContainerArchitecture = fmt.Sprintf("%s/%s", "linux", runtime.GOARCH)
-		}
-
 		rc.JobContainer = container.NewContainer(&container.NewContainerInput{
 			Cmd:        nil,
 			Entrypoint: []string{"/usr/bin/tail", "-f", "/dev/null"},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -79,45 +79,28 @@ func TestRunEvent(t *testing.T) {
 		"ubuntu-latest": "node:12.20.1-buster-slim",
 	}
 	tables := []TestJobFileInfo{
-		// {"testdata", "powershell", "push", "", platforms}, // Powershell is not available on default act test runner (yet) but preserving here for posterity
-		{"testdata", "basic", "push", "", platforms, "linux/amd64"},
-		{"testdata", "fail", "push", "exit with `FAILURE`: 1", platforms, "linux/amd64"},
-		{"testdata", "runs-on", "push", "", platforms, "linux/amd64"},
-		{"testdata", "job-container", "push", "", platforms, "linux/amd64"},
-		{"testdata", "job-container-non-root", "push", "", platforms, "linux/amd64"},
-		{"testdata", "uses-docker-url", "push", "", platforms, "linux/amd64"},
-		{"testdata", "remote-action-docker", "push", "", platforms, "linux/amd64"},
-		{"testdata", "remote-action-js", "push", "", platforms, "linux/amd64"},
-		{"testdata", "local-action-docker-url", "push", "", platforms, "linux/amd64"},
-		{"testdata", "local-action-dockerfile", "push", "", platforms, "linux/amd64"},
-		{"testdata", "local-action-js", "push", "", platforms, "linux/amd64"},
-		{"testdata", "matrix", "push", "", platforms, "linux/amd64"},
-		{"testdata", "matrix-include-exclude", "push", "", platforms, "linux/amd64"},
-		{"testdata", "commands", "push", "", platforms, "linux/amd64"},
-		{"testdata", "workdir", "push", "", platforms, "linux/amd64"},
-		// {"testdata", "issue-228", "push", "", platforms, "linux/amd64"}, // TODO [igni]: Remove this once everything passes
-		{"testdata", "defaults-run", "push", "", platforms, "linux/amd64"},
-		{"testdata", "uses-composite", "push", "", platforms, "linux/amd64"},
+		{"testdata", "basic", "push", "", platforms, ""},
+		{"testdata", "fail", "push", "exit with `FAILURE`: 1", platforms, ""},
+		{"testdata", "runs-on", "push", "", platforms, ""},
+		{"testdata", "job-container", "push", "", platforms, ""},
+		{"testdata", "job-container-non-root", "push", "", platforms, ""},
+		{"testdata", "uses-docker-url", "push", "", platforms, ""},
+		{"testdata", "remote-action-docker", "push", "", platforms, ""},
+		{"testdata", "remote-action-js", "push", "", platforms, ""},
+		{"testdata", "local-action-docker-url", "push", "", platforms, ""},
+		{"testdata", "local-action-dockerfile", "push", "", platforms, ""},
+		{"testdata", "local-action-js", "push", "", platforms, ""},
+		{"testdata", "matrix", "push", "", platforms, ""},
+		{"testdata", "matrix-include-exclude", "push", "", platforms, ""},
+		{"testdata", "commands", "push", "", platforms, ""},
+		{"testdata", "workdir", "push", "", platforms, ""},
+		{"testdata", "defaults-run", "push", "", platforms, ""},
+		{"testdata", "uses-composite", "push", "", platforms, ""},
+		// {"testdata", "powershell", "push", "", platforms, ""}, // Powershell is not available on default act test runner (yet) but preserving here for posterity
+		// {"testdata", "issue-228", "push", "", platforms, ""}, // TODO [igni]: Remove this once everything passes
 
-		// linux/arm64
+		// single test for different architecture: linux/arm64
 		{"testdata", "basic", "push", "", platforms, "linux/arm64"},
-		{"testdata", "fail", "push", "exit with `FAILURE`: 1", platforms, "linux/arm64"},
-		{"testdata", "runs-on", "push", "", platforms, "linux/arm64"},
-		{"testdata", "job-container", "push", "", platforms, "linux/arm64"},
-		{"testdata", "job-container-non-root", "push", "", platforms, "linux/arm64"},
-		{"testdata", "uses-docker-url", "push", "", platforms, "linux/arm64"},
-		{"testdata", "remote-action-docker", "push", "", platforms, "linux/arm64"},
-		{"testdata", "remote-action-js", "push", "", platforms, "linux/arm64"},
-		{"testdata", "local-action-docker-url", "push", "", platforms, "linux/arm64"},
-		{"testdata", "local-action-dockerfile", "push", "", platforms, "linux/arm64"},
-		{"testdata", "local-action-js", "push", "", platforms, "linux/arm64"},
-		{"testdata", "matrix", "push", "", platforms, "linux/arm64"},
-		{"testdata", "matrix-include-exclude", "push", "", platforms, "linux/arm64"},
-		{"testdata", "commands", "push", "", platforms, "linux/arm64"},
-		{"testdata", "workdir", "push", "", platforms, "linux/arm64"},
-		// {"testdata", "issue-228", "push", "", platforms, "linux/arm64"}, // TODO [igni]: Remove this once everything passes
-		{"testdata", "defaults-run", "push", "", platforms, "linux/arm64"},
-		{"testdata", "uses-composite", "push", "", platforms, "linux/arm64"},
 	}
 	log.SetLevel(log.DebugLevel)
 

--- a/pkg/runner/step_context_test.go
+++ b/pkg/runner/step_context_test.go
@@ -12,17 +12,11 @@ func TestStepContextExecutor(t *testing.T) {
 		"ubuntu-latest": "node:12.20.1-buster-slim",
 	}
 	tables := []TestJobFileInfo{
-		{"testdata", "uses-and-run-in-one-step", "push", "Invalid run/uses syntax for job:test step:Test", platforms, "linux/amd64"},
-		{"testdata", "uses-github-empty", "push", "Expected format {org}/{repo}[/path]@ref", platforms, "linux/amd64"},
-		{"testdata", "uses-github-noref", "push", "Expected format {org}/{repo}[/path]@ref", platforms, "linux/amd64"},
-		{"testdata", "uses-github-root", "push", "", platforms, "linux/amd64"},
-		{"testdata", "uses-github-path", "push", "", platforms, "linux/amd64"},
-
-		{"testdata", "uses-and-run-in-one-step", "push", "Invalid run/uses syntax for job:test step:Test", platforms, "linux/arm64"},
-		{"testdata", "uses-github-empty", "push", "Expected format {org}/{repo}[/path]@ref", platforms, "linux/arm64"},
-		{"testdata", "uses-github-noref", "push", "Expected format {org}/{repo}[/path]@ref", platforms, "linux/arm64"},
-		{"testdata", "uses-github-root", "push", "", platforms, "linux/arm64"},
-		{"testdata", "uses-github-path", "push", "", platforms, "linux/arm64"},
+		{"testdata", "uses-and-run-in-one-step", "push", "Invalid run/uses syntax for job:test step:Test", platforms, ""},
+		{"testdata", "uses-github-empty", "push", "Expected format {org}/{repo}[/path]@ref", platforms, ""},
+		{"testdata", "uses-github-noref", "push", "Expected format {org}/{repo}[/path]@ref", platforms, ""},
+		{"testdata", "uses-github-root", "push", "", platforms, ""},
+		{"testdata", "uses-github-path", "push", "", platforms, ""},
 	}
 	// These tests are sufficient to only check syntax.
 	ctx := common.WithDryrun(context.Background(), true)


### PR DESCRIPTION
fix: reworked container architecture

- Don't set architecture, let Docker host decide it's own platform,
  remove runtime dependency and don't show default in `--help`
- Remove most tests, we need to check only once if it works on
  different platform
- Rename `DeleteImage` to `RemoveImage` to conform to existing
  function in `docker` cli, added options to specify `force` and
  `pruneChildren`
fixes #621