### PR TITLE
feat: Don't push `pkg/runner/act/` where actions cache is stored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,7 @@
 .vscode/
 .idea/
 
+# Path for actions cache created when running tests
+pkg/runner/act/
+
 coverage.txt


### PR DESCRIPTION
This will prevent pushing `act` cache that happens occasionally for some people.