### PR TITLE
Separate Container Workdir from host Workdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ pkg/runner/act/
 dist/local/act
 
 coverage.txt
+
+.env
+#Store your GITHUB_TOKEN secret here for purposes of local testing of actions/checkout and others
+.secrets

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -552,7 +552,6 @@ func (rc *RunContext) getGithubContext() *githubContext {
 }
 
 func (ghc *githubContext) isLocalCheckout(step *model.Step) bool {
-
 	if step.Type() != model.StepTypeInvalid {
 		// This will be errored out by the executor later, we need this here to avoid a null panic though
 		return false

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -62,6 +62,32 @@ func (rc *RunContext) jobContainerName() string {
 	return createContainerName("act", rc.String())
 }
 
+// Returns the binds and mounts for the container, resolving paths as appopriate
+func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
+	name := rc.jobContainerName()
+
+	binds := []string{
+		fmt.Sprintf("%s:%s", "/var/run/docker.sock", "/var/run/docker.sock"),
+	}
+
+	mounts := map[string]string{
+		"act-toolcache": "/toolcache",
+		"act-actions":   "/actions",
+	}
+
+	if rc.Config.BindWorkdir {
+		bindModifiers := ""
+		if runtime.GOOS == "darwin" {
+			bindModifiers = ":delegated"
+		}
+		binds = append(binds, fmt.Sprintf("%s:%s%s", rc.Config.Workdir, rc.Config.ContainerWorkdir(), bindModifiers))
+	} else {
+		mounts[name] = rc.Config.ContainerWorkdir()
+	}
+
+	return binds, mounts
+}
+
 func (rc *RunContext) startJobContainer() common.Executor {
 	image := rc.platformImage()
 
@@ -80,34 +106,21 @@ func (rc *RunContext) startJobContainer() common.Executor {
 		name := rc.jobContainerName()
 
 		envList := make([]string, 0)
-		bindModifiers := ""
-		if runtime.GOOS == "darwin" {
-			bindModifiers = ":delegated"
-		}
 
 		envList = append(envList, fmt.Sprintf("%s=%s", "RUNNER_TOOL_CACHE", "/opt/hostedtoolcache"))
 		envList = append(envList, fmt.Sprintf("%s=%s", "RUNNER_OS", "Linux"))
 		envList = append(envList, fmt.Sprintf("%s=%s", "RUNNER_TEMP", "/tmp"))
 
-		binds := []string{
-			fmt.Sprintf("%s:%s", "/var/run/docker.sock", "/var/run/docker.sock"),
-		}
-		if rc.Config.BindWorkdir {
-			binds = append(binds, fmt.Sprintf("%s:%s%s", rc.Config.Workdir, rc.Config.Workdir, bindModifiers))
-		}
+		binds, mounts := rc.GetBindsAndMounts()
 
 		rc.JobContainer = container.NewContainer(&container.NewContainerInput{
-			Cmd:        nil,
-			Entrypoint: []string{"/usr/bin/tail", "-f", "/dev/null"},
-			WorkingDir: rc.Config.Workdir,
-			Image:      image,
-			Name:       name,
-			Env:        envList,
-			Mounts: map[string]string{
-				name:            filepath.Dir(rc.Config.Workdir),
-				"act-toolcache": "/toolcache",
-				"act-actions":   "/actions",
-			},
+			Cmd:         nil,
+			Entrypoint:  []string{"/usr/bin/tail", "-f", "/dev/null"},
+			WorkingDir:  rc.Config.ContainerWorkdir(),
+			Image:       image,
+			Name:        name,
+			Env:         envList,
+			Mounts:      mounts,
 			NetworkMode: "host",
 			Binds:       binds,
 			Stdout:      logWriter,
@@ -121,7 +134,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 		var copyToPath string
 		if !rc.Config.BindWorkdir {
 			copyToPath, copyWorkspace = rc.localCheckoutPath()
-			copyToPath = filepath.Join(rc.Config.Workdir, copyToPath)
+			copyToPath = filepath.Join(rc.Config.ContainerWorkdir(), copyToPath)
 		}
 
 		return common.NewPipelineExecutor(
@@ -130,7 +143,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.Create(),
 			rc.JobContainer.Start(false),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".", rc.Config.UseGitIgnore).IfBool(copyWorkspace),
-			rc.JobContainer.Copy(filepath.Dir(rc.Config.Workdir), &container.FileEntry{
+			rc.JobContainer.Copy(rc.Config.ContainerWorkdir(), &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0644,
 				Body: rc.EventJSON,
@@ -162,6 +175,8 @@ func (rc *RunContext) stopJobContainer() common.Executor {
 		return nil
 	}
 }
+
+// Prepare the mounts and binds for the worker
 
 // ActionCacheDir is for rc
 func (rc *RunContext) ActionCacheDir() string {
@@ -468,14 +483,14 @@ func (rc *RunContext) getGithubContext() *githubContext {
 	}
 	ghc := &githubContext{
 		Event:     make(map[string]interface{}),
-		EventPath: fmt.Sprintf("%s/%s", filepath.Dir(rc.Config.Workdir), "workflow/event.json"),
+		EventPath: fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), "workflow/event.json"),
 		Workflow:  rc.Run.Workflow.Name,
 		RunID:     runID,
 		RunNumber: runNumber,
 		Actor:     rc.Config.Actor,
 		EventName: rc.Config.EventName,
 		Token:     token,
-		Workspace: rc.Config.Workdir,
+		Workspace: rc.Config.ContainerWorkdir(),
 		Action:    rc.CurrentStep,
 	}
 
@@ -537,6 +552,11 @@ func (rc *RunContext) getGithubContext() *githubContext {
 }
 
 func (ghc *githubContext) isLocalCheckout(step *model.Step) bool {
+
+	if step.Type() != model.StepTypeInvalid {
+		// This will be errored out by the executor later, we need this here to avoid a null panic though
+		return false
+	}
 	if step.Type() != model.StepTypeUsesActionRemote {
 		return false
 	}
@@ -606,7 +626,7 @@ func withDefaultBranch(b string, event map[string]interface{}) map[string]interf
 func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	github := rc.getGithubContext()
 	env["CI"] = "true"
-	env["GITHUB_ENV"] = fmt.Sprintf("%s/%s", filepath.Dir(rc.Config.Workdir), "workflow/envs.txt")
+	env["GITHUB_ENV"] = fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), "workflow/envs.txt")
 	env["GITHUB_WORKFLOW"] = github.Workflow
 	env["GITHUB_RUN_ID"] = github.RunID
 	env["GITHUB_RUN_NUMBER"] = github.RunNumber

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -209,5 +210,67 @@ jobs:
 	_, err = file.WriteString(workflow)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRunContext_GetBindsAndMounts(t *testing.T) {
+	rctemplate := &RunContext{
+		Name: "TestRCName",
+		Run: &model.Run{
+			Workflow: &model.Workflow{
+				Name: "TestWorkflowName",
+			},
+		},
+		Config: &Config{
+			BindWorkdir: false,
+		},
+	}
+
+	tests := []struct {
+		windowsPath bool
+		name        string
+		rc          *RunContext
+		wantbind    string
+		wantmount   string
+	}{
+		{false, "/mnt/linux", rctemplate, "/mnt/linux", "/mnt/linux"},
+		{false, "/mnt/path with spaces/linux", rctemplate, "/mnt/path with spaces/linux", "/mnt/path with spaces/linux"},
+		{true, "C:\\Users\\TestPath\\MyTestPath", rctemplate, "/mnt/c/Users/TestPath/MyTestPath", "/mnt/c/Users/TestPath/MyTestPath"},
+		{true, "C:\\Users\\Test Path with Spaces\\MyTestPath", rctemplate, "/mnt/c/Users/Test Path with Spaces/MyTestPath", "/mnt/c/Users/Test Path with Spaces/MyTestPath"},
+		{true, "/LinuxPathOnWindowsShouldFail", rctemplate, "", ""},
+	}
+
+	isWindows := runtime.GOOS == "windows"
+
+	for _, testcase := range tests {
+		// pin for scopelint
+		testcase := testcase
+		for _, bindWorkDir := range []bool{true, false} {
+			// pin for scopelint
+			bindWorkDir := bindWorkDir
+			testBindSuffix := ""
+			if bindWorkDir {
+				testBindSuffix = "Bind"
+			}
+
+			// Only run windows path tests on windows and non-windows on non-windows
+			if (isWindows && testcase.windowsPath) || (!isWindows && !testcase.windowsPath) {
+				t.Run((testcase.name + testBindSuffix), func(t *testing.T) {
+					config := testcase.rc.Config
+					config.Workdir = testcase.name
+					config.BindWorkdir = bindWorkDir
+					gotbind, gotmount := rctemplate.GetBindsAndMounts()
+
+					// Name binds/mounts are either/or
+					if config.BindWorkdir {
+						fullBind := testcase.name + ":" + testcase.wantbind
+						a.Contains(t, gotbind, fullBind)
+					} else {
+						mountkey := testcase.rc.jobContainerName()
+						a.EqualValues(t, testcase.wantmount, gotmount[mountkey])
+					}
+				})
+			}
+		}
 	}
 }

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -264,6 +264,9 @@ func TestRunContext_GetBindsAndMounts(t *testing.T) {
 					// Name binds/mounts are either/or
 					if config.BindWorkdir {
 						fullBind := testcase.name + ":" + testcase.wantbind
+						if runtime.GOOS == "darwin" {
+							fullBind += ":delegated"
+						}
 						a.Contains(t, gotbind, fullBind)
 					} else {
 						mountkey := testcase.rc.jobContainerName()

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -406,13 +406,16 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 
 		maybeCopyToActionDir := func() error {
 			if step.Type() != model.StepTypeUsesActionRemote {
-				return nil
+				// If the workdir is bound to our repository then we don't need to copy the file
+				if rc.Config.BindWorkdir {
+					return nil
+				}
 			}
 			err := removeGitIgnore(actionDir)
 			if err != nil {
 				return err
 			}
-			return rc.JobContainer.CopyDir(containerActionDir+"/", actionLocation, rc.Config.UseGitIgnore)(ctx)
+			return rc.JobContainer.CopyDir(containerActionDir+"/", actionLocation+"/", rc.Config.UseGitIgnore)(ctx)
 		}
 
 		switch action.Runs.Using {

--- a/pkg/runner/step_context_test.go
+++ b/pkg/runner/step_context_test.go
@@ -2,8 +2,10 @@ package runner
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
+	"github.com/joho/godotenv"
 	"github.com/nektos/act/pkg/common"
 )
 
@@ -20,7 +22,8 @@ func TestStepContextExecutor(t *testing.T) {
 	}
 	// These tests are sufficient to only check syntax.
 	ctx := common.WithDryrun(context.Background(), true)
+	secrets, _ := godotenv.Read(filepath.Join("..", ".secrets"))
 	for _, table := range tables {
-		runTestJobFile(ctx, t, table)
+		runTestJobFile(ctx, t, table, secrets)
 	}
 }

--- a/pkg/runner/testdata/workdir/push.yml
+++ b/pkg/runner/testdata/workdir/push.yml
@@ -5,13 +5,11 @@ jobs:
   workdir:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: ls -alFt "${GITHUB_WORKSPACE}/workdir"
+    - run: mkdir -p "${GITHUB_WORKSPACE}/workdir"
     - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}/workdir" ]]'
       working-directory: workdir
 
   noworkdir:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}" ]]'


### PR DESCRIPTION
This PR started as a WSL2 fix but the pathing issue was so pervasive it expanded in scope a bit to meet the requirement.

A summary of changes:
* Adds path translation for WSL2 paths in order to enable act to function on Windows again.
* Refactor Binds and Mounts to a new function to coordinate either/or based on the BindWorkDir setting
* Add ContainerWorkDir() function to fetch the relative container function. This currently has the same behavior as before on Linux but translates to the WSL2 path on windows. In a future PR I will expand this to allow a command switch so that the container can as closely mimic the Github Actions runner paths as possible.

Tests:
* Changed Integration tests to use BindWorkDir: false instead of true to more closely match the most common act behavior (since bindworkdir is false by default). Tested to work both ways, should probably expand them as such
* Removed duplicate integration tests, not sure if this was done on purpose to make sure they are idempotent, this should be more clearly done with a loop instead
* Added the ability for tests to read from the .secrets file so that GITHUB_TOKEN can be specified for actions like action/checkout and be tested locally and not just inside github actions
* Removed checkout from workdir test, it's not necessary for the purpose of the test

Resolves #587