### PR TITLE
Recursively scan for workflows

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -27,6 +27,7 @@ type Input struct {
 	privileged            bool
 	usernsMode            string
 	containerArchitecture string
+	noWorkflowRecurse     bool
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().StringVar(&input.usernsMode, "userns", "", "user namespace to use")
 	rootCmd.PersistentFlags().StringVarP(&input.actor, "actor", "a", "nektos/act", "user that triggered the event")
 	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow file(s)")
+	rootCmd.PersistentFlags().BoolVarP(&input.noWorkflowRecurse, "no-recurse", "", false, "Flag to disable running workflows from subdirectories of specified path in '--workflows'/'-W' flag")
 	rootCmd.PersistentFlags().StringVarP(&input.workdir, "directory", "C", ".", "working directory")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&input.noOutput, "quiet", "q", false, "disable logging of output from steps")
@@ -65,7 +66,6 @@ func Execute(ctx context.Context, version string) {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-
 }
 
 func configLocations() []string {
@@ -164,7 +164,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		secrets := newSecrets(input.secrets)
 		_ = readEnvs(input.Secretfile(), secrets)
 
-		planner, err := model.NewWorkflowPlanner(input.WorkflowsPath())
+		planner, err := model.NewWorkflowPlanner(input.WorkflowsPath(), input.noWorkflowRecurse)
 		if err != nil {
 			return err
 		}

--- a/pkg/model/planner_test.go
+++ b/pkg/model/planner_test.go
@@ -8,25 +8,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type TestJobFileInfo struct {
-	workflowPath string
-	errorMessage string
+type WorkflowPlanTest struct {
+	workflowPath      string
+	errorMessage      string
+	noWorkflowRecurse bool
 }
 
 func TestPlanner(t *testing.T) {
-	tables := []TestJobFileInfo{
-		{"invalid-job-name", "The workflow is not valid. invalid-job-name: Job name invalid-JOB-Name-v1.2.3-docker_hub is invalid. Names must start with a letter or '_' and contain only alphanumeric characters, '-', or '_'"},
-		{"empty-workflow", "unable to read workflow, push.yml file is empty: EOF"},
-
-		{"", ""}, // match whole directory
-	}
 	log.SetLevel(log.DebugLevel)
+
+	tables := []WorkflowPlanTest{
+		{"invalid-job-name/invalid-1.yml", "workflow is not valid. 'invalid-job-name-1': Job name 'invalid-JOB-Name-v1.2.3-docker_hub' is invalid. Names must start with a letter or '_' and contain only alphanumeric characters, '-', or '_'", false},
+		{"invalid-job-name/invalid-2.yml", "workflow is not valid. 'invalid-job-name-2': Job name '1234invalid-JOB-Name-v123-docker_hub' is invalid. Names must start with a letter or '_' and contain only alphanumeric characters, '-', or '_'", false},
+		{"invalid-job-name/valid-1.yml", "", false},
+		{"invalid-job-name/valid-2.yml", "", false},
+		{"empty-workflow", "unable to read workflow, push.yml file is empty: EOF", false},
+		{"nested", "unable to read workflow, fail.yml file is empty: EOF", false},
+		{"nested", "", true},
+	}
 
 	workdir, err := filepath.Abs("testdata")
 	assert.NoError(t, err, workdir)
 	for _, table := range tables {
 		fullWorkflowPath := filepath.Join(workdir, table.workflowPath)
-		_, err = NewWorkflowPlanner(fullWorkflowPath)
+		_, err = NewWorkflowPlanner(fullWorkflowPath, table.noWorkflowRecurse)
 		if table.errorMessage == "" {
 			assert.NoError(t, err, "WorkflowPlanner should exit without any error")
 		} else {

--- a/pkg/model/testdata/invalid-job-name/invalid-1.yml
+++ b/pkg/model/testdata/invalid-job-name/invalid-1.yml
@@ -1,4 +1,4 @@
-name: invalid-job-name
+name: invalid-job-name-1
 on: push
 
 jobs:

--- a/pkg/model/testdata/invalid-job-name/invalid-2.yml
+++ b/pkg/model/testdata/invalid-job-name/invalid-2.yml
@@ -1,0 +1,8 @@
+name: invalid-job-name-2
+on: push
+
+jobs:
+  1234invalid-JOB-Name-v123-docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi

--- a/pkg/model/testdata/invalid-job-name/valid-1.yml
+++ b/pkg/model/testdata/invalid-job-name/valid-1.yml
@@ -1,0 +1,8 @@
+name: valid-job-name-1
+on: push
+
+jobs:
+  valid-JOB-Name-v123-docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi

--- a/pkg/model/testdata/invalid-job-name/valid-2.yml
+++ b/pkg/model/testdata/invalid-job-name/valid-2.yml
@@ -1,0 +1,8 @@
+name: valid-job-name-2
+on: push
+
+jobs:
+  ___valid-JOB-Name-v123-docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi

--- a/pkg/model/testdata/nested/success.yml
+++ b/pkg/model/testdata/nested/success.yml
@@ -1,0 +1,9 @@
+name: Hello World Workflow
+on: push
+
+jobs:
+  hello-world:
+    name: Hello World Job
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Hello World!"

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGraphEvent(t *testing.T) {
-	planner, err := model.NewWorkflowPlanner("testdata/basic")
+	planner, err := model.NewWorkflowPlanner("testdata/basic", true)
 	assert.NilError(t, err)
 
 	plan := planner.PlanEvent("push")
@@ -56,7 +56,7 @@ func runTestJobFile(ctx context.Context, t *testing.T, tjfi TestJobFileInfo) {
 		runner, err := New(runnerConfig)
 		assert.NilError(t, err, tjfi.workflowPath)
 
-		planner, err := model.NewWorkflowPlanner(fullWorkflowPath)
+		planner, err := model.NewWorkflowPlanner(fullWorkflowPath, true)
 		assert.NilError(t, err, fullWorkflowPath)
 
 		plan := planner.PlanEvent(tjfi.eventName)
@@ -160,7 +160,7 @@ func TestRunEventSecrets(t *testing.T) {
 	runner, err := New(runnerConfig)
 	assert.NilError(t, err, workflowPath)
 
-	planner, err := model.NewWorkflowPlanner(fmt.Sprintf("testdata/%s", workflowPath))
+	planner, err := model.NewWorkflowPlanner(fmt.Sprintf("testdata/%s", workflowPath), true)
 	assert.NilError(t, err, workflowPath)
 
 	plan := planner.PlanEvent(eventName)
@@ -197,7 +197,7 @@ func TestRunEventPullRequest(t *testing.T) {
 	runner, err := New(runnerConfig)
 	assert.NilError(t, err, workflowPath)
 
-	planner, err := model.NewWorkflowPlanner(fmt.Sprintf("testdata/%s", workflowPath))
+	planner, err := model.NewWorkflowPlanner(fmt.Sprintf("testdata/%s", workflowPath), true)
 	assert.NilError(t, err, workflowPath)
 
 	plan := planner.PlanEvent(eventName)


### PR DESCRIPTION
fixes #646 

refactor: `NewWorkflowPlanner`
feat: add flag `--no-recurse` to disable recursion when reading workflows from directories
feat: added more tests to `TestPlanner`, renamed `TestJobFileInfo` to more appropriate name `WorkflowPlanTest`
style: changed error message to lowercase, added single quotes for better visibility