### PR TITLE
Fix: pwsh errors with "command not found"

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -198,7 +198,11 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		}
 		scCmd := step.ShellCommand()
 		scResolvedCmd := strings.Replace(scCmd, "{0}", containerPath, 1)
-		if step.Shell == "pwsh" || step.Shell == "powershell" {
+		// Powershell has spaces in its final argument, so just splitting using Fields is insufficient
+		if step.Shell == "pwsh" {
+			// pwsh includes an additional argument, -login
+			sc.Cmd = strings.SplitN(scResolvedCmd, " ", 4)
+		} else if step.Shell == "powershell" {
 			sc.Cmd = strings.SplitN(scResolvedCmd, " ", 3)
 		} else {
 			sc.Cmd = strings.Fields(scResolvedCmd)


### PR DESCRIPTION
pwsh includes the -login switch which causes the split to not work correctly. This fixes that issue.