### PR TITLE
Add `super-linter` + fix lint issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,20 +1,23 @@
 ---
 name: Issue
 about: Use this template for reporting a bug/issue.
-title: "Issue: "
+title: "Issue: <shortly describe issue>"
 labels: kind/bug
 assignees: ''
 ---
 
 <!--
-- Make sure you are able to reproduce it on the [latest version](https://github.com/nektos/act/releases)
-- Search the existing issues.
-- Refer to [README](https://github.com/nektos/act/blob/master/README.md).
+    - Make sure you are able to reproduce it on the [latest version](https://github.com/nektos/act/releases)
+    - Search the existing issues.
+    - Refer to [README](https://github.com/nektos/act/blob/master/README.md).
 -->
 
 ## Act version
 
-<!-- Paste output of `act --version` -->
+<!--
+    - Paste output of `act --version` inside the code block below
+    - If you've built `act` yourself, please provide commit hash
+-->
 
 ```none
 
@@ -22,13 +25,22 @@ assignees: ''
 
 ## Expected behaviour
 
-<!-- Describe how whole process should go and finish -->
+<!--
+    - Describe how whole process should go and finish
+-->
 
 ## Actual behaviour
 
-<!-- Describe what happened -->
+<!--
+    - Describe the issue
+-->
 
 ## Workflow and/or repository
+
+<!--
+    - Provide workflow with which we can reproduce the issue
+      OR
+    - Provide link to your GitHub repository that contains the workflow
 
 <details>
   <summary>workflow</summary>
@@ -47,23 +59,23 @@ jobs:
 ## Steps to reproduce
 
 <!--
-Make sure to include command you used to run `act`
-e.g.:
-1. Clone example repo (https://github.com/cplee/github-actions-demo)
-2. Enter cloned repo directory
-3. Run `act -s SUPER_SECRET=im-a-value`
+    - Make sure to include full command with parameters you used to run `act`, example:
+      1. Clone example repo (https://github.com/cplee/github-actions-demo)
+      2. Enter cloned repo directory
+      3. Run `act -s SUPER_SECRET=im-a-value`
 -->
-
 
 ## `act` output
 
-<!-- Paste output from your terminal, use `-v` or `--verbose` for richer output -->
+<!--
+    - Use `act` with `-v`/`--verbose` and paste output from your terminal in code block below
+-->
 
 <details>
   <summary>Log</summary>
 
 ```none
-
+PASTE YOUR LOG HERE
 ```
 
 </details>

--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,0 +1,1 @@
+../../.golangci.yml

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,11 @@
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013: false
+
+# MD033/no-inline-html - Inline HTML
+MD033: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v1
         with:
           go-version: 1.16
@@ -14,7 +16,19 @@ jobs:
         env:
           CGO_ENABLED: 0
         with:
-          version: v1.32.2
+          version: v1.39.0
+      - uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILTER_REGEX_EXCLUDE: .*testdata/*
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }} # lint only new changes when pull_request
+          VALIDATE_BASH: false
+          VALIDATE_DOCKERFILE: false
+          VALIDATE_DOCKERFILE_HADOLINT: false
+          VALIDATE_GO: false # it's broken, see commit message
+          VALIDATE_JSCPD: false
+          VALIDATE_SHELL_SHFMT: false
 
   test:
     name: Test on Linux

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,19 +6,22 @@ linters-settings:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     mi-complexity: 15
   gocritic:
-     disabled-checks:
+    disabled-checks:
       - ifElseChain
 
 linters:
   enable:
-  - megacheck
-  - govet
-  - golint
-  - gocyclo
-  - gosec
-  - unconvert
-  - dupl
-  - nakedret
-  - prealloc
-  - scopelint
-  - gocritic
+    - megacheck
+    - govet
+    - golint
+    - gocyclo
+    - gosec
+    - unconvert
+    - dupl
+    - nakedret
+    - prealloc
+    - exportloopref
+    - gocritic
+    - goimports
+    - whitespace
+    - misspell

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--fix"
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you've identified a bug in `act`, please [submit an issue](#issue) to our Git
 
 All feature requests should start with [submitting an issue](#issue) documenting the user story and acceptance criteria.  Again, feel free to submit a [Pull Request](#pr) with a proposed implementation of the feature.
 
-## <a name="process"></a> Ready to Contribute!
+## <a name="process"></a> Ready to Contribute
 
 ### <a name="issue"></a> Create an issue
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-![](https://github.com/nektos/act/wiki/img/logo-150.png)
+![act-logo](https://github.com/nektos/act/wiki/img/logo-150.png)
 
 # Overview [![push](https://github.com/nektos/act/workflows/push/badge.svg?branch=master&event=push)](https://github.com/nektos/act/actions) [![Join the chat at https://gitter.im/nektos/act](https://badges.gitter.im/nektos/act.svg)](https://gitter.im/nektos/act?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Go Report Card](https://goreportcard.com/badge/github.com/nektos/act)](https://goreportcard.com/report/github.com/nektos/act)[![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
-
 
 > "Think globally, `act` locally"
 
@@ -269,7 +268,7 @@ Want to contribute to act? Awesome! Check out the [contributing guidelines](CONT
 
 ## Building from source
 
-- Install Go tools 1.16+ - (https://golang.org/doc/install)
+- Install Go tools 1.16+ - (<https://golang.org/doc/install>)
 - Clone this repo `git clone git@github.com:nektos/act.git`
 - Pull the default docker image `docker pull nektos/act-environments-ubuntu:18.04`
 - Run unit tests with `make test`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Let's see it in action with a [sample repo](https://github.com/cplee/github-acti
 # Installation
 
 ## Necessary prerequisites for running `act`
+
 `act` depends on `docker` to run workflows.
 
 If you are using macOS, please be sure to follow the steps outlined in [Docker Docs for how to install Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/).
@@ -47,14 +48,15 @@ curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
 If you are running Windows, download the [latest release](https://github.com/nektos/act/releases/latest) and add the binary into your PATH.
 If you are using [Chocolatey](https://chocolatey.org/) then run:
 
-[![](https://img.shields.io/chocolatey/v/act-cli)](https://community.chocolatey.org/packages/act-cli)
+[![choco-shield](https://img.shields.io/chocolatey/v/act-cli)](https://community.chocolatey.org/packages/act-cli)
+
 ```shell
 choco install act-cli
 ```
 
 If you are using [Scoop](https://scoop.sh/) then run:
 
-[![](https://img.shields.io/scoop/v/act)](https://github.com/ScoopInstaller/Main/blob/master/bucket/act.json)
+[![scoop-shield](https://img.shields.io/scoop/v/act)](https://github.com/ScoopInstaller/Main/blob/master/bucket/act.json)
 
 ```shell
 scoop install act
@@ -62,7 +64,7 @@ scoop install act
 
 If you are running Arch Linux, you can install the [act](https://aur.archlinux.org/packages/act/) package with your favorite package manager:
 
-[![](https://img.shields.io/aur/version/act)](https://aur.archlinux.org/packages/act/)
+[![aur-shield](https://img.shields.io/aur/version/act)](https://aur.archlinux.org/packages/act/)
 
 ```shell
 yay -S act

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -8,7 +8,6 @@ import (
 )
 
 func drawGraph(plan *model.Plan) error {
-
 	drawings := make([]*common.Drawing, 0)
 
 	jobPen := common.NewPen(common.StyleSingleLine, 96)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,6 @@ func Execute(ctx context.Context, version string) {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-
 }
 
 func configLocations() []string {

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -28,7 +28,6 @@ func CopyFile(source string, dest string) (err error) {
 		if err != nil {
 			_ = os.Chmod(dest, sourceinfo.Mode())
 		}
-
 	}
 
 	return
@@ -36,7 +35,6 @@ func CopyFile(source string, dest string) (err error) {
 
 // CopyDir recursive copy of directory
 func CopyDir(source string, dest string) (err error) {
-
 	// get properties of source dir
 	sourceinfo, err := os.Stat(source)
 	if err != nil {
@@ -55,7 +53,6 @@ func CopyDir(source string, dest string) (err error) {
 	objects, err := directory.Readdir(-1)
 
 	for _, obj := range objects {
-
 		sourcefilepointer := source + "/" + obj.Name()
 
 		destinationfilepointer := dest + "/" + obj.Name()
@@ -73,7 +70,6 @@ func CopyDir(source string, dest string) (err error) {
 				fmt.Println(err)
 			}
 		}
-
 	}
 	return err
 }

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -267,7 +267,6 @@ func NewGitCloneExecutor(input NewGitCloneExecutorInput) Executor {
 		// Repos on disk point to commit hashes, and need to checkout input.Ref before
 		// we try and pull down any changes
 		if hash.String() != input.Ref {
-
 			// Run git fetch to make sure we have the latest sha
 			err := r.Fetch(&git.FetchOptions{})
 			if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {

--- a/pkg/common/git_test.go
+++ b/pkg/common/git_test.go
@@ -40,7 +40,6 @@ func TestFindGitSlug(t *testing.T) {
 		assert.Equal(tt.provider, provider)
 		assert.Equal(tt.slug, slug)
 	}
-
 }
 
 func testDir(t *testing.T) string {

--- a/pkg/container/docker_build.go
+++ b/pkg/container/docker_build.go
@@ -63,7 +63,6 @@ func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 		}
 		return nil
 	}
-
 }
 func createBuildContext(contextDir string, relDockerfile string) (io.ReadCloser, error) {
 	log.Debugf("Creating archive for build context dir '%s' with relative dockerfile '%s'", contextDir, relDockerfile)

--- a/pkg/container/docker_pull.go
+++ b/pkg/container/docker_pull.go
@@ -62,9 +62,7 @@ func NewDockerPullExecutor(input NewDockerPullExecutorInput) common.Executor {
 			return err
 		}
 		return nil
-
 	}
-
 }
 
 func cleanImage(image string) string {

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -151,7 +151,6 @@ func (cr *containerReference) UpdateFromGithubEnv(env *map[string]string) common
 }
 
 func (cr *containerReference) Exec(command []string, env map[string]string) common.Executor {
-
 	return common.NewPipelineExecutor(
 		cr.connect(),
 		cr.find(),

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -23,7 +23,6 @@ type Workflow struct {
 
 // On events for the workflow
 func (w *Workflow) On() []string {
-
 	switch w.RawOn.Kind {
 	case yaml.ScalarNode:
 		var val string
@@ -109,7 +108,6 @@ func (j *Job) Container() *ContainerSpec {
 
 // Needs list for Job
 func (j *Job) Needs() []string {
-
 	switch j.RawNeeds.Kind {
 	case yaml.ScalarNode:
 		var val string
@@ -131,7 +129,6 @@ func (j *Job) Needs() []string {
 
 // RunsOn list for Job
 func (j *Job) RunsOn() []string {
-
 	switch j.RawRunsOn.Kind {
 	case yaml.ScalarNode:
 		var val string
@@ -183,7 +180,6 @@ func (j *Job) GetMatrixes() []map[string]interface{} {
 			log.Debugf("Adding include '%v'", include)
 			matrixes = append(matrixes, include)
 		}
-
 	} else {
 		matrixes = append(matrixes, make(map[string]interface{}))
 	}
@@ -313,12 +309,12 @@ func (s *Step) Type() StepType {
 }
 
 func (s *Step) Validate() error {
-    if s.Type() != StepTypeRun {
-        return fmt.Errorf("(StepID: %s): Unexpected value 'uses'", s.String())
-    } else if s.Shell == "" {
-        return fmt.Errorf("(StepID: %s): Required property is missing: 'shell'", s.String())
-    }
-    return nil
+	if s.Type() != StepTypeRun {
+		return fmt.Errorf("(StepID: %s): Unexpected value 'uses'", s.String())
+	} else if s.Shell == "" {
+		return fmt.Errorf("(StepID: %s): Required property is missing: 'shell'", s.String())
+	}
+	return nil
 }
 
 // ReadWorkflow returns a list of jobs for a given workflow file reader

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -199,7 +199,6 @@ func updateTestExpressionWorkflow(t *testing.T, tables []struct {
 	in  string
 	out string
 }, rc *RunContext) {
-
 	var envs string
 	keys := make([]string, 0, len(rc.Env))
 	for k := range rc.Env {
@@ -242,7 +241,6 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func TestRewrite(t *testing.T) {

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -109,7 +109,6 @@ func (f *stepLogFormatter) print(b *bytes.Buffer, entry *logrus.Entry) {
 }
 
 func (f *stepLogFormatter) isColored(entry *logrus.Entry) bool {
-
 	isColored := checkIfTerminal(entry.Logger.Out)
 
 	if force, ok := os.LookupEnv("CLICOLOR_FORCE"); ok && force != "0" {

--- a/pkg/runner/res/trampoline.js
+++ b/pkg/runner/res/trampoline.js
@@ -1,14 +1,14 @@
 const { spawnSync } = require('child_process')
-const spawnArguments={
-  cwd: process.env['INPUT_CWD'],
+const spawnArguments = {
+  cwd: process.env.INPUT_CWD,
   stdio: [
     process.stdin,
     process.stdout,
-    process.stderr,
+    process.stderr
   ]
 }
-const child=spawnSync(
+const child = spawnSync(
   '/bin/sh',
-  [ '-c' ].concat(process.env['INPUT_COMMAND']),
+  ['-c'].concat(process.env.INPUT_COMMAND),
   spawnArguments)
 process.exit(child.status)

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -334,7 +334,6 @@ func (rc *RunContext) EvalBool(expr string) (bool, error) {
 				!strings.Contains(part, "!")) && // but it's not negated
 				interpolatedPart == "false" && // and the interpolated string is false
 				(isString || previousOrNextPartIsAnOperator(i, parts)) { // and it's of type string or has an logical operator before or after
-
 				interpolatedPart = fmt.Sprintf("'%s'", interpolatedPart) // then we have to quote the false expression
 			}
 

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -157,7 +157,6 @@ func updateTestIfWorkflow(t *testing.T, tables []struct {
 	out     bool
 	wantErr bool
 }, rc *RunContext) {
-
 	var envs string
 	keys := make([]string, 0, len(rc.Env))
 	for k := range rc.Env {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -33,7 +33,7 @@ type Config struct {
 	Privileged            bool              // use privileged mode
 	UsernsMode            string            // user namespace to use
 	ContainerArchitecture string            // Desired OS/architecture platform for running containers
-	UseGitIgnore     bool              // controls if paths in .gitignore should not be copied into container, default true
+	UseGitIgnore          bool              // controls if paths in .gitignore should not be copied into container, default true
 }
 
 type runnerImpl struct {

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -508,27 +508,27 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 			stepID := 0
 			for _, compositeStep := range action.Runs.Steps {
 				stepClone := compositeStep
-                // Take a copy of the run context structure (rc is a pointer)
-                // Then take the address of the new structure
-                rcCloneStr := *rc
-                rcClone := &rcCloneStr
+				// Take a copy of the run context structure (rc is a pointer)
+				// Then take the address of the new structure
+				rcCloneStr := *rc
+				rcClone := &rcCloneStr
 				if stepClone.ID == "" {
 					stepClone.ID = fmt.Sprintf("composite-%d", stepID)
 					stepID++
 				}
-                rcClone.CurrentStep = stepClone.ID
+				rcClone.CurrentStep = stepClone.ID
 
-                if err := compositeStep.Validate(); err != nil {
-                    return err
-                }
+				if err := compositeStep.Validate(); err != nil {
+					return err
+				}
 
-                // Setup the outputs for the composite steps
-                if _, ok := rcClone.StepResults[stepClone.ID]; ! ok {
-                    rcClone.StepResults[stepClone.ID]  = &stepResult{
-                        Success: true,
-                        Outputs: make(map[string]string),
-                    }
-                }
+				// Setup the outputs for the composite steps
+				if _, ok := rcClone.StepResults[stepClone.ID]; !ok {
+					rcClone.StepResults[stepClone.ID] = &stepResult{
+						Success: true,
+						Outputs: make(map[string]string),
+					}
+				}
 
 				stepClone.Run = strings.ReplaceAll(stepClone.Run, "${{ github.action_path }}", filepath.Join(containerActionDir, actionName))
 
@@ -538,14 +538,13 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 					Env:        mergeMaps(sc.Env, stepClone.Env),
 				}
 
-                // Interpolate the outer inputs into the composite step with items
-                exprEval := sc.NewExpressionEvaluator()
-                for k, v := range stepContext.Step.With {
-
-                    if strings.Contains(v, "inputs") {
-                        stepContext.Step.With[k] = exprEval.Interpolate(v)
-                    }
-                }
+				// Interpolate the outer inputs into the composite step with items
+				exprEval := sc.NewExpressionEvaluator()
+				for k, v := range stepContext.Step.With {
+					if strings.Contains(v, "inputs") {
+						stepContext.Step.With[k] = exprEval.Interpolate(v)
+					}
+				}
 
 				executors = append(executors, stepContext.Executor())
 			}


### PR DESCRIPTION
Add `super-linter` to lint other languages.
Go linter is disabled because it's currently broken:
https://github.com/github/super-linter/pull/370
Replacing `scopelint` with `exportloopref`: "[runner] The linter
'scopelint' is deprecated (since v1.39.0) due to: The repository of the
linter has been deprecated by the owner.  Replaced by exportloopref."
Fixed formatting in `.golangci.yml`
Add addtional linters:
  `misspell`: purely style, detects typos in comments
  `whitespace`: detects leading and trailing whitespace
  `goimports`: it's gofmt + checks unused imports