### PR TITLE
Fix: Allow known failing actions to gracefully continue

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -81,7 +81,7 @@ func (sc *StepContext) Executor() common.Executor {
 		for _, blacklistItem := range unsupportedActionBlacklist {
 			if blacklistItem == actionName {
 				return func(ctx context.Context) error {
-					common.Logger(ctx).Infof("\U0001F6A7  Skipping currently unsupported remote action %v", actionName)
+					common.Logger(ctx).Infof("\U0001F6A7  Skipping remote action that act currently does not support: %v", actionName)
 					return nil
 				}
 			}

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -81,7 +81,7 @@ func (sc *StepContext) Executor() common.Executor {
 		for _, blacklistItem := range unsupportedActionBlacklist {
 			if blacklistItem == actionName {
 				return func(ctx context.Context) error {
-					common.Logger(ctx).Warnf("SKIP: %v is not supported in act yet, sorry!", actionName)
+					common.Logger(ctx).Infof("\U0001F6A7  Skipping currently unsupported action %v", actionName)
 					return nil
 				}
 			}
@@ -525,27 +525,27 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 			stepID := 0
 			for _, compositeStep := range action.Runs.Steps {
 				stepClone := compositeStep
-                // Take a copy of the run context structure (rc is a pointer)
-                // Then take the address of the new structure
-                rcCloneStr := *rc
-                rcClone := &rcCloneStr
+				// Take a copy of the run context structure (rc is a pointer)
+				// Then take the address of the new structure
+				rcCloneStr := *rc
+				rcClone := &rcCloneStr
 				if stepClone.ID == "" {
 					stepClone.ID = fmt.Sprintf("composite-%d", stepID)
 					stepID++
 				}
-                rcClone.CurrentStep = stepClone.ID
+				rcClone.CurrentStep = stepClone.ID
 
-                if err := compositeStep.Validate(); err != nil {
-                    return err
-                }
+				if err := compositeStep.Validate(); err != nil {
+					return err
+				}
 
-                // Setup the outputs for the composite steps
-                if _, ok := rcClone.StepResults[stepClone.ID]; ! ok {
-                    rcClone.StepResults[stepClone.ID]  = &stepResult{
-                        Success: true,
-                        Outputs: make(map[string]string),
-                    }
-                }
+				// Setup the outputs for the composite steps
+				if _, ok := rcClone.StepResults[stepClone.ID]; !ok {
+					rcClone.StepResults[stepClone.ID] = &stepResult{
+						Success: true,
+						Outputs: make(map[string]string),
+					}
+				}
 
 				stepClone.Run = strings.ReplaceAll(stepClone.Run, "${{ github.action_path }}", filepath.Join(containerActionDir, actionName))
 
@@ -555,14 +555,14 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 					Env:        mergeMaps(sc.Env, stepClone.Env),
 				}
 
-                // Interpolate the outer inputs into the composite step with items
-                exprEval := sc.NewExpressionEvaluator()
-                for k, v := range stepContext.Step.With {
+				// Interpolate the outer inputs into the composite step with items
+				exprEval := sc.NewExpressionEvaluator()
+				for k, v := range stepContext.Step.With {
 
-                    if strings.Contains(v, "inputs") {
-                        stepContext.Step.With[k] = exprEval.Interpolate(v)
-                    }
-                }
+					if strings.Contains(v, "inputs") {
+						stepContext.Step.With[k] = exprEval.Interpolate(v)
+					}
+				}
 
 				executors = append(executors, stepContext.Executor())
 			}

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -81,7 +81,7 @@ func (sc *StepContext) Executor() common.Executor {
 		for _, blacklistItem := range unsupportedActionBlacklist {
 			if blacklistItem == actionName {
 				return func(ctx context.Context) error {
-					common.Logger(ctx).Infof("\U0001F6A7  Skipping currently unsupported action %v", actionName)
+					common.Logger(ctx).Infof("\U0001F6A7  Skipping currently unsupported remote action %v", actionName)
 					return nil
 				}
 			}

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -70,6 +70,23 @@ func (sc *StepContext) Executor() common.Executor {
 		if remoteAction == nil {
 			return common.NewErrorExecutor(formatError(step.Uses))
 		}
+
+		// TODO: Add as remoteAction method?
+		unsupportedActionBlacklist := []string{
+			"actions/cache",
+			"actions/download-artifact",
+			"actions/upload-artifact",
+		}
+		actionName := remoteAction.Org + "/" + remoteAction.Repo
+		for _, blacklistItem := range unsupportedActionBlacklist {
+			if blacklistItem == actionName {
+				return func(ctx context.Context) error {
+					common.Logger(ctx).Warnf("SKIP: %v is not supported in act yet, sorry!", actionName)
+					return nil
+				}
+			}
+		}
+
 		if remoteAction.IsCheckout() && rc.getGithubContext().isLocalCheckout(step) {
 			return func(ctx context.Context) error {
 				common.Logger(ctx).Debugf("Skipping actions/checkout")

--- a/pkg/runner/step_context_test.go
+++ b/pkg/runner/step_context_test.go
@@ -12,6 +12,7 @@ func TestStepContextExecutor(t *testing.T) {
 		"ubuntu-latest": "node:12.20.1-buster-slim",
 	}
 	tables := []TestJobFileInfo{
+		{"testdata", "uses-blacklist", "push", "", platforms, "linux/amd64"},
 		{"testdata", "uses-and-run-in-one-step", "push", "Invalid run/uses syntax for job:test step:Test", platforms, "linux/amd64"},
 		{"testdata", "uses-github-empty", "push", "Expected format {org}/{repo}[/path]@ref", platforms, "linux/amd64"},
 		{"testdata", "uses-github-noref", "push", "Expected format {org}/{repo}[/path]@ref", platforms, "linux/amd64"},

--- a/pkg/runner/testdata/uses-blacklist/push.yml
+++ b/pkg/runner/testdata/uses-blacklist/push.yml
@@ -1,0 +1,9 @@
+name: blacklisted-actions
+on: push
+
+jobs:
+  blacklist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v2
+      - uses: actions/download-artifact@v2


### PR DESCRIPTION
Some actions such as cache, upload-artifact, and download artifact do not work due to lack of an emulated api/server. 

A potential path forward exists with #169, but until that is implemented we should silently continue on some actions that would otherwise fail but do not really impact the flow of the action for testing, to allow other actions in the flow to be tested.

This is intended to be temporary until the feature is implemented.

Related: #329, #285

(cherry picked from commit 523ad078bac2610989b1162bdf884675843cbdce)

Output from a run against JustinGrote/Press:
![image](https://user-images.githubusercontent.com/15258962/116804694-9e912380-aad5-11eb-83c6-781e01bb21ca.png)