### PR TITLE
fix: ignore `act` binary built when using `make`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,7 @@
 # Path for actions cache created when running tests
 pkg/runner/act/
 
+# act binary
+dist/local/act
+
 coverage.txt


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31106839/116894638-95699900-ac32-11eb-9648-0685afc46722.png)
