### PR TITLE
GitHub Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ It will save that information to `~/.actrc`, please refer to [Configuration](#co
       --env stringArray                 env to make available to actions with optional value (e.g. --e myenv=foo or -s myenv)
       --env-file string                 environment file to read and use as env in the containers (default ".env")
   -e, --eventpath string                path to event JSON file
+      --github-instance string          GitHub instance to use. Don't use this if you are not using GitHub Enterprise Server. (default "github.com")
   -g, --graph                           draw workflows
   -h, --help                            help for act
       --insecure-secrets                NOT RECOMMENDED! Doesn't hide secrets while printing logs.

--- a/README.md
+++ b/README.md
@@ -307,6 +307,15 @@ act -e pull-request.json
 
 Act will properly provide `github.head_ref` and `github.base_ref` to the action as expected.
 
+# GitHub Enterprise
+
+Act supports using and authenticating against private GitHub Enterprise servers.
+To use your custom GHE server, set the CLI flag `--github-instance` to your hostname (e.g. `github.company.com`).
+
+Please note that if your GHE server requires authentication, we will use the secret provided via `GITHUB_TOKEN`.
+
+Please also see the [official documentation for GitHub actions on GHE](https://docs.github.com/en/enterprise-server@3.0/admin/github-actions/about-using-actions-in-your-enterprise) for more information on how to use actions.
+
 # Support
 
 Need help? Ask on [Gitter](https://gitter.im/nektos/act)!

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -29,6 +29,7 @@ type Input struct {
 	containerArchitecture string
 	noWorkflowRecurse     bool
 	useGitIgnore          bool
+	githubInstance        string
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().BoolVarP(&input.insecureSecrets, "insecure-secrets", "", false, "NOT RECOMMENDED! Doesn't hide secrets while printing logs.")
 	rootCmd.PersistentFlags().StringVarP(&input.envfile, "env-file", "", ".env", "environment file to read and use as env in the containers")
 	rootCmd.PersistentFlags().StringVarP(&input.containerArchitecture, "container-architecture", "", "", "Architecture which should be used to run containers, e.g.: linux/amd64. If not specified, will use host default architecture. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.")
+	rootCmd.PersistentFlags().StringVarP(&input.githubInstance, "github-instance", "", "github.com", "GitHub instance to use. Don't use this if you are not using GitHub Enterprise Server.")
 	rootCmd.SetArgs(args())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -254,6 +255,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			UsernsMode:            input.usernsMode,
 			ContainerArchitecture: input.containerArchitecture,
 			UseGitIgnore:          input.useGitIgnore,
+			GitHubInstance:        input.githubInstance,
 		}
 		r, err := runner.New(config)
 		if err != nil {

--- a/pkg/common/git_test.go
+++ b/pkg/common/git_test.go
@@ -34,7 +34,7 @@ func TestFindGitSlug(t *testing.T) {
 	}
 
 	for _, tt := range slugTests {
-		provider, slug, err := findGitSlug(tt.url)
+		provider, slug, err := findGitSlug(tt.url, "github.com")
 
 		assert.NoError(err)
 		assert.Equal(tt.provider, provider)

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -639,9 +639,14 @@ func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	env["GITHUB_SHA"] = github.Sha
 	env["GITHUB_REF"] = github.Ref
 	env["GITHUB_TOKEN"] = github.Token
-	env["GITHUB_SERVER_URL"] = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
-	env["GITHUB_API_URL"] = fmt.Sprintf("https://api.%s", rc.Config.GitHubInstance)
-	env["GITHUB_GRAPHQL_URL"] = fmt.Sprintf("https://api.%s/graphql", rc.Config.GitHubInstance)
+	env["GITHUB_SERVER_URL"] = "https://github.com"
+	env["GITHUB_API_URL"] = "https://api.github.com"
+	env["GITHUB_GRAPHQL_URL"] = "https://api.github.com/graphql"
+	if rc.Config.GitHubInstance != "github.com" {
+		env["GITHUB_SERVER_URL"] = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
+		env["GITHUB_API_URL"] = fmt.Sprintf("https://%s/api/v3", rc.Config.GitHubInstance)
+		env["GITHUB_GRAPHQL_URL"] = fmt.Sprintf("https://%s/api/graphql", rc.Config.GitHubInstance)
+	}
 
 	job := rc.Run.Job()
 	if job.RunsOn() != nil {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -639,9 +639,9 @@ func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	env["GITHUB_SHA"] = github.Sha
 	env["GITHUB_REF"] = github.Ref
 	env["GITHUB_TOKEN"] = github.Token
-	env["GITHUB_SERVER_URL"] = "https://github.com"
-	env["GITHUB_API_URL"] = "https://api.github.com"
-	env["GITHUB_GRAPHQL_URL"] = "https://api.github.com/graphql"
+	env["GITHUB_SERVER_URL"] = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
+	env["GITHUB_API_URL"] = fmt.Sprintf("https://api.%s", rc.Config.GitHubInstance)
+	env["GITHUB_GRAPHQL_URL"] = fmt.Sprintf("https://api.%s/graphql", rc.Config.GitHubInstance)
 
 	job := rc.Run.Job()
 	if job.RunsOn() != nil {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -501,7 +501,7 @@ func (rc *RunContext) getGithubContext() *githubContext {
 	}
 
 	repoPath := rc.Config.Workdir
-	repo, err := common.FindGithubRepo(repoPath)
+	repo, err := common.FindGithubRepo(repoPath, rc.Config.GitHubInstance)
 	if err != nil {
 		log.Warningf("unable to get git repo: %v", err)
 	} else {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -38,6 +38,7 @@ type Config struct {
 	UsernsMode            string            // user namespace to use
 	ContainerArchitecture string            // Desired OS/architecture platform for running containers
 	UseGitIgnore          bool              // controls if paths in .gitignore should not be copied into container, default true
+	GitHubInstance        string            // GitHub instance to use, default "github.com"
 }
 
 // Resolves the equivalent host path inside the container

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -56,6 +56,7 @@ func runTestJobFile(ctx context.Context, t *testing.T, tjfi TestJobFileInfo, sec
 			ReuseContainers:       false,
 			ContainerArchitecture: tjfi.containerArchitecture,
 			Secrets:               secrets,
+			GitHubInstance:        "github.com",
 		}
 
 		runner, err := New(runnerConfig)

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -73,7 +73,8 @@ func (sc *StepContext) Executor() common.Executor {
 
 		remoteAction.URL = rc.Config.GitHubInstance
 
-		if remoteAction.IsCheckout() && rc.getGithubContext().isLocalCheckout(step) {
+		github := rc.getGithubContext()
+		if remoteAction.IsCheckout() && github.isLocalCheckout(step) {
 			return func(ctx context.Context) error {
 				common.Logger(ctx).Debugf("Skipping actions/checkout")
 				return nil
@@ -83,9 +84,10 @@ func (sc *StepContext) Executor() common.Executor {
 		actionDir := fmt.Sprintf("%s/%s", rc.ActionCacheDir(), strings.ReplaceAll(step.Uses, "/", "-"))
 		return common.NewPipelineExecutor(
 			common.NewGitCloneExecutor(common.NewGitCloneExecutorInput{
-				URL: remoteAction.CloneURL(),
-				Ref: remoteAction.Ref,
-				Dir: actionDir,
+				URL:   remoteAction.CloneURL(),
+				Ref:   remoteAction.Ref,
+				Dir:   actionDir,
+				Token: github.Token,
 			}),
 			sc.setupAction(actionDir, remoteAction.Path),
 			sc.runAction(actionDir, remoteAction.Path),

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -70,6 +70,9 @@ func (sc *StepContext) Executor() common.Executor {
 		if remoteAction == nil {
 			return common.NewErrorExecutor(formatError(step.Uses))
 		}
+
+		remoteAction.URL = rc.Config.GitHubInstance
+
 		if remoteAction.IsCheckout() && rc.getGithubContext().isLocalCheckout(step) {
 			return func(ctx context.Context) error {
 				common.Logger(ctx).Debugf("Skipping actions/checkout")
@@ -566,6 +569,7 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 }
 
 type remoteAction struct {
+	URL  string
 	Org  string
 	Repo string
 	Path string
@@ -573,7 +577,7 @@ type remoteAction struct {
 }
 
 func (ra *remoteAction) CloneURL() string {
-	return fmt.Sprintf("https://github.com/%s/%s", ra.Org, ra.Repo)
+	return fmt.Sprintf("https://%s/%s/%s", ra.URL, ra.Org, ra.Repo)
 }
 
 func (ra *remoteAction) IsCheckout() bool {
@@ -599,6 +603,7 @@ func newRemoteAction(action string) *remoteAction {
 		Repo: matches[2],
 		Path: matches[4],
 		Ref:  matches[6],
+		URL:  "github.com",
 	}
 }
 


### PR DESCRIPTION
This is a continuation of @catthehacker  https://github.com/catthehacker/act-fork/tree/enterprise-github

* We've updated the GHE URLs, because the API and GraphQL URLs are different on GHE than on github.com
* We've updated the slug matching in common/git.go to match only the configured GHE instance

~~This is a draft for now, because we haven't tested it yet. We'll update and ping once we're ready to merge.~~

Closes https://github.com/nektos/act/issues/497