### PR TITLE
Remove pwsh -login and add Pwsh test

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -258,7 +258,7 @@ func (s *Step) ShellCommand() string {
 	case "", "bash":
 		shellCommand = "bash --login --noprofile --norc -e -o pipefail {0}"
 	case "pwsh":
-		shellCommand = "pwsh -login -command . '{0}'"
+		shellCommand = "pwsh -command . '{0}'"
 	case "python":
 		shellCommand = "python {0}"
 	case "sh":

--- a/pkg/model/workflow_test.go
+++ b/pkg/model/workflow_test.go
@@ -130,3 +130,19 @@ jobs:
 	assert.Equal(t, workflow.Jobs["test"].Steps[3].Type(), StepTypeUsesDockerURL)
 	assert.Equal(t, workflow.Jobs["test"].Steps[4].Type(), StepTypeUsesActionLocal)
 }
+
+func TestStep_ShellCommand(t *testing.T) {
+	tests := []struct {
+		shell string
+		want  string
+	}{
+		{"pwsh", "pwsh -command . '{0}'"},
+		{"powershell", "powershell -command . '{0}'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			got := (&Step{Shell: tt.shell}).ShellCommand()
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -83,14 +83,13 @@ func TestRunEvent(t *testing.T) {
 	platforms := map[string]string{
 		"ubuntu-latest": "node:12.20.1-buster-slim",
 	}
-	pwshplatforms := map[string]string{
-		"ubuntu-latest": "ghcr.io/justingrote/act-pwsh:latest",
-	}
+
 	tables := []TestJobFileInfo{
 		{"testdata", "basic", "push", "", platforms, ""},
 		{"testdata", "fail", "push", "exit with `FAILURE`: 1", platforms, ""},
 		{"testdata", "runs-on", "push", "", platforms, ""},
-		{"testdata", "powershell", "push", "", pwshplatforms, ""},
+		// Pwsh is not available in default worker (yet) so we use a separate image for testing
+		{"testdata", "powershell", "push", "", map[string]string{"ubuntu-latest": "ghcr.io/justingrote/act-pwsh:latest"}, ""},
 		{"testdata", "job-container", "push", "", platforms, ""},
 		{"testdata", "job-container-non-root", "push", "", platforms, ""},
 		{"testdata", "uses-docker-url", "push", "", platforms, ""},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -83,10 +83,14 @@ func TestRunEvent(t *testing.T) {
 	platforms := map[string]string{
 		"ubuntu-latest": "node:12.20.1-buster-slim",
 	}
+	pwshplatforms := map[string]string{
+		"ubuntu-latest": "ghcr.io/justingrote/act-pwsh:latest",
+	}
 	tables := []TestJobFileInfo{
 		{"testdata", "basic", "push", "", platforms, ""},
 		{"testdata", "fail", "push", "exit with `FAILURE`: 1", platforms, ""},
 		{"testdata", "runs-on", "push", "", platforms, ""},
+		{"testdata", "powershell", "push", "", pwshplatforms, ""},
 		{"testdata", "job-container", "push", "", platforms, ""},
 		{"testdata", "job-container-non-root", "push", "", platforms, ""},
 		{"testdata", "uses-docker-url", "push", "", platforms, ""},
@@ -102,7 +106,6 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "defaults-run", "push", "", platforms, ""},
 		{"testdata", "uses-composite", "push", "", platforms, ""},
 		{"testdata", "issue-597", "push", "", platforms, ""},
-		// {"testdata", "powershell", "push", "", platforms, ""}, // Powershell is not available on default act test runner (yet) but preserving here for posterity
 		// {"testdata", "issue-228", "push", "", platforms, ""}, // TODO [igni]: Remove this once everything passes
 
 		// single test for different architecture: linux/arm64


### PR DESCRIPTION
This resolves the issue with pwsh failing due to -login and the command not splitting correctly.

It also adds a test pwsh run using a image that has Powershell integrated, hopefully this doesn't introduce too much into the testing time, but the image can be cached in the CI if necessary to speed things up.

EDIT: Literally took less than half a second to download and extract the container, I guess that's a benefit of using the github container registry :)