### PR TITLE
WIP: Enable Non-Root Runner Scenarios

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+# Dockerfile shell scripts will not compile correctly on windows without this
+* text=lf

--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -55,7 +55,7 @@ func FindGitRevision(file string) (shortSha string, sha string, err error) {
 		refBuf = []byte(ref)
 	}
 
-	log.Debugf("Found revision: %s", refBuf)
+	// log.Debugf("Found revision: %s", refBuf)
 	return string(refBuf[:7]), strings.TrimSpace(string(refBuf)), nil
 }
 
@@ -86,7 +86,8 @@ func FindGitRef(file string) (string, error) {
 				if r == nil || err != nil {
 					break
 				}
-				log.Debugf("Reference: name=%s sha=%s", r.Name().String(), r.Hash().String())
+				// This is super noisy, enable only when needed
+				// log.Debugf("Reference: name=%s sha=%s", r.Name().String(), r.Hash().String())
 				if r.Hash().String() == ref {
 					if r.Name().IsTag() {
 						refTag = r.Name().String()

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -158,9 +158,9 @@ func (cr *containerReference) chownIfRunningAsUser(destPath string) common.Execu
 		if cr.config.User != "" {
 			crChown := cr.chown(destPath, cr.config.User)
 			return crChown(ctx)
-		} else {
-			return nil
 		}
+
+		return nil
 	}
 }
 

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -259,14 +259,14 @@ func (s *Step) ShellCommand() string {
 		shellCommand = "bash --noprofile --norc -e -o pipefail {0}"
 	case "pwsh":
 		shellCommand = "pwsh -command . '{0}'"
+	case "powershell":
+		shellCommand = "powershell -command . '{0}'"
 	case "python":
 		shellCommand = "python {0}"
 	case "sh":
 		shellCommand = "sh -e -c {0}"
 	case "cmd":
 		shellCommand = "%ComSpec% /D /E:ON /V:OFF /S /C \"CALL \"{0}\"\""
-	case "powershell":
-		shellCommand = "powershell -command . '{0}'"
 	default:
 		shellCommand = s.Shell
 	}

--- a/pkg/runner/testdata/basic/push.yml
+++ b/pkg/runner/testdata/basic/push.yml
@@ -16,8 +16,8 @@ jobs:
           args: echo ${INPUT_SOMEKEY} | grep somevalue
       - run: ls
       - run: echo 'hello world' 
-      - run: echo ${GITHUB_SHA} >> $(dirname "${GITHUB_WORKSPACE}")/sha.txt
-      - run: cat $(dirname "${GITHUB_WORKSPACE}")/sha.txt | grep ${GITHUB_SHA}
+      - run: echo ${GITHUB_SHA} >> "${GITHUB_WORKSPACE}/sha.txt"
+      - run: cat "${GITHUB_WORKSPACE}/sha.txt" | grep ${GITHUB_SHA}
   build:
     runs-on: ubuntu-latest
     needs: [check]


### PR DESCRIPTION
Currently act requires the docker container to have root privileges to work because it both binds and mounts to the "same path" as the host.

While the bind method is useful if using act as a task runner, the mount method will fail in non-root containers.

In order to more accurately test Github Actions for both permission and pathing errors, this PR makes mounts use the runner workdir by default and sets permissions accordingly. Binds with the -b flag will be unaffected and will continue to use the same path as what is on the container.

It will also add a parameter to customize the starting container workdir separately from the host workdir, if there is such a situation where you dont' want to use the default (usually /home/runner/workdir)

# Example that this will fix
Try a simple action that does `mkdir -p /my/random/path`. This will work just fine in act, but fail in Github Actions, and you won't find out till you run it in github actions.