### PR TITLE
Fix environment variables and move `envs.txt`/`event.json` to fixed location

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -256,13 +256,13 @@ func (s *Step) ShellCommand() string {
 	//Reference: https://github.com/actions/runner/blob/8109c962f09d9acc473d92c595ff43afceddb347/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs#L9-L17
 	switch s.Shell {
 	case "", "bash":
-		shellCommand = "bash --login --noprofile --norc -e -o pipefail {0}"
+		shellCommand = "bash --noprofile --norc -e -o pipefail {0}"
 	case "pwsh":
 		shellCommand = "pwsh -command . '{0}'"
 	case "python":
 		shellCommand = "python {0}"
 	case "sh":
-		shellCommand = "sh -l -e -c {0}"
+		shellCommand = "sh -e -c {0}"
 	case "cmd":
 		shellCommand = "%ComSpec% /D /E:ON /V:OFF /S /C \"CALL \"{0}\"\""
 	case "powershell":

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -144,6 +144,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.stopJobContainer(),
 			rc.JobContainer.Create(),
 			rc.JobContainer.Start(false),
+			rc.JobContainer.UpdateFromEnv("/etc/environment", &rc.Env),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".", rc.Config.UseGitIgnore).IfBool(copyWorkspace),
 			rc.JobContainer.Copy(rc.Config.ContainerWorkdir(), &container.FileEntry{
 				Name: "workflow/event.json",

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -146,16 +146,12 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.Start(false),
 			rc.JobContainer.UpdateFromEnv("/etc/environment", &rc.Env),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".", rc.Config.UseGitIgnore).IfBool(copyWorkspace),
-			rc.JobContainer.Copy(rc.Config.ContainerWorkdir(), &container.FileEntry{
+			rc.JobContainer.Copy("/tmp/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0644,
 				Body: rc.EventJSON,
 			}, &container.FileEntry{
 				Name: "workflow/envs.txt",
-				Mode: 0644,
-				Body: "",
-			}, &container.FileEntry{
-				Name: "home/.act",
 				Mode: 0644,
 				Body: "",
 			}),
@@ -476,17 +472,20 @@ func (rc *RunContext) getGithubContext() *githubContext {
 	if !ok {
 		token = os.Getenv("GITHUB_TOKEN")
 	}
+
 	runID := rc.Config.Env["GITHUB_RUN_ID"]
 	if runID == "" {
 		runID = "1"
 	}
+
 	runNumber := rc.Config.Env["GITHUB_RUN_NUMBER"]
 	if runNumber == "" {
 		runNumber = "1"
 	}
+
 	ghc := &githubContext{
 		Event:     make(map[string]interface{}),
-		EventPath: fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), "workflow/event.json"),
+		EventPath: "/tmp/workflow/event.json",
 		Workflow:  rc.Run.Workflow.Name,
 		RunID:     runID,
 		RunNumber: runNumber,
@@ -628,7 +627,7 @@ func withDefaultBranch(b string, event map[string]interface{}) map[string]interf
 func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	github := rc.getGithubContext()
 	env["CI"] = "true"
-	env["GITHUB_ENV"] = fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), "workflow/envs.txt")
+	env["GITHUB_ENV"] = "/tmp/workflow/envs.txt"
 	env["GITHUB_WORKFLOW"] = github.Workflow
 	env["GITHUB_RUN_ID"] = github.RunID
 	env["GITHUB_RUN_NUMBER"] = github.RunNumber

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -113,8 +113,7 @@ func (sc *StepContext) mergeEnv() map[string]string {
 	}
 
 	if (rc.ExtraPath != nil) && (len(rc.ExtraPath) > 0) {
-		s := append(rc.ExtraPath, `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`)
-		env["PATH"] = strings.Join(s, `:`)
+		env["PATH"] = strings.Join(rc.ExtraPath, `:`)
 	}
 
 	sc.Env = rc.withGithubEnv(env)
@@ -131,7 +130,7 @@ func (sc *StepContext) setupEnv(ctx context.Context) (ExpressionEvaluator, error
 	rc := sc.RunContext
 	sc.Env = sc.mergeEnv()
 	if sc.Env != nil {
-		err := rc.JobContainer.UpdateFromGithubEnv(&sc.Env)(ctx)
+		err := rc.JobContainer.UpdateFromEnv(sc.Env["GITHUB_ENV"], &sc.Env)(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
fix: move `envs.txt` & `event.json` to `/tmp/workflow/`

Since #635 envs.txt is not copying properly when running act in WSL2 (Linux <> Linux) (didn't tried it with Windows <> Linux scenario)
Moving it to fixed location resolves that as it doesn't need to move around since we have `GITHUB_ENV`
fix: environment variables sourcing from `/etc/environment`