### PR TITLE
fix: hide masked value

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -54,7 +54,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		case "error":
 			logger.Infof("  \U00002757  %s", line)
 		case "add-mask":
-			logger.Infof("  \U00002699  %s", line)
+			logger.Infof("  \U00002699  %s", "***")
 		case "stop-commands":
 			resumeCommand = arg
 			logger.Infof("  \U00002699  %s", line)

--- a/pkg/runner/command_test.go
+++ b/pkg/runner/command_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/nektos/act/pkg/common"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -87,4 +89,18 @@ func TestAddpathADO(t *testing.T) {
 
 	handler("##[add-path]/boo\n")
 	a.Equal("/boo", rc.ExtraPath[1])
+}
+
+func TestAddmask(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
+	a := assert.New(t)
+	ctx := context.Background()
+	loggerCtx := common.WithLogger(ctx, logger)
+
+	rc := new(RunContext)
+	handler := rc.commandHandler(loggerCtx)
+	handler("::add-mask::my-secret-value\n")
+
+	a.NotEqual("  \U00002699  *my-secret-value", hook.LastEntry().Message)
 }


### PR DESCRIPTION
The `::add-mask::` command output logs the value to be masked.

The current implementation does expose critical information which should be hidden from the output.

**Note:** This PR does not implement proper mask handling. It just suppresses the output of the secret in  the `add-mask` command.