### PR TITLE
Write git clone progress only if terminal is a TTY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
+	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.8.1
 	github.com/moby/sys/mount v0.2.0 // indirect


### PR DESCRIPTION
The output written by the git progress is a bit distracting if the terminal act is running in is not a TTY.

```
...
Receiving objects:  38% (166/436)   
Receiving objects:  39% (171/436)   
Receiving objects:  40% (175/436)   
Receiving objects:  41% (179/436)   
Receiving objects:  42% (184/436)   
Receiving objects:  43% (188/436)   
Receiving objects:  44% (192/436)   
Receiving objects:  45% (197/436)   
Receiving objects:  46% (201/436)   
Receiving objects:  47% (205/436)   
Receiving objects:  48% (210/436)   
Receiving objects:  49% (214/436)   
...
```

This PR does check if we are on a TTY and suppress output otherwise.
