### PR TITLE
Replace `gopass` lib with `golang.org/x/term`

### DIFF
--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
-	"github.com/howeyc/gopass"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/term"
 )
 
 type secrets map[string]string
@@ -17,7 +17,7 @@ func newSecrets(secretList []string) secrets {
 		secretPairParts := strings.SplitN(secretPair, "=", 2)
 		secretPairParts[0] = strings.ToUpper(secretPairParts[0])
 		if strings.ToUpper(s[secretPairParts[0]]) == secretPairParts[0] {
-			log.Fatalf("Secret %s is already defined (secrets are case insensitive)", secretPairParts[0])
+			log.Errorf("Secret %s is already defined (secrets are case insensitive)", secretPairParts[0])
 		}
 		if len(secretPairParts) == 2 {
 			s[secretPairParts[0]] = secretPairParts[1]
@@ -25,9 +25,10 @@ func newSecrets(secretList []string) secrets {
 			s[secretPairParts[0]] = env
 		} else {
 			fmt.Printf("Provide value for '%s': ", secretPairParts[0])
-			val, err := gopass.GetPasswdMasked()
+			val, err := term.ReadPassword(int(os.Stdin.Fd()))
 			if err != nil {
-				log.Fatal("abort")
+				log.Errorf("failed to read input: %v", err)
+				os.Exit(1)
 			}
 			s[secretPairParts[0]] = string(val)
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/go-ini/ini v1.62.0
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
-	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -540,8 +540,6 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c/go.mod h1:fHzc09UnyJyqyW+bFuq864eh+wC7dj65aXmXLRe5to0=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
-github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c h1:aY2hhxLhjEAbfXOx2nRJxCXezC6CO2V/yN+OCr1srtk=
-github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=


### PR DESCRIPTION
fix: replace `gopass` lib with `golang.org/x/term` 
Additionally replaced `Fatalf` with `Errorf` since it's bad to exit a program this way (like `Panic`)

Ongoing effort to remove old and abandoned libraries