### PR TITLE
fix: use github auth token for pulling a repository

### DIFF
--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -361,9 +361,17 @@ func NewGitCloneExecutor(input NewGitCloneExecutorInput) Executor {
 			}
 		}
 
-		if err = w.Pull(&git.PullOptions{
+		pullOptions := git.PullOptions{
 			Force: true,
-		}); err != nil && err.Error() != "already up-to-date" {
+		}
+		if input.Token != "" {
+			pullOptions.Auth = &http.BasicAuth{
+				Username: "token",
+				Password: input.Token,
+			}
+		}
+
+		if err = w.Pull(&pullOptions); err != nil && err.Error() != "already up-to-date" {
 			logger.Debugf("Unable to pull %s: %v", refName, err)
 		}
 		logger.Debugf("Cloned %s to %s", input.URL, input.Dir)


### PR DESCRIPTION
Seems like we missed another one 🙈 . This happens when using actions with a branch spec instead of a tag (i.e. `uses: actions/checkout@master` instead of `actions/checkout@v2`).
https://github.com/nektos/act/pull/687