### PR TITLE
Add `arm64`/`arm` and capture all snapshots

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -124,18 +124,69 @@ jobs:
         with:
           version: latest
           args: release --snapshot --rm-dist
-      - name: Capture Linux Binary
+      - name: Capture x86_64 (64-bit) Linux binary
+        if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v2
         with:
-          name: act-linux
+          name: act-linux-amd64
           path: dist/act_linux_amd64/act
-      - name: Capture Windows Binary
+      - name: Capture i386 (32-bit) Linux binary
+        if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v2
         with:
-          name: act-windows
+          name: act-linux-i386
+          path: dist/act_linux_386/act
+      - name: Capture arm64 (64-bit) Linux binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-linux-arm64
+          path: dist/act_linux_arm64/act
+      - name: Capture armv6 (32-bit) Linux binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-linux-armv6
+          path: dist/act_linux_arm_6/act
+      - name: Capture armv7 (32-bit) Linux binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-linux-armv7
+          path: dist/act_linux_arm_7/act
+      - name: Capture x86_64 (64-bit) Windows binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-windows-amd64
           path: dist/act_windows_amd64/act.exe
-      - name: Capture MacOS Binary
+      - name: Capture i386 (32-bit) Windows binary
+        if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v2
         with:
-          name: act-macos
+          name: act-windows-i386
+          path: dist/act_windows_386/act.exe
+      - name: Capture armv6 (32-bit) Windows binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-windows-armv6
+          path: dist/act_windows_arm_6/act.exe
+      - name: Capture armv7 (32-bit) Windows binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-windows-armv7
+          path: dist/act_windows_arm_7/act.exe
+      - name: Capture x86_64 (64-bit) MacOS binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-macos-amd64
           path: dist/act_darwin_amd64/act
+      - name: Capture arm64 (64-bit) MacOS binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-macos-arm64
+          path: dist/act_darwin_arm64/act

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -166,12 +166,6 @@ jobs:
         with:
           name: act-windows-i386
           path: dist/act_windows_386/act.exe
-      - name: Capture armv6 (32-bit) Windows binary
-        if: ${{ !env.ACT }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: act-windows-armv6
-          path: dist/act_windows_arm_6/act.exe
       - name: Capture armv7 (32-bit) Windows binary
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,10 +11,15 @@ builds:
     goarch:
       - amd64
       - 386
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
 checksum:
   name_template: 'checksums.txt'
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
     replacements:
       darwin: Darwin
       linux: Linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,9 @@ builds:
     goarm:
       - 6
       - 7
+    ignore:
+      - goos: windows
+        goarm: 6
 checksum:
   name_template: 'checksums.txt'
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,16 +1,16 @@
 before:
   hooks:
-  - go mod tidy
+    - go mod tidy
 builds:
-- env:
-  - CGO_ENABLED=0
-  goos:
-  - darwin
-  - linux
-  - windows
-  goarch:
-  - amd64
-  - 386
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
 checksum:
   name_template: 'checksums.txt'
 archives:
@@ -22,14 +22,14 @@ archives:
       386: i386
       amd64: x86_64
     format_overrides:
-    - goos: windows
-      format: zip
+      - goos: windows
+        format: zip
 brews:
   - tap:
       owner: nektos
       name: homebrew-tap
     folder: Formula
-    homepage:  https://github.com/nektos/act
+    homepage: https://github.com/nektos/act
     description: Run GitHub Actions locally
     test: |
       system "#{bin}/act --version"


### PR DESCRIPTION
fix: format `.goreleaser.yml`
feat: add `arm64` builds
feat: capture all binaries built by goreleaser, `upload-artifact` actions will run only on GitHub Actions due to `ACTIONS_RUNTIME_TOKEN` requirement

`windows/arm64` support is planned to land in go 1.17