### PR TITLE
Switch to `interface{}` instead of `map[string]...`

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -53,7 +53,7 @@ type stepResult struct {
 // GetEnv returns the env for the context
 func (rc *RunContext) GetEnv() map[string]string {
 	if rc.Env == nil {
-		rc.Env = mergeMaps(rc.Config.Env, rc.Run.Workflow.Env, rc.Run.Job().Env)
+		rc.Env = mergeMaps(rc.Config.Env, rc.Run.Workflow.Env, rc.Run.Job().Environment())
 	}
 	rc.Env["ACT"] = "true"
 	return rc.Env

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -574,13 +574,15 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 			stepClone.Env = make(map[string]string)
 		}
 		actionPath := filepath.Join(containerActionDir, actionName)
-		stepClone.Env["GITHUB_ACTION_PATH"] = actionPath
+
+		env := stepClone.Environment()
+		env["GITHUB_ACTION_PATH"] = actionPath
 		stepClone.Run = strings.ReplaceAll(stepClone.Run, "${{ github.action_path }}", actionPath)
 
 		stepContext := StepContext{
 			RunContext: rcClone,
 			Step:       &stepClone,
-			Env:        mergeMaps(sc.Env, stepClone.Env),
+			Env:        mergeMaps(sc.Env, env),
 		}
 
 		// Interpolate the outer inputs into the composite step with items


### PR DESCRIPTION
Fixes issue with `env:` keys not being able to accept GitHub functions like `fromJSON()`
Fixes issue with matrixes not being able to be built with GitHub functions like `fromJSON()`

Fixed issues:
fixes #284
fixes #540
fixes #450
fixes #330