### PR TITLE
fix: avoid race condition by not running exec/start twice

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -456,13 +456,6 @@ func (cr *containerReference) exec(cmd []string, env map[string]string, user str
 			errWriter = os.Stderr
 		}
 
-		err = cr.cli.ContainerExecStart(ctx, idResp.ID, types.ExecStartCheck{
-			Tty: isTerminal,
-		})
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
 		if !isTerminal || os.Getenv("NORAW") != "" {
 			_, err = stdcopy.StdCopy(outWriter, errWriter, resp.Reader)
 		} else {


### PR DESCRIPTION
ContainerExecAttach implicitly runs ContainerExecStart while attaching
to stdout/stderr.
Ref: https://github.com/moby/moby/blob/e02bc91dcbf6ab70ab39352f3577a4394b0f863a/client/container_exec.go#L40

Calling both can lead to a race condition as observed in #627

Fixes: #627