### PR TITLE
Fix actionPath to always end with actionName

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -397,6 +397,8 @@ func (sc *StepContext) getContainerActionPaths(step *model.Step, actionDir strin
 		if runtime.GOOS == "windows" {
 			actionName = strings.ReplaceAll(actionName, "\\", "/")
 		}
+		// actionName is missing in containerActionDir, append the fixed one
+		containerActionDir += actionName
 	}
 	return actionName, containerActionDir
 }
@@ -573,7 +575,7 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 		if stepClone.Env == nil {
 			stepClone.Env = make(map[string]string)
 		}
-		actionPath := filepath.Join(containerActionDir, actionName)
+		actionPath := containerActionDir
 		stepClone.Env["GITHUB_ACTION_PATH"] = actionPath
 		stepClone.Run = strings.ReplaceAll(stepClone.Run, "${{ github.action_path }}", actionPath)
 


### PR DESCRIPTION
Remove invalid workaround for local composite action
Resolves #708

I'm unshure why local actions are copied via docker cp, they should require the `actions/checkout` step.
- Removing docker cp for localaction makes some parts of this pr redundant, so actionPath doesn't need to always end with actionName

`- uses: ./` has an empty actionName, which is missing in containerActionDir

**Replaced by #712**