### PR TITLE
Refactor local, composite actions and run steps

### DIFF
--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -173,6 +173,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		if step.WorkingDirectory == "" {
 			step.WorkingDirectory = rc.Run.Workflow.Defaults.Run.WorkingDirectory
 		}
+		step.WorkingDirectory = rc.ExprEval.Interpolate(step.WorkingDirectory)
 		if step.WorkingDirectory != "" {
 			_, err = script.WriteString(fmt.Sprintf("cd %s\n", step.WorkingDirectory))
 			if err != nil {
@@ -181,6 +182,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		}
 
 		run := rc.ExprEval.Interpolate(step.Run)
+		step.Shell = rc.ExprEval.Interpolate(step.Shell)
 
 		if _, err = script.WriteString(run); err != nil {
 			return err
@@ -381,14 +383,12 @@ func getOsSafeRelativePath(s, prefix string) string {
 func (sc *StepContext) getContainerActionPaths(step *model.Step, actionDir string, rc *RunContext) (string, string) {
 	actionName := ""
 	containerActionDir := "."
-	if !rc.Config.BindWorkdir && step.Type() != model.StepTypeUsesActionRemote {
+	if step.Type() != model.StepTypeUsesActionRemote {
 		actionName = getOsSafeRelativePath(actionDir, rc.Config.Workdir)
-		containerActionDir = ActPath + "/actions/" + actionName
+		containerActionDir = rc.Config.ContainerWorkdir() + "/" + actionName
+		actionName = "./" + actionName
 	} else if step.Type() == model.StepTypeUsesActionRemote {
 		actionName = getOsSafeRelativePath(actionDir, rc.ActionCacheDir())
-		containerActionDir = ActPath + "/actions/" + actionName
-	} else if step.Type() == model.StepTypeUsesActionLocal {
-		actionName = getOsSafeRelativePath(actionDir, rc.Config.Workdir)
 		containerActionDir = ActPath + "/actions/" + actionName
 	}
 
@@ -422,11 +422,9 @@ func (sc *StepContext) runAction(actionDir string, actionPath string) common.Exe
 		log.Debugf("type=%v actionDir=%s actionPath=%s Workdir=%s ActionCacheDir=%s actionName=%s containerActionDir=%s", step.Type(), actionDir, actionPath, rc.Config.Workdir, rc.ActionCacheDir(), actionName, containerActionDir)
 
 		maybeCopyToActionDir := func() error {
+			sc.Env["GITHUB_ACTION_PATH"] = containerActionDir
 			if step.Type() != model.StepTypeUsesActionRemote {
-				// If the workdir is bound to our repository then we don't need to copy the file
-				if rc.Config.BindWorkdir {
-					return nil
-				}
+				return nil
 			}
 			err := removeGitIgnore(actionDir)
 			if err != nil {
@@ -570,28 +568,29 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 			}
 		}
 
-		if stepClone.Env == nil {
-			stepClone.Env = make(map[string]string)
-		}
-		actionPath := filepath.Join(containerActionDir, actionName)
-
 		env := stepClone.Environment()
-		env["GITHUB_ACTION_PATH"] = actionPath
-		stepClone.Run = strings.ReplaceAll(stepClone.Run, "${{ github.action_path }}", actionPath)
-
 		stepContext := StepContext{
 			RunContext: rcClone,
-			Step:       &stepClone,
+			Step:       step,
 			Env:        mergeMaps(sc.Env, env),
 		}
 
-		// Interpolate the outer inputs into the composite step with items
-		exprEval := sc.NewExpressionEvaluator()
-		for k, v := range stepContext.Step.With {
-			if strings.Contains(v, "inputs") {
-				stepContext.Step.With[k] = exprEval.Interpolate(v)
-			}
+		// Required to set github.action_path
+		if rcClone.Config.Env == nil {
+			// Workaround to get test working
+			rcClone.Config.Env = make(map[string]string)
 		}
+		rcClone.Config.Env["GITHUB_ACTION_PATH"] = sc.Env["GITHUB_ACTION_PATH"]
+		ev := stepContext.NewExpressionEvaluator()
+		// Required to interpolate inputs and github.action_path into the env map
+		stepContext.interpolateEnv(ev)
+		// Required to interpolate inputs, env and github.action_path into run steps
+		ev = stepContext.NewExpressionEvaluator()
+		stepClone.Run = ev.Interpolate(stepClone.Run)
+		stepClone.Shell = ev.Interpolate(stepClone.Shell)
+		stepClone.WorkingDirectory = ev.Interpolate(stepClone.WorkingDirectory)
+
+		stepContext.Step = &stepClone
 
 		executors = append(executors, stepContext.Executor())
 	}

--- a/pkg/runner/testdata/local-action-docker-url/push.yml
+++ b/pkg/runner/testdata/local-action-docker-url/push.yml
@@ -5,4 +5,5 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: ./actions/docker-url

--- a/pkg/runner/testdata/local-action-dockerfile/push.yml
+++ b/pkg/runner/testdata/local-action-dockerfile/push.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: ./actions/docker-local
       with:
         who-to-greet: 'Mona the Octocat'

--- a/pkg/runner/testdata/local-action-js/push.yml
+++ b/pkg/runner/testdata/local-action-js/push.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: ./actions/node12
       with:
         who-to-greet: 'Mona the Octocat'


### PR DESCRIPTION
This PR makes my previous PR redundant and conflicts with it.

Skip docker cp for local actions and use their correct path
~~Allow cloning local actions where you wish~~, (needs a lot of more changes)
Defines GITHUB_ACTION_PATH also for nodejs actions
Evaluate Env of composite action
Evaluate Run of composite action correctly
Evaluate Shell of run steps
Evaluate WorkingDirectory of run steps
Resolves #441
Resolves #640
Resolves #664
Resolves #708
Replaces #709

~~**Known issues**~~
- ~~composite step's properties are evaluated twice, this make escaping `${{'${{Test}}'}}` impossible (this doesn't work in act yet)~~, this is a bug / feature of act

~~_`path.Join` always use `/` to concat path's and is better than +_~~

> If the workdir is bound to our repository then we don't need to copy the file

Act should never copy local actions, because they can come from anywhere via checkout, git clone etc.

~~Merging this might resolve this known issue:
https://github.com/nektos/act#module_not_found~~ (seems like we would need to copy files from the container to host)
_I have no experience in golang_

Update:
fixes #733