### PR TITLE
fix: wrong perms

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -159,11 +159,11 @@ func (rc *RunContext) startJobContainer() common.Executor {
 				Body: rc.EventJSON,
 			}, &container.FileEntry{
 				Name: "workflow/envs.txt",
-				Mode: 0644,
+				Mode: 0666,
 				Body: "",
 			}, &container.FileEntry{
 				Name: "workflow/paths.txt",
-				Mode: 0644,
+				Mode: 0666,
 				Body: "",
 			}),
 		)(ctx)


### PR DESCRIPTION
if someone is using image with a non-root user, they will get a permission denied since only root has write perms

fixes #729