### PR TITLE
Fix format function {{, }} are escapes

### DIFF
--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -110,6 +110,14 @@ func TestEvaluate(t *testing.T) {
 		{"env.key", "value", ""},
 		{"secrets.CASE_INSENSITIVE_SECRET", "value", ""},
 		{"secrets.case_insensitive_secret", "value", ""},
+		{"format('{{0}}', 'test')", "{0}", ""},
+		{"format('{{{0}}}', 'test')", "{test}", ""},
+		{"format('}}')", "}", ""},
+		{"format('echo Hello {0} ${{Test}}', 'World')", "echo Hello World ${Test}", ""},
+		{"format('echo Hello {0} ${{Test}}', github.undefined_property)", "echo Hello  ${Test}", ""},
+		{"format('echo Hello {0}{1} ${{Te{0}st}}', github.undefined_property, 'World')", "echo Hello World ${Test}", ""},
+		{"format('{0}', '{1}', 'World')", "{1}", ""},
+		{"format('{{{0}', '{1}', 'World')", "{{1}", ""},
 	}
 
 	for _, table := range tables {


### PR DESCRIPTION
Github transforms multiple expressions into one format expression while parsing and every non expression `{` is replaced by `{{` and `}` by `}}`.

I assume vmformat should mimic githubs behavior, issues appeard during testing of https://github.com/ChristopherHX/github-actions-act-runner.

Haven't searched any documentation about this yet.

Some corner cases fixed too
`format('{0}', github.undefined_value)` should be an empty string not `undefined`.
`format('{0}', '{1}', 'Hello')` should be `{1}` not `Hello`.

How do I test the error handler?
vmFormat has no error output, so the tests cannot test for error messages or did I miss something?