### PR TITLE
Fix defaults (composite)

### DIFF
--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -403,7 +403,7 @@ func (sc *StepContext) vmInputs() func(*otto.Otto) {
 	// Set Defaults
 	if sc.Action != nil {
 		for k, input := range sc.Action.Inputs {
-			inputs[k] = input.Default
+			inputs[k] = sc.RunContext.NewExpressionEvaluator().Interpolate(input.Default)
 		}
 	}
 

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -591,6 +591,7 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 			RunContext: rcClone,
 			Step:       step,
 			Env:        mergeMaps(sc.Env, env),
+			Action:     action,
 		}
 
 		// Required to set github.action_path

--- a/pkg/runner/testdata/uses-composite/composite_action/action.yml
+++ b/pkg/runner/testdata/uses-composite/composite_action/action.yml
@@ -10,6 +10,18 @@ inputs:
     description: "optional defaulted input"
     required: false
     default: "test_input_optional_value"
+  test_input_optional_with_default_overriden:
+    description: "optional defaulted input"
+    required: false
+    default: "test_input_optional_value"
+  test_input_required_with_default:
+    description: "Required with default, due to an old bug of github actions this is allowed"
+    required: true
+    default: "test_input_optional_value"
+  test_input_required_with_default_overriden:
+    description: "Required with default, due to an old bug of github actions this is allowed"
+    required: true
+    default: "test_input_optional_value"
 
 outputs:
   test_output:
@@ -25,6 +37,9 @@ runs:
         echo "---"
         echo "test_input_required=${{ inputs.test_input_required }}"
         echo "test_input_optional=${{ inputs.test_input_optional }}"
+        echo "test_input_optional_with_default_overriden=${{ inputs.test_input_optional_with_default_overriden }}"
+        echo "test_input_required_with_default=${{ inputs.test_input_required_with_default }}"
+        echo "test_input_required_with_default_overriden=${{ inputs.test_input_required_with_default_overriden }}"
         echo "---"
       shell: bash
 
@@ -37,6 +52,24 @@ runs:
 
     - run: |
         if [ "${{ inputs.test_input_optional }}" != "test_input_optional_value" ]; then
+          exit 1
+        fi
+      shell: bash
+
+    - run: |
+        if [ "${{ inputs.test_input_optional_with_default_overriden }}" != "test_input_optional_with_default_overriden" ]; then
+          exit 1
+        fi
+      shell: bash
+
+    - run: |
+        if [ "${{ inputs.test_input_required_with_default }}" != "test_input_optional_value" ]; then
+          exit 1
+        fi
+      shell: bash
+
+    - run: |
+        if [ "${{ inputs.test_input_required_with_default_overriden }}" != "test_input_required_with_default_overriden" ]; then
           exit 1
         fi
       shell: bash

--- a/pkg/runner/testdata/uses-composite/push.yml
+++ b/pkg/runner/testdata/uses-composite/push.yml
@@ -19,6 +19,7 @@ jobs:
     # Now test again with default values
     - uses: ./uses-composite/composite_action
       id: composite2
+      test_input_required: 'test_input_required_value'
 
     - if: steps.composite2.outputs.test_output != "test_output_value"
       run: |

--- a/pkg/runner/testdata/uses-composite/push.yml
+++ b/pkg/runner/testdata/uses-composite/push.yml
@@ -16,3 +16,11 @@ jobs:
         echo "steps.composite.outputs.test_output=${{ steps.composite.outputs.test_output }}"
         exit 1
 
+    # Now test again with default values
+    - uses: ./uses-composite/composite_action
+      id: composite2
+
+    - if: steps.composite2.outputs.test_output != "test_output_value"
+      run: |
+        echo "steps.composite.outputs.test_output=${{ steps.composite.outputs.test_output }}"
+        exit 1

--- a/pkg/runner/testdata/uses-composite/push.yml
+++ b/pkg/runner/testdata/uses-composite/push.yml
@@ -10,6 +10,9 @@ jobs:
       with:
         test_input_required: 'test_input_required_value'
         test_input_optional: 'test_input_optional_value'
+        test_input_optional_with_default_overriden: 'test_input_optional_with_default_overriden'
+        test_input_required_with_default: 'test_input_optional_value'
+        test_input_required_with_default_overriden: 'test_input_required_with_default_overriden'
 
     - if: steps.composite.outputs.test_output != "test_output_value"
       run: |
@@ -19,7 +22,10 @@ jobs:
     # Now test again with default values
     - uses: ./uses-composite/composite_action
       id: composite2
-      test_input_required: 'test_input_required_value'
+      with:
+        test_input_required: 'test_input_required_value'
+        test_input_optional_with_default_overriden: 'test_input_optional_with_default_overriden'
+        test_input_required_with_default_overriden: 'test_input_required_with_default_overriden'
 
     - if: steps.composite2.outputs.test_output != "test_output_value"
       run: |


### PR DESCRIPTION
Missing assignment in runcontext copy caused missing defaults in vmInputs.
Also vmInputs needs interpolation of the default value, like the INPUT_ env variables

Resolves #655