### PR TITLE
Fix `ImageOS` format

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -707,7 +707,7 @@ func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 					// hardcode current ubuntu-latest since we have no way to check that 'on the fly'
 					env["ImageOS"] = "ubuntu20"
 				} else {
-					platformName = strings.SplitN(strings.Replace(platformName, `-`, ``, 1), `.`, 1)[0]
+					platformName = strings.SplitN(strings.Replace(platformName, `-`, ``, 1), `.`, 2)[0]
 					env["ImageOS"] = platformName
 				}
 			}


### PR DESCRIPTION
The current algorithm given `ubuntu-18.04` returns `ubuntu18.04` when it should be `ubuntu18` according to https://github.com/actions/virtual-environments/issues/345#issuecomment-581263296.