### PR TITLE
Add proper support for working-directory & fix command builder

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -112,6 +112,7 @@ func (cr *containerReference) Create(capAdd []string, capDrop []string) common.E
 			).IfNot(common.Dryrun),
 		)
 }
+
 func (cr *containerReference) Start(attach bool) common.Executor {
 	return common.
 		NewInfoExecutor("%sdocker run image=%s platform=%s entrypoint=%+q cmd=%+q", logPrefix, cr.input.Image, cr.input.Platform, cr.input.Entrypoint, cr.input.Cmd).
@@ -125,6 +126,7 @@ func (cr *containerReference) Start(attach bool) common.Executor {
 			).IfNot(common.Dryrun),
 		)
 }
+
 func (cr *containerReference) Pull(forcePull bool) common.Executor {
 	return common.
 		NewInfoExecutor("%sdocker pull image=%s platform=%s username=%s forcePull=%t", logPrefix, cr.input.Image, cr.input.Platform, cr.input.Username, forcePull).

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -103,7 +103,7 @@ func supportsContainerImagePlatform(cli *client.Client) bool {
 
 func (cr *containerReference) Create(capAdd []string, capDrop []string) common.Executor {
 	return common.
-		NewDebugExecutor("%sdocker create image=%s platform=%s entrypoint=%+q cmd=%+q", logPrefix, cr.input.Image, cr.input.Platform, cr.input.Entrypoint, cr.input.Cmd).
+		NewInfoExecutor("%sdocker create image=%s platform=%s entrypoint=%+q cmd=%+q", logPrefix, cr.input.Image, cr.input.Platform, cr.input.Entrypoint, cr.input.Cmd).
 		Then(
 			common.NewPipelineExecutor(
 				cr.connect(),
@@ -126,13 +126,17 @@ func (cr *containerReference) Start(attach bool) common.Executor {
 		)
 }
 func (cr *containerReference) Pull(forcePull bool) common.Executor {
-	return NewDockerPullExecutor(NewDockerPullExecutorInput{
-		Image:     cr.input.Image,
-		ForcePull: forcePull,
-		Platform:  cr.input.Platform,
-		Username:  cr.input.Username,
-		Password:  cr.input.Password,
-	})
+	return common.
+		NewInfoExecutor("%sdocker pull image=%s platform=%s username=%s forcePull=%t", logPrefix, cr.input.Image, cr.input.Platform, cr.input.Username, forcePull).
+		Then(
+			NewDockerPullExecutor(NewDockerPullExecutorInput{
+				Image:     cr.input.Image,
+				ForcePull: forcePull,
+				Platform:  cr.input.Platform,
+				Username:  cr.input.Username,
+				Password:  cr.input.Password,
+			}),
+		)
 }
 
 func (cr *containerReference) Copy(destPath string, files ...*FileEntry) common.Executor {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -151,7 +151,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.Create(rc.Config.ContainerCapAdd, rc.Config.ContainerCapDrop),
 			rc.JobContainer.Start(false),
 			rc.JobContainer.UpdateFromEnv("/etc/environment", &rc.Env),
-			rc.JobContainer.Exec([]string{"mkdir", "-m", "0777", "-p", ActPath}, rc.Env, "root"),
+			rc.JobContainer.Exec([]string{"mkdir", "-m", "0777", "-p", ActPath}, rc.Env, "root", ""),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".", rc.Config.UseGitIgnore).IfBool(copyWorkspace),
 			rc.JobContainer.Copy(ActPath+"/", &container.FileEntry{
 				Name: "workflow/event.json",
@@ -169,9 +169,10 @@ func (rc *RunContext) startJobContainer() common.Executor {
 		)(ctx)
 	}
 }
-func (rc *RunContext) execJobContainer(cmd []string, env map[string]string) common.Executor {
+
+func (rc *RunContext) execJobContainer(cmd []string, env map[string]string, user, workdir string) common.Executor {
 	return func(ctx context.Context) error {
-		return rc.JobContainer.Exec(cmd, env, "")(ctx)
+		return rc.JobContainer.Exec(cmd, env, user, workdir)(ctx)
 	}
 }
 

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -227,7 +227,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		run = runPrepend + "\n" + run + "\n" + runAppend
 
 		log.Debugf("Wrote command '%s' to '%s'", run, scriptName)
-		containerPath := fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), scriptName)
+		scriptPath := fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), scriptName)
 
 		if step.Shell == "" {
 			step.Shell = rc.Run.Job().Defaults.Run.Shell
@@ -245,8 +245,8 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		}
 
 		for k, v := range finalCMD {
-			if v == "{0}" {
-				finalCMD[k] = strings.Replace(v, "{0}", containerPath, 1)
+			if strings.Contains(v, `{0}`) {
+				finalCMD[k] = strings.Replace(v, `{0}`, scriptPath, 1)
 			}
 		}
 

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -307,6 +307,7 @@ func (sc *StepContext) newStepContainer(ctx context.Context, image string, cmd [
 	})
 	return stepContainer
 }
+
 func (sc *StepContext) runUsesContainer() common.Executor {
 	rc := sc.RunContext
 	step := sc.Step

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -236,12 +236,21 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 			step.Shell = rc.Run.Workflow.Defaults.Run.Shell
 		}
 		scCmd := step.ShellCommand()
-		scResolvedCmd := strings.Replace(scCmd, "{0}", containerPath, 1)
+
+		var finalCMD []string
 		if step.Shell == "pwsh" || step.Shell == "powershell" {
-			sc.Cmd = strings.SplitN(scResolvedCmd, " ", 3)
+			finalCMD = strings.SplitN(scCmd, " ", 3)
 		} else {
-			sc.Cmd = strings.Fields(scResolvedCmd)
+			finalCMD = strings.Fields(scCmd)
 		}
+
+		for k, v := range finalCMD {
+			if v == "{0}" {
+				finalCMD[k] = strings.Replace(v, "{0}", containerPath, 1)
+			}
+		}
+
+		sc.Cmd = finalCMD
 
 		return rc.JobContainer.Copy(rc.Config.ContainerWorkdir(), &container.FileEntry{
 			Name: scriptName,

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -37,7 +37,7 @@ type StepContext struct {
 
 func (sc *StepContext) execJobContainer() common.Executor {
 	return func(ctx context.Context) error {
-		return sc.RunContext.execJobContainer(sc.Cmd, sc.Env)(ctx)
+		return sc.RunContext.execJobContainer(sc.Cmd, sc.Env, "", sc.Step.WorkingDirectory)(ctx)
 	}
 }
 
@@ -195,12 +195,6 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 			step.WorkingDirectory = rc.Run.Workflow.Defaults.Run.WorkingDirectory
 		}
 		step.WorkingDirectory = rc.ExprEval.Interpolate(step.WorkingDirectory)
-		if step.WorkingDirectory != "" {
-			_, err = script.WriteString(fmt.Sprintf("cd %s\n", step.WorkingDirectory))
-			if err != nil {
-				return err
-			}
-		}
 
 		run := rc.ExprEval.Interpolate(step.Run)
 		step.Shell = rc.ExprEval.Interpolate(step.Shell)
@@ -486,7 +480,7 @@ func (sc *StepContext) runAction(actionDir string, actionPath string, localActio
 			}
 			containerArgs := []string{"node", path.Join(containerActionDir, action.Runs.Main)}
 			log.Debugf("executing remote job container: %s", containerArgs)
-			return rc.execJobContainer(containerArgs, sc.Env)(ctx)
+			return rc.execJobContainer(containerArgs, sc.Env, "", "")(ctx)
 		case model.ActionRunsUsingDocker:
 			return sc.execAsDocker(ctx, action, actionName, containerActionDir, actionLocation, rc, step, localAction)
 		case model.ActionRunsUsingComposite:

--- a/pkg/runner/testdata/basic/push.yml
+++ b/pkg/runner/testdata/basic/push.yml
@@ -8,6 +8,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}" ]]'
       - run: echo ${{ env.TEST }} | grep value
       - run: env
       - uses: docker://node:12-buster-slim

--- a/pkg/runner/testdata/dir with spaces/push.yml
+++ b/pkg/runner/testdata/dir with spaces/push.yml
@@ -1,0 +1,7 @@
+---
+jobs:
+  dir-with-spaces:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "$PWD"
+'on': push

--- a/pkg/runner/testdata/workdir/push.yml
+++ b/pkg/runner/testdata/workdir/push.yml
@@ -1,5 +1,8 @@
-name: workdir
 on: push
+
+defaults:
+  run:
+    working-directory: /tmp
 
 jobs:
   workdir:
@@ -9,11 +12,13 @@ jobs:
         working-directory: /root
     steps:
       - run: '[[ "$(pwd)" == "/root" ]]'
+
       - run: mkdir -p "${GITHUB_WORKSPACE}/workdir"
+
       - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}/workdir" ]]'
         working-directory: workdir
 
-  noworkdir:
+  top-level-workdir:
     runs-on: ubuntu-latest
     steps:
-      - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}" ]]'
+      - run: '[[ "$(pwd)" == "/tmp" ]]'

--- a/pkg/runner/testdata/workdir/push.yml
+++ b/pkg/runner/testdata/workdir/push.yml
@@ -4,10 +4,14 @@ on: push
 jobs:
   workdir:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: /root
     steps:
-    - run: mkdir -p "${GITHUB_WORKSPACE}/workdir"
-    - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}/workdir" ]]'
-      working-directory: workdir
+      - run: '[[ "$(pwd)" == "/root" ]]'
+      - run: mkdir -p "${GITHUB_WORKSPACE}/workdir"
+      - run: '[[ "$(pwd)" == "${GITHUB_WORKSPACE}/workdir" ]]'
+        working-directory: workdir
 
   noworkdir:
     runs-on: ubuntu-latest


### PR DESCRIPTION
changelog:
  - `working-directory:` is set through Docker now instead of adding `cd %s` to script
  - workdir cases:
    - if starts `/`, it replaces workdir during that exec
    - if doesn't start with `/`, merge with current workdir
    - if empty, leave it alone and use what has been used before (container workdir)
  - few formatting touches
  - Print Docker executors to `Info` loglevel, when pulling (big) images this should let user know what is currently happening (currently it doesn't show anything about pull without verbose option)
  - Replace pattern to script path **after** command has been re-split for Docker

Fixes https://github.com/nektos/act/issues/211
Fixes https://github.com/nektos/act/issues/748