### PR TITLE
fix: mount volume for workflow info

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -79,6 +79,7 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 
 	mounts := map[string]string{
 		"act-toolcache": "/toolcache",
+		name + "-env":   ActPath,
 	}
 
 	if rc.Config.BindWorkdir {

--- a/pkg/runner/testdata/actions/docker-local/entrypoint.sh
+++ b/pkg/runner/testdata/actions/docker-local/entrypoint.sh
@@ -3,3 +3,5 @@
 echo "Hello $1"
 time=$(date)
 echo ::set-output name=time::$time
+
+echo "SOMEVAR=$1" >>$GITHUB_ENV

--- a/pkg/runner/testdata/local-action-dockerfile/push.yml
+++ b/pkg/runner/testdata/local-action-dockerfile/push.yml
@@ -9,4 +9,5 @@ jobs:
     - uses: ./actions/docker-local
       with:
         who-to-greet: 'Mona the Octocat'
+    - run: '[[ "${{ env.SOMEVAR }}" == "Mona the Octocat" ]]'
     - uses: ./localdockerimagetest_


### PR DESCRIPTION
Mounts volume for `/var/run/act` into master and slave/nested containers from a workflow

fixes https://github.com/nektos/act/issues/747