### PR TITLE
Update Go to 1.17

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -169,6 +169,12 @@ jobs:
         with:
           name: act-windows-i386
           path: dist/act_windows_386/act.exe
+      - name: Capture arm64 (64-bit) Windows binary
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: act-windows-arm64
+          path: dist/act_windows_arm64/act.exe
       - name: Capture armv7 (32-bit) Windows binary
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,9 @@
 name: checks
 on: [pull_request, workflow_dispatch]
 
+env:
+  GO_VERSION: 1.17
+
 jobs:
   lint:
     name: lint
@@ -11,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - uses: golangci/golangci-lint-action@v2
         env:
           CGO_ENABLED: 0
@@ -41,7 +44,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v2
         if: ${{ !env.ACT }}
         with:
@@ -68,7 +71,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v2
         if: ${{ !env.ACT }}
         with:
@@ -111,7 +114,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v2
         if: ${{ !env.ACT }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - v*
 
+env:
+  GO_VERSION: 1.17
+
 jobs:
   release:
     name: release
@@ -14,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v2
         if: ${{ !env.ACT }}
         with:

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
-	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	google.golang.org/genproto v0.0.0-20201117123952-62d171c70ae1 // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1136,8 +1136,12 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
+golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
`go.mod` stays with `1.16` because that's the lowest version which supports `embed` and the goal is to support last 3 minor versions `1.x`
Tests and release are updated to use Go 1.17 to include new Go version improvements