### PR TITLE
Add Act Path

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -19,8 +19,6 @@ import (
 	"github.com/nektos/act/pkg/model"
 )
 
-const ActPath string = "/var/run/act"
-
 // RunContext contains info about current job
 type RunContext struct {
 	Name           string
@@ -36,6 +34,18 @@ type RunContext struct {
 	JobContainer   container.Container
 	OutputMappings map[MappableOutput]MappableOutput
 	JobName        string
+	actPath        string
+}
+
+func (rc *RunContext) SetActPath(actPath string) {
+	rc.actPath = actPath
+}
+
+func (rc *RunContext) GetActPath() string {
+	if len(rc.actPath) > 0 {
+		return rc.actPath
+	}
+	return "/var/run/act"
 }
 
 type MappableOutput struct {
@@ -491,7 +501,7 @@ type githubContext struct {
 func (rc *RunContext) getGithubContext() *githubContext {
 	ghc := &githubContext{
 		Event:            make(map[string]interface{}),
-		EventPath:        ActPath + "/workflow/event.json",
+		EventPath:        rc.GetActPath() + "/workflow/event.json",
 		Workflow:         rc.Run.Workflow.Name,
 		RunID:            rc.Config.Env["GITHUB_RUN_ID"],
 		RunNumber:        rc.Config.Env["GITHUB_RUN_NUMBER"],
@@ -663,8 +673,8 @@ func withDefaultBranch(b string, event map[string]interface{}) map[string]interf
 func (rc *RunContext) withGithubEnv(env map[string]string) map[string]string {
 	github := rc.getGithubContext()
 	env["CI"] = "true"
-	env["GITHUB_ENV"] = ActPath + "/workflow/envs.txt"
-	env["GITHUB_PATH"] = ActPath + "/workflow/paths.txt"
+	env["GITHUB_ENV"] = rc.GetActPath() + "/workflow/envs.txt"
+	env["GITHUB_PATH"] = rc.GetActPath() + "/workflow/paths.txt"
 	env["GITHUB_WORKFLOW"] = github.Workflow
 	env["GITHUB_RUN_ID"] = github.RunID
 	env["GITHUB_RUN_NUMBER"] = github.RunNumber

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -336,6 +336,6 @@ func TestGetGitHubContext(t *testing.T) {
 	assert.Equal(t, ghc.Repository, repo)
 	assert.Equal(t, ghc.RepositoryOwner, owner)
 	assert.Equal(t, ghc.RunnerPerflog, "/dev/null")
-	assert.Equal(t, ghc.EventPath, ActPath+"/workflow/event.json")
+	assert.Equal(t, ghc.EventPath, rc.GetActPath()+"/workflow/event.json")
 	assert.Equal(t, ghc.Token, rc.Config.Secrets["GITHUB_TOKEN"])
 }

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -227,7 +227,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 		run = runPrepend + "\n" + run + "\n" + runAppend
 
 		log.Debugf("Wrote command '%s' to '%s'", run, scriptName)
-		scriptPath := fmt.Sprintf("%s/%s", rc.Config.ContainerWorkdir(), scriptName)
+		scriptPath := fmt.Sprintf("%s/%s", rc.GetActPath(), scriptName)
 
 		if step.Shell == "" {
 			step.Shell = rc.Run.Job().Defaults.Run.Shell
@@ -252,7 +252,7 @@ func (sc *StepContext) setupShellCommand() common.Executor {
 
 		sc.Cmd = finalCMD
 
-		return rc.JobContainer.Copy(rc.Config.ContainerWorkdir(), &container.FileEntry{
+		return rc.JobContainer.Copy(rc.GetActPath(), &container.FileEntry{
 			Name: scriptName,
 			Mode: 0755,
 			Body: script.String(),
@@ -437,7 +437,7 @@ func (sc *StepContext) getContainerActionPaths(step *model.Step, actionDir strin
 		actionName = "./" + actionName
 	} else if step.Type() == model.StepTypeUsesActionRemote {
 		actionName = getOsSafeRelativePath(actionDir, rc.ActionCacheDir())
-		containerActionDir = ActPath + "/actions/" + actionName
+		containerActionDir = rc.GetActPath() + "/actions/" + actionName
 	}
 
 	if actionName == "" {


### PR DESCRIPTION
Please make actpath relocatable, I need this for my hostexecutor mode. I'm working on merging my whole fork back to nektos/act.
On windows `/var/run/act` cannot even be created, this make it more dynamic.

Also this moves run scripts to actpath away from your workspace.