### PR TITLE
Remove ubuntu-16.04 and add missing links for nix/go

### DIFF
--- a/IMAGES.md
+++ b/IMAGES.md
@@ -8,12 +8,10 @@
 
 **Note 2: `node` `-slim` images don't have `python` installed, if you want to use actions or software that is depending on `python`, you need to specify image manually**
 
-| Image                                | Size                                                     |
-| ------------------------------------ | -------------------------------------------------------- |
-| [`node:12-buster`][hub/_/node]       | ![`buster-size`][hub/_/node/12-buster/size]              |
-| [`node:12-buster-slim`][hub/_/node]  | ![`micro-buster-size`][hub/_/node/12-buster-slim/size]   |
-| [`node:12-stretch`][hub/_/node]      | ![`stretch-size`][hub/_/node/12-stretch/size]            |
-| [`node:12-stretch-slim`][hub/_/node] | ![`micro-stretch-size`][hub/_/node/12-stretch-slim/size] |
+| Image                               | Size                                                   |
+| ----------------------------------- | ------------------------------------------------------ |
+| [`node:12-buster`][hub/_/node]      | ![`buster-size`][hub/_/node/12-buster/size]            |
+| [`node:12-buster-slim`][hub/_/node] | ![`micro-buster-size`][hub/_/node/12-buster-slim/size] |
 
 **Note: `catthehacker/ubuntu` images are based on Ubuntu root filesystem**
 
@@ -46,8 +44,6 @@ Feel free to make a pull request with your image added here
 [hub/_/node]: https://hub.docker.com/r/_/node
 [hub/_/node/12-buster/size]: https://img.shields.io/docker/image-size/_/node/12-buster
 [hub/_/node/12-buster-slim/size]: https://img.shields.io/docker/image-size/_/node/12-buster-slim
-[hub/_/node/12-stretch/size]: https://img.shields.io/docker/image-size/_/node/12-stretch
-[hub/_/node/12-stretch-slim/size]: https://img.shields.io/docker/image-size/_/node/12-stretch-slim
 [ghcr/catthehacker/ubuntu]: https://github.com/catthehacker/docker_images/pkgs/container/ubuntu
 [hub/nektos/act-environments-ubuntu]: https://hub.docker.com/r/nektos/act-environments-ubuntu
 [hub/nektos/act-environments-ubuntu/18.04/size]: https://img.shields.io/docker/image-size/nektos/act-environments-ubuntu/18.04

--- a/README.md
+++ b/README.md
@@ -238,12 +238,7 @@ GitHub Actions offers managed [virtual environments](https://help.github.com/en/
 [micro]: https://hub.docker.com/_/buildpack-deps
 [docker_images]: https://github.com/catthehacker/docker_images
 
-Below platforms are currently **unsupported and won't work** (see issue [#97](https://github.com/nektos/act/issues/97))
-
-- `windows-latest`
-- `windows-2019`
-- `macos-latest`
-- `macos-10.15`
+Windows and macOS based platforms are currently **unsupported and won't work** (see issue [#97](https://github.com/nektos/act/issues/97))
 
 ## Please see [IMAGES.md](./IMAGES.md) for more information about the Docker images that can be used with `act`
 

--- a/README.md
+++ b/README.md
@@ -227,12 +227,11 @@ export DOCKER_HOST=$(docker context inspect --format '{{.Endpoints.docker.Host}}
 
 GitHub Actions offers managed [virtual environments](https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners) for running workflows. In order for `act` to run your workflows locally, it must run a container for the runner defined in your workflow file. Here are the images that `act` uses for each runner type and size:
 
-| GitHub Runner   | Micro Docker Image              | Medium Docker Image                                       | Large Docker Image                                         |
-| --------------- | ------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------- |
-| `ubuntu-latest` | [`node:12-buster-slim`][micro]  | [`ghcr.io/catthehacker/ubuntu:act-latest`][docker_images] | [`ghcr.io/catthehacker/ubuntu:full-latest`][docker_images] |
-| `ubuntu-20.04`  | [`node:12-buster-slim`][micro]  | [`ghcr.io/catthehacker/ubuntu:act-20.04`][docker_images]  | [`ghcr.io/catthehacker/ubuntu:full-20.04`][docker_images]  |
-| `ubuntu-18.04`  | [`node:12-buster-slim`][micro]  | [`ghcr.io/catthehacker/ubuntu:act-18.04`][docker_images]  | [`ghcr.io/catthehacker/ubuntu:full-18.04`][docker_images]  |
-| `ubuntu-16.04`  | [`node:12-stretch-slim`][micro] | [`ghcr.io/catthehacker/ubuntu:act-16.04`][docker_images]  | `unavailable`                                              |
+| GitHub Runner   | Micro Docker Image             | Medium Docker Image                                       | Large Docker Image                                         |
+| --------------- | ------------------------------ | --------------------------------------------------------- | ---------------------------------------------------------- |
+| `ubuntu-latest` | [`node:12-buster-slim`][micro] | [`ghcr.io/catthehacker/ubuntu:act-latest`][docker_images] | [`ghcr.io/catthehacker/ubuntu:full-latest`][docker_images] |
+| `ubuntu-20.04`  | [`node:12-buster-slim`][micro] | [`ghcr.io/catthehacker/ubuntu:act-20.04`][docker_images]  | [`ghcr.io/catthehacker/ubuntu:full-20.04`][docker_images]  |
+| `ubuntu-18.04`  | [`node:12-buster-slim`][micro] | [`ghcr.io/catthehacker/ubuntu:act-18.04`][docker_images]  | [`ghcr.io/catthehacker/ubuntu:full-18.04`][docker_images]  |
 
 [micro]: https://hub.docker.com/_/buildpack-deps
 [docker_images]: https://github.com/catthehacker/docker_images

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ scoop install act
 yay -S act
 ```
 
-### Nix (Linux/macOS)
+### [Nix](https://nixos.org) (Linux/macOS)
+
+[Nix recipe](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/misc/act/default.nix)
 
 Global install:
 
@@ -85,7 +87,7 @@ or through `nix-shell`:
 nix-shell -p act
 ```
 
-### Go (Linux/Windows/macOS/any other platform supported by Go)
+### [Go](https://golang.org) (Linux/Windows/macOS/any other platform supported by Go)
 
 If you have Go 1.16+, you can install latest released version of `act` directly from source by running:
 

--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -9,7 +9,6 @@ func (i *Input) newPlatforms() map[string]string {
 		"ubuntu-latest":  "node:12-buster-slim",
 		"ubuntu-20.04":   "node:12-buster-slim",
 		"ubuntu-18.04":   "node:12-buster-slim",
-		"ubuntu-16.04":   "node:12-stretch-slim",
 		"windows-latest": "",
 		"windows-2019":   "",
 		"macos-latest":   "",

--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -6,13 +6,9 @@ import (
 
 func (i *Input) newPlatforms() map[string]string {
 	platforms := map[string]string{
-		"ubuntu-latest":  "node:12-buster-slim",
-		"ubuntu-20.04":   "node:12-buster-slim",
-		"ubuntu-18.04":   "node:12-buster-slim",
-		"windows-latest": "",
-		"windows-2019":   "",
-		"macos-latest":   "",
-		"macos-10.15":    "",
+		"ubuntu-latest": "node:12-buster-slim",
+		"ubuntu-20.04":  "node:12-buster-slim",
+		"ubuntu-18.04":  "node:12-buster-slim",
 	}
 
 	for _, p := range i.platforms {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -310,9 +310,9 @@ func defaultImageSurvey(actrc string) error {
 	case "Large":
 		option = "-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:full-latest\n-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:full-20.04\n-P ubuntu-18.04=ghcr.io/catthehacker/ubuntu:full-18.04\n"
 	case "Medium":
-		option = "-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest\n-P ubuntu-20.04=ghcr.io/catthehacker/ubuntu:act-20.04\n-P ubuntu-18.04=ghcr.io/catthehacker/ubuntu:act-18.04\n-P ubuntu-16.04=ghcr.io/catthehacker/ubuntu:act-16.04\n"
+		option = "-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest\n-P ubuntu-20.04=ghcr.io/catthehacker/ubuntu:act-20.04\n-P ubuntu-18.04=ghcr.io/catthehacker/ubuntu:act-18.04\n"
 	case "Micro":
-		option = "-P ubuntu-latest=node:12-buster-slim\n-P ubuntu-20.04=node:12-buster-slim\n-P ubuntu-18.04=node:12-buster-slim\n-P ubuntu-16.04=node:12-stretch-slim\n"
+		option = "-P ubuntu-latest=node:12-buster-slim\n-P ubuntu-20.04=node:12-buster-slim\n-P ubuntu-18.04=node:12-buster-slim\n"
 	}
 
 	f, err := os.Create(actrc)


### PR DESCRIPTION
Fixes #645 

GitHub removes `ubuntu-16.04` environment since it reached standard EOL.

We will follow that change and remove default images for `ubuntu-16.04` but it doesn't prevent users from using that platform.

To still use `ubuntu-16.04`, apart from being defined in workflow, it has to be specified via `-P`/`--platform` flags, e.g.:

```sh
act -P ubuntu-16.04=ghcr.io/catthehacker/ubuntu:act-16.04
```

`.actrc`:

```
-P ubuntu-16.04=node:12-stretch-slim
```

I'm not planning on removing Ubuntu 16.04 images, but they will eventually stop receiving updates so I advise on migrating to newer Ubuntu.

---
`fix: remove specific platform versions`: remove mention of specific versions to remove confusion since platforms such as `macos-11` or `windows-2022`, `windows-2016` exist

Platforms still will be properly inferred from workflow and `README.md` mentions about macOS and Windows

```
  ~/go/src/github.com/nektos/act cat/fix/remove-ubuntu-16.04 *14 ❯ go run main.go -W .github/workflows/test-windows.yml                                12:20:27 PM
[test-windows.yml/test] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
  ~/go/src/github.com/nektos/act cat/fix/remove-ubuntu-16.04 *14 ❯ go run main.go -W .github/workflows/test-windows.yml                                12:21:46 PM
[test-windows.yml/test] 🚧  Skipping unsupported platform -- Try running with `-P windows-2016=...`
  ~/go/src/github.com/nektos/act cat/fix/remove-ubuntu-16.04 *14 ❯
```