### PR TITLE
fix: continue jobs + steps after failure

### DIFF
--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -7,6 +7,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type errorContextKey string
+
+const ErrorContextKeyVal = errorContextKey("error")
+
 // Warning that implements `error` but safe to ignore
 type Warning struct {
 	Message string
@@ -136,13 +140,12 @@ func (e Executor) Then(then Executor) Executor {
 			case Warning:
 				log.Warning(err.Error())
 			default:
-				log.Debugf("%+v", err)
-				return err
+				ctx = context.WithValue(ctx, ErrorContextKeyVal, err)
 			}
+		} else if ctx.Err() != nil {
+			ctx = context.WithValue(ctx, ErrorContextKeyVal, ctx.Err())
 		}
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
+
 		return then(ctx)
 	}
 }

--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -7,10 +7,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type errorContextKey string
-
-const ErrorContextKeyVal = errorContextKey("error")
-
 // Warning that implements `error` but safe to ignore
 type Warning struct {
 	Message string
@@ -140,10 +136,10 @@ func (e Executor) Then(then Executor) Executor {
 			case Warning:
 				log.Warning(err.Error())
 			default:
-				ctx = context.WithValue(ctx, ErrorContextKeyVal, err)
+				SetJobError(ctx, err)
 			}
 		} else if ctx.Err() != nil {
-			ctx = context.WithValue(ctx, ErrorContextKeyVal, ctx.Err())
+			SetJobError(ctx, ctx.Err())
 		}
 
 		return then(ctx)

--- a/pkg/common/job_error.go
+++ b/pkg/common/job_error.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"context"
+)
+
+type jobErrorContextKey string
+
+const jobErrorContextKeyVal = jobErrorContextKey("job.error")
+
+// JobError returns the job error for current context if any
+func JobError(ctx context.Context) error {
+	val := ctx.Value(jobErrorContextKeyVal)
+	if val != nil {
+		if container, ok := val.(map[string]error); ok {
+			return container["error"]
+		}
+	}
+	return nil
+}
+
+func SetJobError(ctx context.Context, err error) {
+	ctx.Value(jobErrorContextKeyVal).(map[string]error)["error"] = err
+}
+
+// WithJobErrorContainer adds a value to the context as a container for an error
+func WithJobErrorContainer(ctx context.Context) context.Context {
+	container := map[string]error{}
+	return context.WithValue(ctx, jobErrorContextKeyVal, container)
+}

--- a/pkg/model/planner.go
+++ b/pkg/model/planner.go
@@ -78,6 +78,9 @@ func FixIfStatement(content []byte, wr *Workflow) error {
 			if err != nil {
 				return err
 			}
+			if val == "" {
+				val = "success()"
+			}
 			jobs[j].Steps[i].If.Value = val
 		}
 	}

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -434,6 +434,9 @@ func (w *Workflow) GetJob(jobID string) *Job {
 			if j.Name == "" {
 				j.Name = id
 			}
+			if j.If.Value == "" {
+				j.If.Value = "success()"
+			}
 			return j
 		}
 	}

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -69,6 +69,7 @@ type Job struct {
 	RawContainer   yaml.Node                 `yaml:"container"`
 	Defaults       Defaults                  `yaml:"defaults"`
 	Outputs        map[string]string         `yaml:"outputs"`
+	Result         string
 }
 
 // Strategy for the job

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -381,7 +381,7 @@ func (rc *RunContext) vmSuccess() func(*otto.Otto) {
 	return func(vm *otto.Otto) {
 		_ = vm.Set("success", func() bool {
 			jobs := rc.Run.Workflow.Jobs
-			jobNeeds := rc.Run.Job().Needs()
+			jobNeeds := rc.getNeedsTransitive(rc.Run.Job())
 
 			for _, needs := range jobNeeds {
 				if jobs[needs].Result != "success" {
@@ -398,7 +398,7 @@ func (rc *RunContext) vmFailure() func(*otto.Otto) {
 	return func(vm *otto.Otto) {
 		_ = vm.Set("failure", func() bool {
 			jobs := rc.Run.Workflow.Jobs
-			jobNeeds := rc.Run.Job().Needs()
+			jobNeeds := rc.getNeedsTransitive(rc.Run.Job())
 
 			for _, needs := range jobNeeds {
 				if jobs[needs].Result == "failure" {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -524,6 +524,17 @@ func (rc *RunContext) getStepsContext() map[string]*stepResult {
 	return rc.StepResults
 }
 
+func (rc *RunContext) getNeedsTransitive(job *model.Job) []string {
+	needs := job.Needs()
+
+	for _, need := range needs {
+		parentNeeds := rc.getNeedsTransitive(rc.Run.Workflow.GetJob(need))
+		needs = append(needs, parentNeeds...)
+	}
+
+	return needs
+}
+
 type githubContext struct {
 	Event            map[string]interface{} `json:"event"`
 	EventPath        string                 `json:"event_path"`

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -322,15 +322,9 @@ func (rc *RunContext) newStepExecutor(step *model.Step) common.Executor {
 			Conclusion: stepStatusSuccess,
 			Outputs:    make(map[string]string),
 		}
-		runStep, err := EvalBool(sc.NewExpressionEvaluator(), sc.Step.If.Value)
 
+		runStep, err := sc.isEnabled(ctx)
 		if err != nil {
-			common.Logger(ctx).Errorf("  \u274C  Error in if: expression - %s", sc.Step)
-			exprEval, err := sc.setupEnv(ctx)
-			if err != nil {
-				return err
-			}
-			rc.ExprEval = exprEval
 			rc.StepResults[rc.CurrentStep].Conclusion = stepStatusFailure
 			rc.StepResults[rc.CurrentStep].Outcome = stepStatusFailure
 			return err

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -294,8 +294,8 @@ func (rc *RunContext) Executor() common.Executor {
 		}
 
 		rc.Run.Job().Result = "success"
-		_, ok := ctx.Value(common.ErrorContextKeyVal).(error)
-		if ok {
+		jobError := common.JobError(ctx)
+		if jobError != nil {
 			rc.Run.Job().Result = "failure"
 		}
 

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -343,4 +344,139 @@ func TestGetGitHubContext(t *testing.T) {
 	assert.Equal(t, ghc.RunnerPerflog, "/dev/null")
 	assert.Equal(t, ghc.EventPath, ActPath+"/workflow/event.json")
 	assert.Equal(t, ghc.Token, rc.Config.Secrets["GITHUB_TOKEN"])
+}
+
+func createIfTestRunContext(jobs map[string]*model.Job) *RunContext {
+	rc := &RunContext{
+		Config: &Config{
+			Workdir: ".",
+			Platforms: map[string]string{
+				"ubuntu-latest": "ubuntu-latest",
+			},
+		},
+		Env: map[string]string{},
+		Run: &model.Run{
+			JobID: "job1",
+			Workflow: &model.Workflow{
+				Name: "test-workflow",
+				Jobs: jobs,
+			},
+		},
+	}
+	rc.ExprEval = rc.NewExpressionEvaluator()
+
+	return rc
+}
+
+func createJob(t *testing.T, input string, result string) *model.Job {
+	var job *model.Job
+	err := yaml.Unmarshal([]byte(input), &job)
+	assert.NoError(t, err)
+	job.Result = result
+
+	return job
+}
+
+func TestRunContextIsEnabled(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	assertObject := assert.New(t)
+
+	// success()
+	rc := createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest
+if: success()`, ""),
+	})
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "failure"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+needs: [job1]
+if: success()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.False(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "success"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+needs: [job1]
+if: success()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "failure"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+if: success()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	// failure()
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest
+if: failure()`, ""),
+	})
+	assertObject.False(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "failure"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+needs: [job1]
+if: failure()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "success"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+needs: [job1]
+if: failure()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.False(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "failure"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+if: failure()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.False(rc.isEnabled(context.Background()))
+
+	// always()
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest
+if: always()`, ""),
+	})
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "failure"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+needs: [job1]
+if: always()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "success"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+needs: [job1]
+if: always()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, "success"),
+		"job2": createJob(t, `runs-on: ubuntu-latest
+if: always()`, ""),
+	})
+	rc.Run.JobID = "job2"
+	assertObject.True(rc.isEnabled(context.Background()))
 }

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -153,7 +153,7 @@ func TestRunContext_EvalBool(t *testing.T) {
 		t.Run(table.in, func(t *testing.T) {
 			assertObject := assert.New(t)
 			defer hook.Reset()
-			b, err := rc.EvalBool(table.in)
+			b, err := EvalBool(rc.ExprEval, table.in)
 			if table.wantErr {
 				assertObject.Error(err)
 			}

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -179,7 +179,7 @@ func updateTestIfWorkflow(t *testing.T, tables []struct {
 	for _, k := range keys {
 		envs += fmt.Sprintf("  %s: %s\n", k, rc.Env[k])
 	}
-
+	// editorconfig-checker-disable
 	workflow := fmt.Sprintf(`
 name: "Test what expressions result in true and false on GitHub"
 on: push
@@ -192,6 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 `, envs)
+	// editorconfig-checker-enable
 
 	for i, table := range tables {
 		if table.wantErr || strings.HasPrefix(table.in, "github.actor") {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -167,16 +166,20 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 		}
 	}
 
-	return common.NewPipelineExecutor(pipeline...).Then(func(ctx context.Context) error {
+	return common.NewPipelineExecutor(pipeline...).Then(handleFailure(plan))
+}
+
+func handleFailure(plan *model.Plan) common.Executor {
+	return func(ctx context.Context) error {
 		for _, stage := range plan.Stages {
 			for _, run := range stage.Runs {
 				if run.Job().Result == "failure" {
-					return errors.New(fmt.Sprintf("Job '%s' failed", run.String()))
+					return fmt.Errorf("Job '%s' failed", run.String())
 				}
 			}
 		}
 		return nil
-	})
+	}
 }
 
 func (runner *runnerImpl) newRunContext(run *model.Run, matrix map[string]interface{}) *RunContext {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -154,7 +154,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 						}
 
 						return nil
-					})(WithJobLogger(ctx, jobName, rc.Config.Secrets, rc.Config.InsecureSecrets))
+					})(common.WithJobErrorContainer(WithJobLogger(ctx, jobName, rc.Config.Secrets, rc.Config.InsecureSecrets)))
 				})
 				b++
 				if b == maxParallel {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -123,6 +123,7 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "outputs", "push", "", platforms, ""},
 		{"testdata", "steps-context/conclusion", "push", "", platforms, ""},
 		{"testdata", "steps-context/outcome", "push", "", platforms, ""},
+		{"testdata", "job-status-check", "push", "job 'fail' failed", platforms, ""},
 		{"../model/testdata", "strategy", "push", "", platforms, ""}, // TODO: move all testdata into pkg so we can validate it with planner and runner
 		// {"testdata", "issue-228", "push", "", platforms, ""}, // TODO [igni]: Remove this once everything passes
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -124,6 +124,7 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "steps-context/conclusion", "push", "", platforms, ""},
 		{"testdata", "steps-context/outcome", "push", "", platforms, ""},
 		{"testdata", "job-status-check", "push", "job 'fail' failed", platforms, ""},
+		{"testdata", "if-expressions", "push", "Job 'mytest' failed", platforms, ""},
 		{"../model/testdata", "strategy", "push", "", platforms, ""}, // TODO: move all testdata into pkg so we can validate it with planner and runner
 		// {"testdata", "issue-228", "push", "", platforms, ""}, // TODO [igni]: Remove this once everything passes
 

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -145,6 +145,21 @@ func (sc *StepContext) interpolateEnv(exprEval ExpressionEvaluator) {
 	}
 }
 
+func (sc *StepContext) isEnabled(ctx context.Context) (bool, error) {
+	runStep, err := EvalBool(sc.NewExpressionEvaluator(), sc.Step.If.Value)
+	if err != nil {
+		common.Logger(ctx).Errorf("  \u274C  Error in if: expression - %s", sc.Step)
+		exprEval, err := sc.setupEnv(ctx)
+		if err != nil {
+			return false, err
+		}
+		sc.RunContext.ExprEval = exprEval
+		return false, err
+	}
+
+	return runStep, nil
+}
+
 func (sc *StepContext) setupEnv(ctx context.Context) (ExpressionEvaluator, error) {
 	rc := sc.RunContext
 	sc.Env = sc.mergeEnv()

--- a/pkg/runner/step_context_test.go
+++ b/pkg/runner/step_context_test.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/model"
 )
 
 func TestStepContextExecutor(t *testing.T) {
@@ -26,4 +31,86 @@ func TestStepContextExecutor(t *testing.T) {
 	for _, table := range tables {
 		runTestJobFile(ctx, t, table)
 	}
+}
+
+func createIfTestStepContext(t *testing.T, input string) *StepContext {
+	var step *model.Step
+	err := yaml.Unmarshal([]byte(input), &step)
+	assert.NoError(t, err)
+
+	return &StepContext{
+		RunContext: &RunContext{
+			Config: &Config{
+				Workdir: ".",
+				Platforms: map[string]string{
+					"ubuntu-latest": "ubuntu-latest",
+				},
+			},
+			StepResults: map[string]*stepResult{},
+			Env:         map[string]string{},
+			Run: &model.Run{
+				JobID: "job1",
+				Workflow: &model.Workflow{
+					Name: "workflow1",
+					Jobs: map[string]*model.Job{
+						"job1": createJob(t, `runs-on: ubuntu-latest`, ""),
+					},
+				},
+			},
+		},
+		Step: step,
+	}
+}
+
+func TestStepContextIsEnabled(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	assertObject := assert.New(t)
+
+	// success()
+	sc := createIfTestStepContext(t, "if: success()")
+	assertObject.True(sc.isEnabled(context.Background()))
+
+	sc = createIfTestStepContext(t, "if: success()")
+	sc.RunContext.StepResults["a"] = &stepResult{
+		Conclusion: stepStatusSuccess,
+	}
+	assertObject.True(sc.isEnabled(context.Background()))
+
+	sc = createIfTestStepContext(t, "if: success()")
+	sc.RunContext.StepResults["a"] = &stepResult{
+		Conclusion: stepStatusFailure,
+	}
+	assertObject.False(sc.isEnabled(context.Background()))
+
+	// failure()
+	sc = createIfTestStepContext(t, "if: failure()")
+	assertObject.False(sc.isEnabled(context.Background()))
+
+	sc = createIfTestStepContext(t, "if: failure()")
+	sc.RunContext.StepResults["a"] = &stepResult{
+		Conclusion: stepStatusSuccess,
+	}
+	assertObject.False(sc.isEnabled(context.Background()))
+
+	sc = createIfTestStepContext(t, "if: failure()")
+	sc.RunContext.StepResults["a"] = &stepResult{
+		Conclusion: stepStatusFailure,
+	}
+	assertObject.True(sc.isEnabled(context.Background()))
+
+	// always()
+	sc = createIfTestStepContext(t, "if: always()")
+	assertObject.True(sc.isEnabled(context.Background()))
+
+	sc = createIfTestStepContext(t, "if: always()")
+	sc.RunContext.StepResults["a"] = &stepResult{
+		Conclusion: stepStatusSuccess,
+	}
+	assertObject.True(sc.isEnabled(context.Background()))
+
+	sc = createIfTestStepContext(t, "if: always()")
+	sc.RunContext.StepResults["a"] = &stepResult{
+		Conclusion: stepStatusFailure,
+	}
+	assertObject.True(sc.isEnabled(context.Background()))
 }

--- a/pkg/runner/testdata/if-expressions/push.yml
+++ b/pkg/runner/testdata/if-expressions/push.yml
@@ -1,0 +1,29 @@
+on: push
+jobs:
+  mytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # - run: exit 1
+      - uses: ./
+        if: failure()
+      - run: echo Success
+        shell: bash
+      - run: echo Success
+        if: success()
+        shell: bash
+      - run: exit 1
+        shell: bash
+      - run: echo "Shouldn't run"
+        if: success()
+        shell: bash
+      - run: echo "Shouldn't run2"
+        shell: bash
+      - run: echo expected to run
+        if: failure()
+        shell: bash
+  next:
+    needs: mytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2

--- a/pkg/runner/testdata/job-status-check/push.yml
+++ b/pkg/runner/testdata/job-status-check/push.yml
@@ -1,0 +1,28 @@
+on: push
+jobs:
+  fail:
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit 1
+  suc1:
+    if: success() || failure()
+    needs:
+    - fail
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit 0
+  suc2:
+    if: success() || failure()
+    needs:
+    - fail
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit 0
+  next:
+    needs:
+    - suc1
+    - suc2
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo should never reach here
+    - run: exit 1


### PR DESCRIPTION
To allow proper if expression handling on jobs and steps (like always,
success, failure, ...) we need to continue running all executors in
the prepared chain.
To keep the error handling intact we add an occurred error to the
go context and handle it later in the pipeline/chain.

Also we add the job result to the needs context to give expressions
access to it.
The needs object, failure and success functions are split between
run context (on jobs) and step context.

Closes #442
