### PR TITLE
Update homebrew-based installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you are using Linux, you will need to [install Docker Engine](https://docs.do
 [![homebrew version](https://img.shields.io/homebrew/v/act)](https://github.com/nektos/homebrew-tap/blob/master/Formula/act.rb)
 
 ```shell
-brew install act
+brew install act --HEAD
 ```
 
 ### [MacPorts](https://www.macports.org) (macOS)


### PR DESCRIPTION
The current release fails on a fairly common config (`strategy[].fail-fast: true`) and the [recommended](https://github.com/nektos/act/issues/811#issuecomment-945182745) method of installation is to install from source.

Refs #811