### PR TITLE
Fixes

### DIFF
--- a/pkg/container/docker_build.go
+++ b/pkg/container/docker_build.go
@@ -29,7 +29,11 @@ type NewDockerBuildExecutorInput struct {
 func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
-		logger.Infof("%sdocker build -t %s --platform %s %s", logPrefix, input.ImageTag, input.Platform, input.ContextDir)
+		if input.Platform != "" {
+			logger.Infof("%sdocker build -t %s --platform %s %s", logPrefix, input.ImageTag, input.Platform, input.ContextDir)
+		} else {
+			logger.Infof("%sdocker build -t %s %s", logPrefix, input.ImageTag, input.ContextDir)
+		}
 		if common.Dryrun(ctx) {
 			return nil
 		}

--- a/pkg/container/docker_logger.go
+++ b/pkg/container/docker_logger.go
@@ -116,7 +116,7 @@ func logDockerResponse(logger logrus.FieldLogger, dockerResponse io.ReadCloser, 
 				writeLog(logger, isError, "%s :: %s\n", msg.Status, msg.ID)
 			}
 		} else if msg.Stream != "" {
-			writeLog(logger, isError, msg.Stream)
+			writeLog(logger, isError, "%s", msg.Stream)
 		} else {
 			writeLog(logger, false, "Unable to handle line: %s", string(line))
 		}


### PR DESCRIPTION
I was getting output like this:
```
[choco/choco] Filesystem      Size  Used Avail Use%!M(MISSING)ounted on
overlay          59G  9.0G   47G  17%!/(MISSING)
tmpfs            64M     0   64M   0%!/(MISSING)dev
tmpfs           993M     0  993M   0%!/(MISSING)sys/fs/cgroup
shm              64M     0   64M   0%!/(MISSING)dev/shm
/dev/vda1        59G  9.0G   47G  17%!/(MISSING)etc/hosts
tmpfs           993M     0  993M   0%!/(MISSING)proc/acpi
tmpfs           993M     0  993M   0%!/(MISSING)sys/firmware
```
Which was very confusing.

Also output like this:
```
[choco/choco]  🐳  docker build -t act-github-actions-choco-dockeraction:latest --platform  /Users/jsoref/code/nektos/act/.github/actions/choco
[choco/choco] RBuilding image from '/Users/jsoref/code/nektos/act/.github/actions/choco'
[choco/choco] RCreating image from context dir '/Users/jsoref/code/nektos/act/.github/actions/choco' with tag 'act-github-actions-choco-dockeraction:latest' and platform ''
```