### PR TITLE
feat: allow existing logger from context

### DIFF
--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -47,7 +47,14 @@ func WithJobLogger(ctx context.Context, jobName string, secrets map[string]strin
 	formatter.insecureSecrets = insecureSecrets
 	nextColor++
 
-	logger := logrus.New()
+	var logger *logrus.Logger
+	fieldLogger := common.Logger(ctx)
+	if fieldLogger != nil {
+		logger = fieldLogger.(*logrus.Logger)
+	}
+	if logger == nil {
+		logger = logrus.New()
+	}
 	logger.SetFormatter(formatter)
 	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logrus.GetLevel())


### PR DESCRIPTION
We should reuse an existing context logger if available.
This will allow test to setup act with a null logger to assert log messages.
