### PR TITLE
fix: use docker lib for image ref parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/containerd/containerd v1.5.5 // indirect
 	github.com/containerd/continuity v0.2.0 // indirect
 	github.com/docker/cli v20.10.10+incompatible
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.10+incompatible
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2

--- a/pkg/container/docker_pull.go
+++ b/pkg/container/docker_pull.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
-	"strings"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -99,12 +98,11 @@ func getImagePullOptions(ctx context.Context, input NewDockerPullExecutorInput) 
 }
 
 func cleanImage(image string) string {
-	imageParts := len(strings.Split(image, "/"))
-	if imageParts == 1 {
-		image = fmt.Sprintf("docker.io/library/%s", image)
-	} else if imageParts == 2 {
-		image = fmt.Sprintf("docker.io/%s", image)
+	ref, err := reference.ParseAnyReference(image)
+	if err != nil {
+		log.Error(err)
+		return ""
 	}
 
-	return image
+	return ref.String()
 }

--- a/pkg/container/docker_pull_test.go
+++ b/pkg/container/docker_pull_test.go
@@ -18,6 +18,9 @@ func TestCleanImage(t *testing.T) {
 		imageOut string
 	}{
 		{"myhost.com/foo/bar", "myhost.com/foo/bar"},
+		{"localhost:8000/canonical/ubuntu", "localhost:8000/canonical/ubuntu"},
+		{"localhost/canonical/ubuntu:latest", "localhost/canonical/ubuntu:latest"},
+		{"localhost:8000/canonical/ubuntu:latest", "localhost:8000/canonical/ubuntu:latest"},
 		{"ubuntu", "docker.io/library/ubuntu"},
 		{"ubuntu:18.04", "docker.io/library/ubuntu:18.04"},
 		{"cibuilds/hugo:0.53", "docker.io/cibuilds/hugo:0.53"},


### PR DESCRIPTION
Fixes #795

The only downside is custom URL can't be, e.g.: `localhost:8000/_/ubuntu:latest`

Signed-off-by: hackercat <me@hackerc.at>