### PR TITLE
Add more steps context support

### DIFF
--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -466,9 +466,19 @@ func (rc *RunContext) vmJob() func(*otto.Otto) {
 }
 
 func (rc *RunContext) vmSteps() func(*otto.Otto) {
-	steps := rc.getStepsContext()
+	ctxSteps := rc.getStepsContext()
+
+	steps := make(map[string]interface{})
+	for id, ctxStep := range ctxSteps {
+		steps[id] = map[string]interface{}{
+			"conclusion": ctxStep.Conclusion.String(),
+			"outcome":    ctxStep.Outcome.String(),
+			"outputs":    ctxStep.Outputs,
+		}
+	}
 
 	return func(vm *otto.Otto) {
+		log.Debugf("context steps => %v", steps)
 		_ = vm.Set("steps", steps)
 	}
 }

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -50,21 +50,21 @@ func TestEvaluate(t *testing.T) {
 		StepResults: map[string]*stepResult{
 			"idwithnothing": {
 				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusSuccess,
+				Outcome:    stepStatusFailure,
 				Outputs: map[string]string{
 					"foowithnothing": "barwithnothing",
 				},
 			},
 			"id-with-hyphens": {
 				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusSuccess,
+				Outcome:    stepStatusFailure,
 				Outputs: map[string]string{
 					"foo-with-hyphens": "bar-with-hyphens",
 				},
 			},
 			"id_with_underscores": {
 				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusSuccess,
+				Outcome:    stepStatusFailure,
 				Outputs: map[string]string{
 					"foo_with_underscores": "bar_with_underscores",
 				},
@@ -110,8 +110,14 @@ func TestEvaluate(t *testing.T) {
 		{"github.run_id", "1", ""},
 		{"github.run_number", "1", ""},
 		{"job.status", "success", ""},
+		{"steps.idwithnothing.conclusion", "success", ""},
+		{"steps.idwithnothing.outcome", "failure", ""},
 		{"steps.idwithnothing.outputs.foowithnothing", "barwithnothing", ""},
+		{"steps.id-with-hyphens.conclusion", "success", ""},
+		{"steps.id-with-hyphens.outcome", "failure", ""},
 		{"steps.id-with-hyphens.outputs.foo-with-hyphens", "bar-with-hyphens", ""},
+		{"steps.id_with_underscores.conclusion", "success", ""},
+		{"steps.id_with_underscores.outcome", "failure", ""},
 		{"steps.id_with_underscores.outputs.foo_with_underscores", "bar_with_underscores", ""},
 		{"runner.os", "Linux", ""},
 		{"matrix.os", "Linux", ""},

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -49,22 +49,25 @@ func TestEvaluate(t *testing.T) {
 		},
 		StepResults: map[string]*stepResult{
 			"idwithnothing": {
+				Conclusion: stepStatusSuccess,
+				Outcome:    stepStatusSuccess,
 				Outputs: map[string]string{
 					"foowithnothing": "barwithnothing",
 				},
-				Success: true,
 			},
 			"id-with-hyphens": {
+				Conclusion: stepStatusSuccess,
+				Outcome:    stepStatusSuccess,
 				Outputs: map[string]string{
 					"foo-with-hyphens": "bar-with-hyphens",
 				},
-				Success: true,
 			},
 			"id_with_underscores": {
+				Conclusion: stepStatusSuccess,
+				Outcome:    stepStatusSuccess,
 				Outputs: map[string]string{
 					"foo_with_underscores": "bar_with_underscores",
 				},
-				Success: true,
 			},
 		},
 	}

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -54,10 +54,11 @@ func TestRunContext_EvalBool(t *testing.T) {
 		},
 		StepResults: map[string]*stepResult{
 			"id1": {
+				Conclusion: stepStatusSuccess,
+				Outcome:    stepStatusSuccess,
 				Outputs: map[string]string{
 					"foo": "bar",
 				},
-				Success: true,
 			},
 		},
 	}

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -55,7 +55,7 @@ func TestRunContext_EvalBool(t *testing.T) {
 		StepResults: map[string]*stepResult{
 			"id1": {
 				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusSuccess,
+				Outcome:    stepStatusFailure,
 				Outputs: map[string]string{
 					"foo": "bar",
 				},
@@ -74,6 +74,10 @@ func TestRunContext_EvalBool(t *testing.T) {
 		{in: "success()", out: true},
 		{in: "cancelled()", out: false},
 		{in: "always()", out: true},
+		{in: "steps.id1.conclusion == 'success'", out: true},
+		{in: "steps.id1.conclusion != 'success'", out: false},
+		{in: "steps.id1.outcome == 'failure'", out: true},
+		{in: "steps.id1.outcome != 'failure'", out: false},
 		{in: "true", out: true},
 		{in: "false", out: false},
 		{in: "!true", wantErr: true},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -121,6 +121,8 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "issue-598", "push", "", platforms, ""},
 		{"testdata", "env-and-path", "push", "", platforms, ""},
 		{"testdata", "outputs", "push", "", platforms, ""},
+		{"testdata", "steps-context/conclusion", "push", "", platforms, ""},
+		{"testdata", "steps-context/outcome", "push", "", platforms, ""},
 		{"../model/testdata", "strategy", "push", "", platforms, ""}, // TODO: move all testdata into pkg so we can validate it with planner and runner
 		// {"testdata", "issue-228", "push", "", platforms, ""}, // TODO [igni]: Remove this once everything passes
 

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -640,8 +640,8 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 		// Setup the outputs for the composite steps
 		if _, ok := rcClone.StepResults[stepClone.ID]; !ok {
 			rcClone.StepResults[stepClone.ID] = &stepResult{
-				Success: true,
-				Outputs: make(map[string]string),
+				Conclusion: stepStatusSuccess,
+				Outputs:    make(map[string]string),
 			}
 		}
 

--- a/pkg/runner/testdata/steps-context/conclusion/push.yml
+++ b/pkg/runner/testdata/steps-context/conclusion/push.yml
@@ -1,0 +1,14 @@
+name: conclusion
+on: push
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - id: first
+        run: exit 0
+      - id: second
+        continue-on-error: true
+        run: exit 1
+      - run: echo '${{ steps.first.conclusion }}' | grep 'success'
+      - run: echo '${{ steps.second.conclusion }}' | grep 'success'

--- a/pkg/runner/testdata/steps-context/outcome/push.yml
+++ b/pkg/runner/testdata/steps-context/outcome/push.yml
@@ -1,0 +1,14 @@
+name: outcome
+on: push
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - id: first
+        run: exit 0
+      - id: second
+        continue-on-error: true
+        run: exit 1
+      - run: echo '${{ steps.first.outcome }}' | grep 'success'
+      - run: echo '${{ steps.second.outcome }}' | grep 'failure'


### PR DESCRIPTION
Add more steps context support to match GitHub:
https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context

Should reference https://github.com/nektos/act/issues/465 and https://github.com/nektos/act/pull/557.

### Changes

#### Add step outcome

`steps.<step id>.outcome` string is the result of a completed step **before** `continue-on-error`.

#### Remove step success in favour of conclusion

`steps.<step id>.conclusion` string is the result of a completed step **after** `continue-on-error` is applied, which currently matches the original `stepResult.Success` value. So, respectively, all checks have been replaced:

- `Success == true` &rarr; `Conclusion == stepStatusSuccess`
- `Success == false` &rarr; `Conclusion == stepStatusFailure`

### Tested on

- Linux (Ubuntu 20.04.3 LTS x86_64)

All `runner` package tests have passed. The following workflow has been used to check the behaviour as well:

```yml
name: test
on: push

jobs:
  action-check:
    runs-on: ubuntu-latest
    steps:
      - name: First
        id: first
        run: exit 0
      - name: Second
        continue-on-error: true
        id: second
        run: exit 1
      - run: echo '${{ toJSON(steps.first) }}'
      - run: echo '${{ toJSON(steps.second) }}'
```

<details>
<summary><b>Output (before)</b></summary>

```txt
[test/action-check] 🚀  Start image=node:12-buster-slim
[test/action-check]   🐳  docker pull image=node:12-buster-slim platform= username= forcePull=false
[test/action-check]   🐳  docker create image=node:12-buster-slim platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[test/action-check]   🐳  docker run image=node:12-buster-slim platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[test/action-check]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[test/action-check] ⭐  Run First
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/first] user= workdir=
[test/action-check]   ✅  Success - First
[test/action-check] ⭐  Run Second
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/second] user= workdir=
[test/action-check]   ❌  Failure - Second
[test/action-check] Failed but continue next step
[test/action-check] ⭐  Run echo '${{ toJSON(steps.first) }}'
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/2] user= workdir=
| {
|   "success": true,
|   "outputs": {}
| }
[test/action-check]   ✅  Success - echo '${{ toJSON(steps.first) }}'
[test/action-check] ⭐  Run echo '${{ toJSON(steps.second) }}'
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/3] user= workdir=
| {
|   "success": true,
|   "outputs": {}
| }
[test/action-check]   ✅  Success - echo '${{ toJSON(steps.second) }}'
INFO[0002] Cleaning up container for job action-check
```
</details>

<details>
<summary><b>Output (after)</b></summary>

```txt
[test/action-check] 🚀  Start image=node:12-buster-slim
[test/action-check]   🐳  docker pull image=node:12-buster-slim platform= username= forcePull=false
[test/action-check]   🐳  docker create image=node:12-buster-slim platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[test/action-check]   🐳  docker run image=node:12-buster-slim platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[test/action-check]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[test/action-check] ⭐  Run First
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/first] user= workdir=
[test/action-check]   ✅  Success - First
[test/action-check] ⭐  Run Second
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/second] user= workdir=
[test/action-check]   ❌  Failure - Second
[test/action-check] Failed but continue next step
[test/action-check] ⭐  Run echo '${{ toJSON(steps.first) }}'
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/2] user= workdir=
| {
|   "conclusion": "success",
|   "outcome": "success",
|   "outputs": {}
| }
[test/action-check]   ✅  Success - echo '${{ toJSON(steps.first) }}'
[test/action-check] ⭐  Run echo '${{ toJSON(steps.second) }}'
[test/action-check]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/victor/Forks/act/workflow/3] user= workdir=
| {
|   "conclusion": "success",
|   "outcome": "failure",
|   "outputs": {}
| }
[test/action-check]   ✅  Success - echo '${{ toJSON(steps.second) }}'
INFO[0002] Cleaning up container for job action-check
```
</details>