### PR TITLE
Revert "feat: allow existing logger from context"

### DIFF
--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -47,14 +47,7 @@ func WithJobLogger(ctx context.Context, jobName string, secrets map[string]strin
 	formatter.insecureSecrets = insecureSecrets
 	nextColor++
 
-	var logger *logrus.Logger
-	fieldLogger := common.Logger(ctx)
-	if fieldLogger != nil {
-		logger = fieldLogger.(*logrus.Logger)
-	}
-	if logger == nil {
-		logger = logrus.New()
-	}
+	logger := logrus.New()
 	logger.SetFormatter(formatter)
 	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logrus.GetLevel())


### PR DESCRIPTION
Reverts nektos/act#859
That PR broke colours for jobs and prints `nil`s for certain lines (see above PR for context)

note for me (and maybe others): verify future PRs touching loggers on local machine