### PR TITLE
Docker auth

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,7 @@ github.com/docker/docker v20.10.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05b
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.10+incompatible h1:GKkP0T7U4ks6X3lmmHKC2QDprnpRJor2Z5a8m62R9ZM=
 github.com/docker/docker v20.10.10+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=

--- a/pkg/container/docker_auth.go
+++ b/pkg/container/docker_auth.go
@@ -1,0 +1,41 @@
+package container
+
+import (
+	"net/url"
+	"regexp"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/credentials"
+	"github.com/docker/docker/api/types"
+	log "github.com/sirupsen/logrus"
+)
+
+func LoadDockerAuthConfig(image string) (types.AuthConfig, error) {
+	config, err := config.Load(config.Dir())
+	if err != nil {
+		log.Warnf("Could not load docker config: %v", err)
+		return types.AuthConfig{}, err
+	}
+
+	if !config.ContainsAuth() {
+		config.CredentialsStore = credentials.DetectDefaultStore(config.CredentialsStore)
+	}
+
+	if matches, _ := regexp.MatchString("^[^.]+\\/", image); matches {
+		image = "https://index.docker.io/v1/" + image
+	}
+
+	parsed, err := url.Parse(image)
+	if err != nil {
+		log.Warnf("Could not parse image url: %v", err)
+		return types.AuthConfig{}, err
+	}
+
+	authConfig, err := config.GetAuthConfig(parsed.Hostname())
+	if err != nil {
+		log.Warnf("Could not get auth config from docker config: %v", err)
+		return types.AuthConfig{}, err
+	}
+
+	return types.AuthConfig(authConfig), nil
+}

--- a/pkg/container/docker_auth.go
+++ b/pkg/container/docker_auth.go
@@ -22,10 +22,10 @@ func LoadDockerAuthConfig(image string) (types.AuthConfig, error) {
 	}
 
 	if matches, _ := regexp.MatchString("^[^.]+\\/", image); matches {
-		image = "https://index.docker.io/v1/" + image
+		image = "index.docker.io/v1/" + image
 	}
 
-	parsed, err := url.Parse(image)
+	parsed, err := url.Parse("http://" + image)
 	if err != nil {
 		log.Warnf("Could not parse image url: %v", err)
 		return types.AuthConfig{}, err

--- a/pkg/container/docker_auth.go
+++ b/pkg/container/docker_auth.go
@@ -21,7 +21,7 @@ func LoadDockerAuthConfig(image string) (types.AuthConfig, error) {
 		config.CredentialsStore = credentials.DetectDefaultStore(config.CredentialsStore)
 	}
 
-	if matches, _ := regexp.MatchString("^[^.]+\\/", image); matches {
+	if matches, _ := regexp.MatchString("^[^.:]+\\/", image); matches {
 		image = "index.docker.io/v1/" + image
 	}
 

--- a/pkg/container/docker_pull_test.go
+++ b/pkg/container/docker_pull_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/cli/cli/config"
+
 	log "github.com/sirupsen/logrus"
 	assert "github.com/stretchr/testify/assert"
 )
@@ -35,9 +37,11 @@ func TestCleanImage(t *testing.T) {
 func TestGetImagePullOptions(t *testing.T) {
 	ctx := context.Background()
 
+	config.SetDir("/non-existent/docker")
+
 	options, err := getImagePullOptions(ctx, NewDockerPullExecutorInput{})
 	assert.Nil(t, err, "Failed to create ImagePullOptions")
-	assert.Equal(t, options.RegistryAuth, "", "RegistryAuth should be empty if no username or password is set")
+	assert.Equal(t, "", options.RegistryAuth, "RegistryAuth should be empty if no username or password is set")
 
 	options, err = getImagePullOptions(ctx, NewDockerPullExecutorInput{
 		Image:    "",
@@ -45,5 +49,13 @@ func TestGetImagePullOptions(t *testing.T) {
 		Password: "password",
 	})
 	assert.Nil(t, err, "Failed to create ImagePullOptions")
-	assert.Equal(t, options.RegistryAuth, "eyJ1c2VybmFtZSI6InVzZXJuYW1lIiwicGFzc3dvcmQiOiJwYXNzd29yZCJ9", "Username and Password should be provided")
+	assert.Equal(t, "eyJ1c2VybmFtZSI6InVzZXJuYW1lIiwicGFzc3dvcmQiOiJwYXNzd29yZCJ9", options.RegistryAuth, "Username and Password should be provided")
+
+	config.SetDir("testdata/docker-pull-options")
+
+	options, err = getImagePullOptions(ctx, NewDockerPullExecutorInput{
+		Image: "nektos/act",
+	})
+	assert.Nil(t, err, "Failed to create ImagePullOptions")
+	assert.Equal(t, "eyJ1c2VybmFtZSI6InVzZXJuYW1lIiwicGFzc3dvcmQiOiJwYXNzd29yZFxuIiwic2VydmVyYWRkcmVzcyI6Imh0dHBzOi8vaW5kZXguZG9ja2VyLmlvL3YxLyJ9", options.RegistryAuth, "RegistryAuth should be taken from local docker config")
 }

--- a/pkg/container/testdata/docker-pull-options/config.json
+++ b/pkg/container/testdata/docker-pull-options/config.json
@@ -1,0 +1,7 @@
+{
+  "auths": {
+          "https://index.docker.io/v1/": {
+                  "auth": "dXNlcm5hbWU6cGFzc3dvcmQK"
+          }
+  }
+}


### PR DESCRIPTION
This PR uses parts of the `docker/cli` to read the local docker config to get the authentication from it.
This is helpful for private registries, which worked before, but required to pass `DOCKER_USERNAME` and `DOCKER_PASSWORD` as secrets.
Now it will take existing authentication information from the Docker CLI if the secrets are not explicitly passed.