### PR TITLE
Fix regex for GITHUB_ENV parsing

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -369,7 +369,10 @@ var singleLineEnvPattern, mulitiLineEnvPattern *regexp.Regexp
 
 func (cr *containerReference) extractEnv(srcPath string, env *map[string]string) common.Executor {
 	if singleLineEnvPattern == nil {
-		singleLineEnvPattern = regexp.MustCompile("^([^=]+)=([^=]+)$")
+		// Single line pattern matches:
+		// SOME_VAR=data=moredata
+		// SOME_VAR=datamoredata
+		singleLineEnvPattern = regexp.MustCompile(`^([^=]*)\=(.*)$`)
 		mulitiLineEnvPattern = regexp.MustCompile(`^([^<]+)<<(\w+)$`)
 	}
 

--- a/pkg/runner/testdata/env-and-path/push.yaml
+++ b/pkg/runner/testdata/env-and-path/push.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: "Check single line env"
         run: |
           if [[ "${KEY}" != "value" ]]; then
-            echo "${KEY} dosen't == 'value'"
+            echo "${KEY} doesn't == 'value'"
             exit 1
           fi
       - name: "Write single line env with more than one 'equals' signs to $GITHUB_ENV"
@@ -63,8 +63,6 @@ jobs:
       - name: "Check multiline line env"
         run: |
           if [[ "${KEY2}" != "value2" ]]; then
-            echo "${KEY2} dosen't == 'value'"
+            echo "${KEY2} doesn't == 'value'"
             exit 1
           fi
-
-

--- a/pkg/runner/testdata/env-and-path/push.yaml
+++ b/pkg/runner/testdata/env-and-path/push.yaml
@@ -46,6 +46,15 @@ jobs:
             echo "${KEY} dosen't == 'value'"
             exit 1
           fi
+      - name: "Write single line env with more than one 'equals' signs to $GITHUB_ENV"
+        run: |
+          echo "KEY=value=anothervalue" >> $GITHUB_ENV
+      - name: "Check single line env"
+        run: |
+          if [[ "${KEY}" != "value=anothervalue" ]]; then
+            echo "${KEY} doesn't == 'value=anothervalue'"
+            exit 1
+          fi
       - name: "Write multiline env to $GITHUB_ENV"
         run: |
           echo 'KEY2<<EOF' >> $GITHUB_ENV


### PR DESCRIPTION
While troubleshooting `cachix/install-nix-action` (https://github.com/cachix/install-nix-action/pull/111) we hit a bug where envvars in `$GITHUB_ENV` file that contain equals sign (`=`) do not work
This PR fixes that issue