### PR TITLE
feat: allow existing logger from context

### DIFF
--- a/pkg/common/testflag.go
+++ b/pkg/common/testflag.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"context"
+)
+
+type testFlagContextKey string
+
+const testFlagContextKeyVal = testFlagContextKey("test-context")
+
+// TestContext returns whether the context has the test flag set
+func TestContext(ctx context.Context) bool {
+	val := ctx.Value(testFlagContextKeyVal)
+	return val != nil
+}
+
+// WithTextContext sets the test flag in the context
+func WithTestContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, testFlagContextKeyVal, true)
+}

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -48,6 +48,12 @@ func WithJobLogger(ctx context.Context, jobName string, secrets map[string]strin
 	nextColor++
 
 	logger := logrus.New()
+	if common.TestContext(ctx) {
+		fieldLogger := common.Logger(ctx)
+		if fieldLogger != nil {
+			logger = fieldLogger.(*logrus.Logger)
+		}
+	}
 	logger.SetFormatter(formatter)
 	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logrus.GetLevel())


### PR DESCRIPTION
We should reuse an existing context logger if in test context.
This will allow test to setup act with a null logger to assert
log messages.
