### PR TITLE
test: add testdata for pre/post actions

### DIFF
--- a/pkg/runner/testdata/actions/pre-post-if/action.yml
+++ b/pkg/runner/testdata/actions/pre-post-if/action.yml
@@ -1,0 +1,18 @@
+name: 'action-with-pre-post-if'
+description: 'Action with pre-post-if'
+inputs:
+  failInPreStep:
+    description: 'Throw error in pre step'
+    required: false
+    default: 'false'
+  failInPostStep:
+    description: 'Throw error in post step'
+    required: false
+    default: 'false'
+runs:
+  using: 'node12'
+  pre: './pre.js'
+  pre-if: ${{ "pre-if-never-true" == "true" }}
+  main: './main.js'
+  post: './post.js'
+  post-if: ${{ "post-if-never-true" == "true" }}

--- a/pkg/runner/testdata/actions/pre-post-if/main.js
+++ b/pkg/runner/testdata/actions/pre-post-if/main.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/pkg/runner/testdata/actions/pre-post-if/post.js
+++ b/pkg/runner/testdata/actions/pre-post-if/post.js
@@ -1,0 +1,5 @@
+console.log('post step');
+
+if (process.env.INPUT_FAILINPOSTSTEP === 'true') {
+    throw new Error("Fail in post step");
+}

--- a/pkg/runner/testdata/actions/pre-post-if/pre.js
+++ b/pkg/runner/testdata/actions/pre-post-if/pre.js
@@ -1,0 +1,5 @@
+console.log('pre step');
+
+if (process.env.INPUT_FAILINPRESTEP === 'true') {
+    throw new Error("Fail in pre step");
+}

--- a/pkg/runner/testdata/actions/pre-post/action.yml
+++ b/pkg/runner/testdata/actions/pre-post/action.yml
@@ -1,0 +1,16 @@
+name: 'action-with-pre-post-step'
+description: 'Action with pre-post-step'
+inputs:
+  failInPreStep:
+    description: 'Throw error in pre step'
+    required: false
+    default: 'false'
+  failInPostStep:
+    description: 'Throw error in pre step'
+    required: false
+    default: 'false'
+runs:
+  using: 'node12'
+  pre: './pre.js'
+  main: './main.js'
+  post: './post.js'

--- a/pkg/runner/testdata/actions/pre-post/main.js
+++ b/pkg/runner/testdata/actions/pre-post/main.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/pkg/runner/testdata/actions/pre-post/post.js
+++ b/pkg/runner/testdata/actions/pre-post/post.js
@@ -1,0 +1,5 @@
+console.log('post step');
+
+if (process.env.INPUT_FAILINPOSTSTEP === 'true') {
+    throw new Error("Fail in post step");
+}

--- a/pkg/runner/testdata/actions/pre-post/pre.js
+++ b/pkg/runner/testdata/actions/pre-post/pre.js
@@ -1,0 +1,5 @@
+console.log('pre step');
+
+if (process.env.INPUT_FAILINPRESTEP === 'true') {
+    throw new Error("Fail in pre step");
+}

--- a/pkg/runner/testdata/remote-action-with-post-step-failing/push.yml
+++ b/pkg/runner/testdata/remote-action-with-post-step-failing/push.yml
@@ -1,0 +1,10 @@
+name: runs-on
+on: push
+
+jobs:
+  fail-in-post:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: nektos/act/pkg/runner/testdata/actions/pre-post@master
+      with:
+        failInPostStep: 'true'

--- a/pkg/runner/testdata/remote-action-with-pre-and-post-step/push.yml
+++ b/pkg/runner/testdata/remote-action-with-pre-and-post-step/push.yml
@@ -1,0 +1,9 @@
+name: runs-on
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: nektos/act/pkg/runner/testdata/actions/pre-post@master
+    - uses: nektos/act/pkg/runner/testdata/actions/pre-post-if@master

--- a/pkg/runner/testdata/remote-action-with-pre-step-failing/push.yml
+++ b/pkg/runner/testdata/remote-action-with-pre-step-failing/push.yml
@@ -1,0 +1,10 @@
+name: runs-on
+on: push
+
+jobs:
+  fail-in-pre:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: nektos/act/pkg/runner/testdata/actions/pre-post@master
+      with:
+        failInPreStep: 'true'


### PR DESCRIPTION
This is in preparation for https://github.com/nektos/act/pull/861
Because local actions cannot have a pre-step, we need to reference the
test actions as remote actions from nektos/act/...@master
