### PR TITLE
patch: print plan summary upfront to executing it

### DIFF
--- a/pkg/runner/boundaries.go
+++ b/pkg/runner/boundaries.go
@@ -1,0 +1,64 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/model"
+	log "github.com/sirupsen/logrus"
+)
+
+func escapeID(id string) string {
+	return strings.ReplaceAll(id, "|", "||")
+}
+
+func printPlan(plan *model.Plan) {
+	log.Debugln("################################################################################")
+	log.Debugf("# %s", plan.Stages[0].Runs[0].Workflow.Name)
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			log.Debugf("## %s | %s", escapeID(run.JobID), run.Job().Name)
+			for n, step := range run.Job().Steps {
+				id := step.ID
+				if id == "" {
+					id = fmt.Sprint(n)
+				}
+
+				log.Debugf("### %s | %s", escapeID(id), step)
+			}
+		}
+	}
+	log.Debugln("################################################################################")
+}
+
+func (rc *RunContext) logJobBoundaries(executor common.Executor) common.Executor {
+	id := escapeID(rc.Run.JobID)
+	jobName := escapeID(rc.JobName)
+
+	var jobStatus string
+
+	return common.NewDebugExecutor("@@ job | start | %s | %s @@", id, jobName).
+		Then(executor).
+		Finally(func(ctx context.Context) error {
+			jobStatus = rc.getJobContext().Status
+			return nil
+		}).
+		Finally(common.NewDebugExecutor("@@ job | end | %s | %s | %s @@", id, jobName, jobStatus))
+}
+
+func (rc *RunContext) logStepBoundaries(step *model.Step, executor common.Executor) common.Executor {
+	id := escapeID(step.ID)
+	stepIdentifier := escapeID(step.String())
+
+	var stepStatus stepStatus
+
+	return common.NewDebugExecutor("@@ step | start | %s | %s @@", id, stepIdentifier).
+		Then(executor).
+		Finally(func(ctx context.Context) error {
+			stepStatus = rc.StepResults[step.ID].Conclusion
+			return nil
+		}).
+		Finally(common.NewDebugExecutor("@@ step | stop | %s | %s | %s @@", id, stepIdentifier, stepStatus))
+}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -286,7 +286,7 @@ func (rc *RunContext) Executor() common.Executor {
 		if step.ID == "" {
 			step.ID = fmt.Sprintf("%d", i)
 		}
-		steps = append(steps, rc.newStepExecutor(step))
+		steps = append(steps, rc.logStepBoundaries(step, rc.newStepExecutor(step)))
 	}
 	steps = append(steps, rc.stopJobContainer())
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -112,6 +112,8 @@ func New(runnerConfig *Config) (Runner, error) {
 }
 
 func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
+	printPlan(plan)
+
 	maxJobNameLen := 0
 
 	pipeline := make([]common.Executor, 0)
@@ -141,7 +143,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				}
 				stageExecutor = append(stageExecutor, func(ctx context.Context) error {
 					jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
-					return rc.Executor().Finally(func(ctx context.Context) error {
+					return rc.logJobBoundaries(rc.Executor()).Finally(func(ctx context.Context) error {
 						isLastRunningContainer := func(currentStage int, currentRun int) bool {
 							return currentStage == len(plan.Stages)-1 && currentRun == len(stage.Runs)-1
 						}


### PR DESCRIPTION
This change will print a toc at debug level upfront to running
a workflow. It will help prepare outputs for (e.g. UI) before
executing and parsing the log output.

Co-authored-by: Philipp Hinrichsen <philipp.hinrichsen@new-work.se>
Co-authored-by: Björn Brauer <bjoern.brauer@new-work.se>