### PR TITLE
fix: ::stop-commands:: should continue to print the lines

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -36,6 +36,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		}
 
 		if resumeCommand != "" && command != resumeCommand {
+			logger.Infof("  \U00002699  %s", line)
 			return false
 		}
 		arg = unescapeCommandData(arg)

--- a/pkg/runner/command_test.go
+++ b/pkg/runner/command_test.go
@@ -64,8 +64,10 @@ func TestAddpath(t *testing.T) {
 }
 
 func TestStopCommands(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
 	a := assert.New(t)
-	ctx := context.Background()
+	ctx := common.WithLogger(context.Background(), logger)
 	rc := new(RunContext)
 	handler := rc.commandHandler(ctx)
 
@@ -77,6 +79,13 @@ func TestStopCommands(t *testing.T) {
 	handler("::my-end-token::\n")
 	handler("::set-env name=x::abcd\n")
 	a.Equal("abcd", rc.Env["x"])
+
+	messages := make([]string, 0)
+	for _, entry := range hook.AllEntries() {
+		messages = append(messages, entry.Message)
+	}
+
+	a.Contains(messages, "  \U00002699  ::set-env name=x::abcd\n")
 }
 
 func TestAddpathADO(t *testing.T) {


### PR DESCRIPTION
> This special command allows you to log anything without accidentally running a workflow command.
https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#stopping-and-starting-workflow-commands

Example: https://github.com/ZauberNerd/act-test/runs/4469496818?check_suite_focus=true#step:8:10