### PR TITLE
refactor: export and move shared contexts into pkg/model

### DIFF
--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -1,0 +1,28 @@
+package model
+
+type GithubContext struct {
+	Event            map[string]interface{} `json:"event"`
+	EventPath        string                 `json:"event_path"`
+	Workflow         string                 `json:"workflow"`
+	RunID            string                 `json:"run_id"`
+	RunNumber        string                 `json:"run_number"`
+	Actor            string                 `json:"actor"`
+	Repository       string                 `json:"repository"`
+	EventName        string                 `json:"event_name"`
+	Sha              string                 `json:"sha"`
+	Ref              string                 `json:"ref"`
+	HeadRef          string                 `json:"head_ref"`
+	BaseRef          string                 `json:"base_ref"`
+	Token            string                 `json:"token"`
+	Workspace        string                 `json:"workspace"`
+	Action           string                 `json:"action"`
+	ActionPath       string                 `json:"action_path"`
+	ActionRef        string                 `json:"action_ref"`
+	ActionRepository string                 `json:"action_repository"`
+	Job              string                 `json:"job"`
+	JobName          string                 `json:"job_name"`
+	RepositoryOwner  string                 `json:"repository_owner"`
+	RetentionDays    string                 `json:"retention_days"`
+	RunnerPerflog    string                 `json:"runner_perflog"`
+	RunnerTrackingID string                 `json:"runner_tracking_id"`
+}

--- a/pkg/model/job_context.go
+++ b/pkg/model/job_context.go
@@ -1,0 +1,12 @@
+package model
+
+type JobContext struct {
+	Status    string `json:"status"`
+	Container struct {
+		ID      string `json:"id"`
+		Network string `json:"network"`
+	} `json:"container"`
+	Services map[string]struct {
+		ID string `json:"id"`
+	} `json:"services"`
+}

--- a/pkg/model/step_result.go
+++ b/pkg/model/step_result.go
@@ -1,0 +1,43 @@
+package model
+
+import "fmt"
+
+type stepStatus int
+
+const (
+	StepStatusSuccess stepStatus = iota
+	StepStatusFailure
+)
+
+var stepStatusStrings = [...]string{
+	"success",
+	"failure",
+}
+
+func (s stepStatus) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s *stepStatus) UnmarshalText(b []byte) error {
+	str := string(b)
+	for i, name := range stepStatusStrings {
+		if name == str {
+			*s = stepStatus(i)
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid step status %q", str)
+}
+
+func (s stepStatus) String() string {
+	if int(s) >= len(stepStatusStrings) {
+		return ""
+	}
+	return stepStatusStrings[s]
+}
+
+type StepResult struct {
+	Outputs    map[string]string `json:"outputs"`
+	Conclusion stepStatus        `json:"conclusion"`
+	Outcome    stepStatus        `json:"outcome"`
+}

--- a/pkg/runner/command_test.go
+++ b/pkg/runner/command_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/model"
 )
 
 func TestSetEnv(t *testing.T) {
@@ -24,11 +25,11 @@ func TestSetOutput(t *testing.T) {
 	a := assert.New(t)
 	ctx := context.Background()
 	rc := new(RunContext)
-	rc.StepResults = make(map[string]*stepResult)
+	rc.StepResults = make(map[string]*model.StepResult)
 	handler := rc.commandHandler(ctx)
 
 	rc.CurrentStep = "my-step"
-	rc.StepResults[rc.CurrentStep] = &stepResult{
+	rc.StepResults[rc.CurrentStep] = &model.StepResult{
 		Outputs: make(map[string]string),
 	}
 	handler("::set-output name=x::valz\n")

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -47,24 +47,24 @@ func TestEvaluate(t *testing.T) {
 			"os":  "Linux",
 			"foo": "bar",
 		},
-		StepResults: map[string]*stepResult{
+		StepResults: map[string]*model.StepResult{
 			"idwithnothing": {
-				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusFailure,
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusFailure,
 				Outputs: map[string]string{
 					"foowithnothing": "barwithnothing",
 				},
 			},
 			"id-with-hyphens": {
-				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusFailure,
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusFailure,
 				Outputs: map[string]string{
 					"foo-with-hyphens": "bar-with-hyphens",
 				},
 			},
 			"id_with_underscores": {
-				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusFailure,
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusFailure,
 				Outputs: map[string]string{
 					"foo_with_underscores": "bar_with_underscores",
 				},
@@ -232,6 +232,7 @@ func updateTestExpressionWorkflow(t *testing.T, tables []struct {
 		envs += fmt.Sprintf("  %s: %s\n", k, rc.Env[k])
 	}
 
+	// editorconfig-checker-disable
 	workflow := fmt.Sprintf(`
 name: "Test how expressions are handled on GitHub"
 on: push
@@ -244,6 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 `, envs)
+	// editorconfig-checker-enable
 	for _, table := range tables {
 		expressionPattern = regexp.MustCompile(`\${{\s*(.+?)\s*}}`)
 

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -53,10 +53,10 @@ func TestRunContext_EvalBool(t *testing.T) {
 			"os":  "Linux",
 			"foo": "bar",
 		},
-		StepResults: map[string]*stepResult{
+		StepResults: map[string]*model.StepResult{
 			"id1": {
-				Conclusion: stepStatusSuccess,
-				Outcome:    stepStatusFailure,
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusFailure,
 				Outputs: map[string]string{
 					"foo": "bar",
 				},
@@ -312,7 +312,7 @@ func TestGetGitHubContext(t *testing.T) {
 		Matrix:         map[string]interface{}{},
 		Env:            map[string]string{},
 		ExtraPath:      []string{},
-		StepResults:    map[string]*stepResult{},
+		StepResults:    map[string]*model.StepResult{},
 		OutputMappings: map[MappableOutput]MappableOutput{},
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -188,7 +188,7 @@ func (runner *runnerImpl) newRunContext(run *model.Run, matrix map[string]interf
 		Config:      runner.config,
 		Run:         run,
 		EventJSON:   runner.eventJSON,
-		StepResults: make(map[string]*stepResult),
+		StepResults: make(map[string]*model.StepResult),
 		Matrix:      matrix,
 	}
 	rc.ExprEval = rc.NewExpressionEvaluator()

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -77,7 +77,7 @@ func (sc *StepContext) Executor(ctx context.Context) common.Executor {
 		remoteAction.URL = rc.Config.GitHubInstance
 
 		github := rc.getGithubContext()
-		if remoteAction.IsCheckout() && github.isLocalCheckout(step) {
+		if remoteAction.IsCheckout() && isLocalCheckout(github, step) {
 			return func(ctx context.Context) error {
 				common.Logger(ctx).Debugf("Skipping local actions/checkout because workdir was already copied")
 				return nil

--- a/pkg/runner/step_context_test.go
+++ b/pkg/runner/step_context_test.go
@@ -46,7 +46,7 @@ func createIfTestStepContext(t *testing.T, input string) *StepContext {
 					"ubuntu-latest": "ubuntu-latest",
 				},
 			},
-			StepResults: map[string]*stepResult{},
+			StepResults: map[string]*model.StepResult{},
 			Env:         map[string]string{},
 			Run: &model.Run{
 				JobID: "job1",
@@ -71,14 +71,14 @@ func TestStepContextIsEnabled(t *testing.T) {
 	assertObject.True(sc.isEnabled(context.Background()))
 
 	sc = createIfTestStepContext(t, "if: success()")
-	sc.RunContext.StepResults["a"] = &stepResult{
-		Conclusion: stepStatusSuccess,
+	sc.RunContext.StepResults["a"] = &model.StepResult{
+		Conclusion: model.StepStatusSuccess,
 	}
 	assertObject.True(sc.isEnabled(context.Background()))
 
 	sc = createIfTestStepContext(t, "if: success()")
-	sc.RunContext.StepResults["a"] = &stepResult{
-		Conclusion: stepStatusFailure,
+	sc.RunContext.StepResults["a"] = &model.StepResult{
+		Conclusion: model.StepStatusFailure,
 	}
 	assertObject.False(sc.isEnabled(context.Background()))
 
@@ -87,14 +87,14 @@ func TestStepContextIsEnabled(t *testing.T) {
 	assertObject.False(sc.isEnabled(context.Background()))
 
 	sc = createIfTestStepContext(t, "if: failure()")
-	sc.RunContext.StepResults["a"] = &stepResult{
-		Conclusion: stepStatusSuccess,
+	sc.RunContext.StepResults["a"] = &model.StepResult{
+		Conclusion: model.StepStatusSuccess,
 	}
 	assertObject.False(sc.isEnabled(context.Background()))
 
 	sc = createIfTestStepContext(t, "if: failure()")
-	sc.RunContext.StepResults["a"] = &stepResult{
-		Conclusion: stepStatusFailure,
+	sc.RunContext.StepResults["a"] = &model.StepResult{
+		Conclusion: model.StepStatusFailure,
 	}
 	assertObject.True(sc.isEnabled(context.Background()))
 
@@ -103,14 +103,14 @@ func TestStepContextIsEnabled(t *testing.T) {
 	assertObject.True(sc.isEnabled(context.Background()))
 
 	sc = createIfTestStepContext(t, "if: always()")
-	sc.RunContext.StepResults["a"] = &stepResult{
-		Conclusion: stepStatusSuccess,
+	sc.RunContext.StepResults["a"] = &model.StepResult{
+		Conclusion: model.StepStatusSuccess,
 	}
 	assertObject.True(sc.isEnabled(context.Background()))
 
 	sc = createIfTestStepContext(t, "if: always()")
-	sc.RunContext.StepResults["a"] = &stepResult{
-		Conclusion: stepStatusFailure,
+	sc.RunContext.StepResults["a"] = &model.StepResult{
+		Conclusion: model.StepStatusFailure,
 	}
 	assertObject.True(sc.isEnabled(context.Background()))
 }


### PR DESCRIPTION
This commit moves the `githubContext`, `jobContext` and `stepResult` structs
from the `runner` package to the `model` package in preparation for #908
because the `expression.go` file lives in the `runner` package and would
introduce cyclic dependencies with the `exprparser` package.