### PR TITLE
fix: GetEnv need to be initialized before first access

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -195,6 +195,9 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			copyToPath = filepath.Join(rc.Config.ContainerWorkdir(), copyToPath)
 		}
 
+		// fixme: this should be done in a better way
+		rc.GetEnv()
+
 		return common.NewPipelineExecutor(
 			rc.JobContainer.Pull(rc.Config.ForcePull),
 			rc.stopJobContainer(),


### PR DESCRIPTION
This commit ensures that the run context env is initialized before its
first access.
This is done in preparation for #908

- [ ] polish this patch and remove the `fixme` comment (cc @KnisterPeter)