### PR TITLE
fix: all copied files now owned by runner inside the container

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -30,6 +30,7 @@ type Input struct {
 	usernsMode            string
 	containerArchitecture string
 	containerDaemonSocket string
+	containerUser         string
 	noWorkflowRecurse     bool
 	useGitIgnore          bool
 	githubInstance        string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().BoolVar(&input.useGitIgnore, "use-gitignore", true, "Controls whether paths specified in .gitignore should be copied into container")
 	rootCmd.Flags().StringArrayVarP(&input.containerCapAdd, "container-cap-add", "", []string{}, "kernel capabilities to add to the workflow containers (e.g. --container-cap-add SYS_PTRACE)")
 	rootCmd.Flags().StringArrayVarP(&input.containerCapDrop, "container-cap-drop", "", []string{}, "kernel capabilities to remove from the workflow containers (e.g. --container-cap-drop SYS_PTRACE)")
-	rootCmd.Flags().StringVarP(&input.containerUser, "container-user", "", "", "UID or username which will be used for running act containers")
+	rootCmd.Flags().StringVarP(&input.containerUser, "container-user", "", "runner", "UID or username which will be used for running act containers")
 	rootCmd.Flags().BoolVar(&input.autoRemove, "rm", false, "automatically remove container(s)/volume(s) after a workflow(s) failure")
 	rootCmd.PersistentFlags().StringVarP(&input.actor, "actor", "a", "nektos/act", "user that triggered the event")
 	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow file(s)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().BoolVar(&input.useGitIgnore, "use-gitignore", true, "Controls whether paths specified in .gitignore should be copied into container")
 	rootCmd.Flags().StringArrayVarP(&input.containerCapAdd, "container-cap-add", "", []string{}, "kernel capabilities to add to the workflow containers (e.g. --container-cap-add SYS_PTRACE)")
 	rootCmd.Flags().StringArrayVarP(&input.containerCapDrop, "container-cap-drop", "", []string{}, "kernel capabilities to remove from the workflow containers (e.g. --container-cap-drop SYS_PTRACE)")
+	rootCmd.Flags().StringVarP(&input.containerUser, "container-user", "", "", "UID or username which will be used for running act containers")
 	rootCmd.Flags().BoolVar(&input.autoRemove, "rm", false, "automatically remove container(s)/volume(s) after a workflow(s) failure")
 	rootCmd.PersistentFlags().StringVarP(&input.actor, "actor", "a", "nektos/act", "user that triggered the event")
 	rootCmd.PersistentFlags().StringVarP(&input.workflowsPath, "workflows", "W", "./.github/workflows/", "path to workflow file(s)")
@@ -278,6 +279,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			GitHubInstance:        input.githubInstance,
 			ContainerCapAdd:       input.containerCapAdd,
 			ContainerCapDrop:      input.containerCapDrop,
+			ContainerUser:         input.containerUser,
 			AutoRemove:            input.autoRemove,
 			ArtifactServerPath:    input.artifactServerPath,
 			ArtifactServerPort:    input.artifactServerPort,

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -42,6 +42,7 @@ type NewContainerInput struct {
 	Password    string
 	Entrypoint  []string
 	Cmd         []string
+	User        string
 	WorkingDir  string
 	Env         []string
 	Binds       []string
@@ -156,7 +157,7 @@ func (cr *containerReference) Copy(destPath string, files ...*FileEntry) common.
 func (cr *containerReference) CopyDir(destPath string, srcPath string, useGitIgnore bool) common.Executor {
 	return common.NewPipelineExecutor(
 		common.NewInfoExecutor("%sdocker cp src=%s dst=%s", logPrefix, srcPath, destPath),
-		cr.Exec([]string{"mkdir", "-p", destPath}, nil, "", ""),
+		cr.Exec([]string{"mkdir", "-m", "0777", "-p", destPath}, nil, cr.input.User, ""),
 		cr.copyDir(destPath, srcPath, useGitIgnore),
 	).IfNot(common.Dryrun)
 }
@@ -314,6 +315,7 @@ func (cr *containerReference) create(capAdd []string, capDrop []string) common.E
 		input := cr.input
 
 		config := &container.Config{
+			User:       input.User,
 			Image:      input.Image,
 			Cmd:        input.Cmd,
 			Entrypoint: input.Entrypoint,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -204,6 +204,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.UpdateFromEnv("/etc/environment", &rc.Env),
 			rc.JobContainer.Exec([]string{"mkdir", "-m", "0777", "-p", ActPath}, rc.Env, "root", ""),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".", rc.Config.UseGitIgnore).IfBool(copyWorkspace),
+			rc.JobContainer.Exec([]string{"chown", "-R", "runner.runner", copyToPath}, rc.Env, "root", "").IfBool(copyWorkspace),
 			rc.JobContainer.Copy(ActPath+"/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0644,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -205,7 +205,8 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.UpdateFromEnv("/etc/environment", &rc.Env),
 			rc.JobContainer.Exec([]string{"mkdir", "-m", "0777", "-p", ActPath}, rc.Env, "0", ""),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".", rc.Config.UseGitIgnore).IfBool(copyWorkspace),
-			rc.JobContainer.Exec([]string{"chown", "-R", "runner.runner", copyToPath}, rc.Env, "root", "").IfBool(copyWorkspace),
+			rc.JobContainer.Exec([]string{"chown", "-R", rc.Config.ContainerUser, copyToPath}, rc.Env, "root", "").IfBool(copyWorkspace),
+			rc.JobContainer.Exec([]string{"chown", "-R", rc.Config.ContainerUser, "/home/runner"}, rc.Env, "root", ""),
 			rc.JobContainer.Copy(ActPath+"/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0644,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -186,6 +186,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			UsernsMode:  rc.Config.UsernsMode,
 			Platform:    rc.Config.ContainerArchitecture,
 			Hostname:    hostname,
+			User:        rc.Config.ContainerUser,
 		})
 
 		var copyWorkspace bool
@@ -202,7 +203,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.Start(false),
 			rc.JobContainer.UpdateFromImageEnv(&rc.Env),
 			rc.JobContainer.UpdateFromEnv("/etc/environment", &rc.Env),
-			rc.JobContainer.Exec([]string{"mkdir", "-m", "0777", "-p", ActPath}, rc.Env, "root", ""),
+			rc.JobContainer.Exec([]string{"mkdir", "-m", "0777", "-p", ActPath}, rc.Env, "0", ""),
 			rc.JobContainer.CopyDir(copyToPath, rc.Config.Workdir+string(filepath.Separator)+".", rc.Config.UseGitIgnore).IfBool(copyWorkspace),
 			rc.JobContainer.Exec([]string{"chown", "-R", "runner.runner", copyToPath}, rc.Env, "root", "").IfBool(copyWorkspace),
 			rc.JobContainer.Copy(ActPath+"/", &container.FileEntry{

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -43,6 +43,7 @@ type Config struct {
 	GitHubInstance        string            // GitHub instance to use, default "github.com"
 	ContainerCapAdd       []string          // list of kernel capabilities to add to the containers
 	ContainerCapDrop      []string          // list of kernel capabilities to remove from the containers
+	ContainerUser         string            // User that will run the command(s) inside the container, also support user:group
 	AutoRemove            bool              // controls if the container is automatically removed upon workflow completion
 	ArtifactServerPath    string            // the path where the artifact server stores uploads
 	ArtifactServerPort    string            // the port the artifact server binds to


### PR DESCRIPTION
This recursively changes ownership of all copied files and other working folders to `runner` inside the container, or whichever user is specified by `--container-user`.

Fixes #398 both with and without `--bind`, thanks to the `--container-user` patch by @catthehacker:
https://github.com/catthehacker/act-fork/commit/a4dd723dd182201a99db24a86a590d28749661ce