### PR TITLE
SSH-agent authentication for cloning actions

### DIFF
--- a/pkg/common/git.go
+++ b/pkg/common/git.go
@@ -232,8 +232,8 @@ type NewGitCloneExecutorInput struct {
 	Token string
 }
 
-// CloneIfRequired ...
-func CloneIfRequired(ctx context.Context, refName plumbing.ReferenceName, input NewGitCloneExecutorInput, logger log.FieldLogger) (*git.Repository, error) {
+// cloneIfRequired ...
+func cloneIfRequired(ctx context.Context, refName plumbing.ReferenceName, input NewGitCloneExecutorInput, logger log.FieldLogger) (*git.Repository, error) {
 	r, err := git.PlainOpen(input.Dir)
 	if err != nil {
 		var progressWriter io.Writer
@@ -285,7 +285,7 @@ func NewGitCloneExecutor(input NewGitCloneExecutorInput) Executor {
 		defer cloneLock.Unlock()
 
 		refName := plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", input.Ref))
-		r, err := CloneIfRequired(ctx, refName, input, logger)
+		r, err := cloneIfRequired(ctx, refName, input, logger)
 		if err != nil {
 			return err
 		}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -615,7 +615,7 @@ func isLocalCheckout(ghc *model.GithubContext, step *model.Step) bool {
 	if step.Type() != model.StepTypeUsesActionRemote {
 		return false
 	}
-	remoteAction := newRemoteAction(step.Uses)
+	remoteAction := newRemoteAction(step.Uses, "github.com")
 	if remoteAction == nil {
 		// IsCheckout() will nil panic if we dont bail out early
 		return false

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -69,12 +69,10 @@ func (sc *StepContext) Executor(ctx context.Context) common.Executor {
 			sc.runAction(actionDir, "", "", "", true),
 		)
 	case model.StepTypeUsesActionRemote:
-		remoteAction := newRemoteAction(step.Uses)
+		remoteAction := newRemoteAction(step.Uses, rc.Config.GitHubInstance)
 		if remoteAction == nil {
 			return common.NewErrorExecutor(formatError(step.Uses))
 		}
-
-		remoteAction.URL = rc.Config.GitHubInstance
 
 		github := rc.getGithubContext()
 		if remoteAction.IsCheckout() && isLocalCheckout(github, step) {
@@ -776,7 +774,7 @@ func (ra *remoteAction) IsCheckout() bool {
 	return false
 }
 
-func newRemoteAction(action string) *remoteAction {
+func newRemoteAction(action, githubInstance string) *remoteAction {
 	// GitHub's document[^] describes:
 	// > We strongly recommend that you include the version of
 	// > the action you are using by specifying a Git ref, SHA, or Docker tag number.
@@ -792,7 +790,7 @@ func newRemoteAction(action string) *remoteAction {
 		Repo: matches[2],
 		Path: matches[4],
 		Ref:  matches[6],
-		URL:  "github.com",
+		URL:  githubInstance,
 	}
 }
 


### PR DESCRIPTION
This makes it easier to run act locally with GitHub enterprise, because
cloning remote actions otherwise always requires setting `GITHUB_TOKEN`.

It will also help with remote actions in private repositories.

Unfortunately a `GITHUB_TOKEN` still needs to be provided for the
`actions/checkout` action when cloning a remote repository or different
ref (i.e. not a local checkout). This *might* change, if:
actions/checkout#660 is acceptable.

Also a token needs to be provided in case the workflow contains actions
that talk to the GitHub API.