### PR TITLE
fix: set composite outputs on failure

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -299,7 +299,9 @@ func (rc *RunContext) CompositeExecutor() common.Executor {
 	}
 
 	steps = append(steps, common.JobError)
-	return common.NewPipelineExecutor(steps...)
+	return func(ctx context.Context) error {
+		return common.NewPipelineExecutor(steps...)(common.WithJobErrorContainer(ctx))
+	}
 }
 
 func (rc *RunContext) newStepExecutor(step *model.Step) common.Executor {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -122,6 +122,7 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "uses-composite", "push", "", platforms, ""},
 		{"testdata", "uses-composite-with-error", "push", "Job 'failing-composite-action' failed", platforms, ""},
 		{"testdata", "uses-nested-composite", "push", "", platforms, ""},
+		{"testdata", "composite-fail-with-output", "push", "", platforms, ""},
 		{"testdata", "issue-597", "push", "", platforms, ""},
 		{"testdata", "issue-598", "push", "", platforms, ""},
 		{"testdata", "env-and-path", "push", "", platforms, ""},

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -722,9 +722,6 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 	compositerc.Inputs = inputs
 	compositerc.ExprEval = compositerc.NewExpressionEvaluator()
 	err = compositerc.CompositeExecutor()(ctx)
-	if err != nil {
-		return err
-	}
 
 	// Map outputs to parent rc
 	eval = (&StepContext{
@@ -744,7 +741,7 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 			backup.Env[k] = v
 		}
 	}
-	return nil
+	return err
 }
 
 func (sc *StepContext) populateEnvsFromInput(action *model.Action, rc *RunContext) {

--- a/pkg/runner/testdata/actions/composite-fail-with-output/action.yml
+++ b/pkg/runner/testdata/actions/composite-fail-with-output/action.yml
@@ -1,0 +1,13 @@
+outputs:
+  customoutput:
+    value: my-customoutput-${{ steps.random-color-generator.outputs.SELECTED_COLOR }}
+runs:
+  using: composite
+  steps:
+  - name: Set selected color
+    run: echo '::set-output name=SELECTED_COLOR::green'
+    id: random-color-generator
+    shell: bash
+  - name: fail
+    run: exit 1
+    shell: bash

--- a/pkg/runner/testdata/composite-fail-with-output/push.yml
+++ b/pkg/runner/testdata/composite-fail-with-output/push.yml
@@ -1,0 +1,14 @@
+name: composite-fail-with-output
+on: push
+
+jobs:
+  test-for-output:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./actions/composite-fail-with-output
+      id: composite-fail-with-output
+      continue-on-error: true
+    - run: |
+        echo ${{steps.composite-fail-with-output.outputs.customoutput}}
+        exit ${{steps.composite-fail-with-output.outputs.customoutput == 'my-customoutput-green' && '0' || '1'}}


### PR DESCRIPTION
fix: conclusion and outcome after error with failure condition
fix: continue-on-error doesn't work correctly for composite actions

I added a test workflow for this defect.

Follow up of https://github.com/nektos/act/pull/793