### PR TITLE
fix(goreleaser): add append mode for release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,3 +47,4 @@ changelog:
       order: 999
 release:
   prerelease: auto
+  mode: append


### PR DESCRIPTION
this should properly update release notes when release is created via GitHub UI