### PR TITLE
fix: deep evaluate matrix strategy

### DIFF
--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -144,7 +144,7 @@ func (ee expressionEvaluator) evaluateScalarYamlNode(node *yaml.Node) error {
 	if in != expr {
 		log.Debugf("expression '%s' rewritten to '%s'", in, expr)
 	}
-	res, err := ee.evaluate(in, false)
+	res, err := ee.evaluate(expr, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -126,7 +126,9 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				job := run.Job()
 				if job.Strategy != nil {
 					strategyRc := runner.newRunContext(run, nil)
-					strategyRc.NewExpressionEvaluator().EvaluateYamlNode(&job.Strategy.RawMatrix)
+					if err := strategyRc.NewExpressionEvaluator().EvaluateYamlNode(&job.Strategy.RawMatrix); err != nil {
+						return err
+					}
 				}
 				matrixes := job.GetMatrixes()
 				maxParallel := 4

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -127,7 +127,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				if job.Strategy != nil {
 					strategyRc := runner.newRunContext(run, nil)
 					if err := strategyRc.NewExpressionEvaluator().EvaluateYamlNode(&job.Strategy.RawMatrix); err != nil {
-						return err
+						log.Errorf("Error while evaluating matrix: %v", err)
 					}
 				}
 				matrixes := job.GetMatrixes()

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -115,59 +115,69 @@ func New(runnerConfig *Config) (Runner, error) {
 func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 	maxJobNameLen := 0
 
-	pipeline := make([]common.Executor, 0)
-	for s, stage := range plan.Stages {
-		stageExecutor := make([]common.Executor, 0)
-		for r, run := range stage.Runs {
-			job := run.Job()
-			matrixes := job.GetMatrixes()
-			maxParallel := 4
-			if job.Strategy != nil {
-				maxParallel = job.Strategy.MaxParallel
-			}
-
-			if len(matrixes) < maxParallel {
-				maxParallel = len(matrixes)
-			}
-
-			b := 0
-			for i, matrix := range matrixes {
-				rc := runner.newRunContext(run, matrix)
-				rc.JobName = rc.Name
-				if len(matrixes) > 1 {
-					rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
+	stagePipeline := make([]common.Executor, 0)
+	for i := range plan.Stages {
+		s := i
+		stage := plan.Stages[i]
+		stagePipeline = append(stagePipeline, func(ctx context.Context) error {
+			pipeline := make([]common.Executor, 0)
+			stageExecutor := make([]common.Executor, 0)
+			for r, run := range stage.Runs {
+				job := run.Job()
+				if job.Strategy != nil {
+					strategyRc := runner.newRunContext(run, nil)
+					strategyRc.NewExpressionEvaluator().EvaluateYamlNode(&job.Strategy.RawMatrix)
 				}
-				if len(rc.String()) > maxJobNameLen {
-					maxJobNameLen = len(rc.String())
+				matrixes := job.GetMatrixes()
+				maxParallel := 4
+				if job.Strategy != nil {
+					maxParallel = job.Strategy.MaxParallel
 				}
-				stageExecutor = append(stageExecutor, func(ctx context.Context) error {
-					jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
-					return rc.Executor().Finally(func(ctx context.Context) error {
-						isLastRunningContainer := func(currentStage int, currentRun int) bool {
-							return currentStage == len(plan.Stages)-1 && currentRun == len(stage.Runs)-1
-						}
 
-						if runner.config.AutoRemove && isLastRunningContainer(s, r) {
-							log.Infof("Cleaning up container for job %s", rc.JobName)
-							if err := rc.stopJobContainer()(ctx); err != nil {
-								log.Errorf("Error while cleaning container: %v", err)
+				if len(matrixes) < maxParallel {
+					maxParallel = len(matrixes)
+				}
+
+				b := 0
+				for i, matrix := range matrixes {
+					rc := runner.newRunContext(run, matrix)
+					rc.JobName = rc.Name
+					if len(matrixes) > 1 {
+						rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
+					}
+					if len(rc.String()) > maxJobNameLen {
+						maxJobNameLen = len(rc.String())
+					}
+					stageExecutor = append(stageExecutor, func(ctx context.Context) error {
+						jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
+						return rc.Executor().Finally(func(ctx context.Context) error {
+							isLastRunningContainer := func(currentStage int, currentRun int) bool {
+								return currentStage == len(plan.Stages)-1 && currentRun == len(stage.Runs)-1
 							}
-						}
 
-						return nil
-					})(common.WithJobErrorContainer(WithJobLogger(ctx, jobName, rc.Config.Secrets, rc.Config.InsecureSecrets)))
-				})
-				b++
-				if b == maxParallel {
-					pipeline = append(pipeline, common.NewParallelExecutor(stageExecutor...))
-					stageExecutor = make([]common.Executor, 0)
-					b = 0
+							if runner.config.AutoRemove && isLastRunningContainer(s, r) {
+								log.Infof("Cleaning up container for job %s", rc.JobName)
+								if err := rc.stopJobContainer()(ctx); err != nil {
+									log.Errorf("Error while cleaning container: %v", err)
+								}
+							}
+
+							return nil
+						})(common.WithJobErrorContainer(WithJobLogger(ctx, jobName, rc.Config.Secrets, rc.Config.InsecureSecrets)))
+					})
+					b++
+					if b == maxParallel {
+						pipeline = append(pipeline, common.NewParallelExecutor(stageExecutor...))
+						stageExecutor = make([]common.Executor, 0)
+						b = 0
+					}
 				}
 			}
-		}
+			return common.NewPipelineExecutor(pipeline...)(ctx)
+		})
 	}
 
-	return common.NewPipelineExecutor(pipeline...).Then(handleFailure(plan))
+	return common.NewPipelineExecutor(stagePipeline...).Then(handleFailure(plan))
 }
 
 func handleFailure(plan *model.Plan) common.Executor {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -131,6 +131,9 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "steps-context/outcome", "push", "", platforms, ""},
 		{"testdata", "job-status-check", "push", "job 'fail' failed", platforms, ""},
 		{"testdata", "if-expressions", "push", "Job 'mytest' failed", platforms, ""},
+		{"testdata", "evalmatrix", "push", "", platforms, ""},
+		{"testdata", "evalmatrixneeds", "push", "", platforms, ""},
+		{"testdata", "evalmatrixneeds2", "push", "", platforms, ""},
 		{"../model/testdata", "strategy", "push", "", platforms, ""}, // TODO: move all testdata into pkg so we can validate it with planner and runner
 		// {"testdata", "issue-228", "push", "", platforms, ""}, // TODO [igni]: Remove this once everything passes
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -134,6 +134,8 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "evalmatrix", "push", "", platforms, ""},
 		{"testdata", "evalmatrixneeds", "push", "", platforms, ""},
 		{"testdata", "evalmatrixneeds2", "push", "", platforms, ""},
+		{"testdata", "evalmatrix-merge-map", "push", "", platforms, ""},
+		{"testdata", "evalmatrix-merge-array", "push", "", platforms, ""},
 		{"../model/testdata", "strategy", "push", "", platforms, ""}, // TODO: move all testdata into pkg so we can validate it with planner and runner
 		// {"testdata", "issue-228", "push", "", platforms, ""}, // TODO [igni]: Remove this once everything passes
 

--- a/pkg/runner/testdata/evalmatrix-merge-array/push.yml
+++ b/pkg/runner/testdata/evalmatrix-merge-array/push.yml
@@ -1,0 +1,12 @@
+on: push
+jobs:
+  a:
+    strategy:
+      matrix:
+        a:
+        - env:
+              key1: ${{'val'}}1
+        - ${{fromJSON('[{"env":{"key2":"val2"}},{"env":{"key3":"val3"}}]')}}
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit ${{ (matrix.a.env.key2 == 'val2' || matrix.a.env.key1 == 'val1' || matrix.a.env.key3 == 'val3' ) && '0' || '1' }}

--- a/pkg/runner/testdata/evalmatrix-merge-map/push.yml
+++ b/pkg/runner/testdata/evalmatrix-merge-map/push.yml
@@ -1,0 +1,14 @@
+on: push
+jobs:
+  a:
+    strategy:
+      matrix:
+        a:
+        - env:
+              key1: val1
+              ${{insert}}:
+                 key2: val2
+              ${{ insert }}: ${{fromJSON('{"key3":"val3"}')}}
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit ${{ (matrix.a.env.key2 == 'val2' && matrix.a.env.key1 == 'val1' && matrix.a.env.key3 == 'val3' ) && '0' || '1' }}

--- a/pkg/runner/testdata/evalmatrix/push.yml
+++ b/pkg/runner/testdata/evalmatrix/push.yml
@@ -1,0 +1,18 @@
+on: push
+jobs:
+  evalm:
+    strategy:
+      matrix: |-
+        ${{fromJson('
+          {
+            "A": [ "A", "B" ]
+          }
+        ')}}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if the matrix key A exists
+      run: |
+        echo $MATRIX
+        exit ${{matrix.A && '0' || '1'}}
+      env:
+        MATRIX: ${{toJSON(matrix)}}

--- a/pkg/runner/testdata/evalmatrixneeds/push.yml
+++ b/pkg/runner/testdata/evalmatrixneeds/push.yml
@@ -1,0 +1,24 @@
+on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo '::set-output name=matrix::{"package": ["a", "b"]}'
+      id: r1
+    outputs:
+      matrix: ${{steps.r1.outputs.matrix}}
+  evalm:
+    needs:
+    - prepare
+    strategy:
+      matrix: |-
+        ${{fromJson(needs.prepare.outputs.matrix)}}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if the matrix key package exists
+      run: |
+        echo $MATRIX
+        exit ${{matrix.package && '0' || '1'}}
+      env:
+        MATRIX: ${{toJSON(matrix)}}

--- a/pkg/runner/testdata/evalmatrixneeds2/push.yml
+++ b/pkg/runner/testdata/evalmatrixneeds2/push.yml
@@ -1,0 +1,29 @@
+on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo '::set-output name=matrix::["a", "b"]'
+      id: r1
+    outputs:
+      matrix: ${{steps.r1.outputs.matrix}}
+      helix: steady
+  evalm:
+    needs:
+    - prepare
+    strategy:
+      matrix: 
+        ${{needs.prepare.outputs.helix}}: |-
+          ${{fromJson(needs.prepare.outputs.matrix)}}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if the matrix key doesn't ends up unevaluated
+      run: |
+        echo $MATRIX
+        exit ${{matrix['${{needs.prepare.outputs.helix}}'] && '1' || '0'}}
+      env:
+        MATRIX: ${{toJSON(matrix)}}
+    - name: Check if the evaluated matrix key contains a value
+      run: |
+        exit ${{matrix[needs.prepare.outputs.helix] && '0' || '1'}}


### PR DESCRIPTION
We need to wait for the previous stage to finish, otherwise we don't know how the final strategy will look like.
Then we need to evaluate all expression nodes of the strategy.matrix property, even the mapping keys.

I also added support for the insert directive and array merge operations, both are undocumented features of the github/actions which are available since 2019.

My tests aren't cover all possibilities, but the fixed issue has a test.

Most likely this change collides with @catthehacker plans of rewriting the yaml parser to actionslint, since I use the current yaml.Node types.

I have no idea how big the regressions regarding parallelism are with this change.

Resolves https://github.com/nektos/act/issues/927