### PR TITLE
docs: Expand the GITHUB_TOKEN section

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,15 @@ It will save that information to `~/.actrc`, please refer to [Configuration](#co
   -W, --workflows string                 path to workflow file(s) (default "./.github/workflows/")
 ```
 
-In case you want to pass a value for `${{ github.token }}`, you should pass `GITHUB_TOKEN` as secret: `act -s GITHUB_TOKEN=[insert token or leave blank for secure input]`.
+## `GITHUB_TOKEN`
+
+Github [automatically provides](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) a `GITHUB_TOKEN` secret when running workflows inside Github.
+
+If your workflow depends on this token, you need to create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and pass it to `act`  as a secret:
+
+```bash
+act -s GITHUB_TOKEN=[insert token or leave blank for secure input]
+```
 
 # Known Issues
 

--- a/README.md
+++ b/README.md
@@ -206,11 +206,13 @@ It will save that information to `~/.actrc`, please refer to [Configuration](#co
 
 Github [automatically provides](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) a `GITHUB_TOKEN` secret when running workflows inside Github.
 
-If your workflow depends on this token, you need to create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and pass it to `act`  as a secret:
+If your workflow depends on this token, you need to create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and pass it to `act` as a secret:
 
 ```bash
 act -s GITHUB_TOKEN=[insert token or leave blank for secure input]
 ```
+
+**WARNING**: `GITHUB_TOKEN` will be logged in shell history if not inserted through secure input or (depending on your shell config) the command is prefixed with a whitespace.
 
 # Known Issues
 


### PR DESCRIPTION
When I started using act, it kept failing because I was missing the `GITHUB_TOKEN` and I couldn't be bothered to figure it out.

I was unsure how to get this token, so I did some research and wanted to lessen the confusion of future users.

I believe this is such a common use-case that it bears spelling out.

Fixes #967
