### PR TITLE
Fix: regression run after failure

### DIFF
--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -136,12 +136,13 @@ func (e Executor) Then(then Executor) Executor {
 			case Warning:
 				log.Warning(err.Error())
 			default:
-				SetJobError(ctx, err)
+				log.Debugf("%+v", err)
+				return err
 			}
-		} else if ctx.Err() != nil {
-			SetJobError(ctx, ctx.Err())
 		}
-
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return then(ctx)
 	}
 }

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -265,7 +265,11 @@ func (rc *RunContext) Executor() common.Executor {
 		steps = append(steps, func(ctx context.Context) error {
 			err := stepExec(ctx)
 			if err != nil {
+				common.Logger(ctx).Errorf("%v", err)
 				common.SetJobError(ctx, err)
+			} else if ctx.Err() != nil {
+				common.Logger(ctx).Errorf("%v", ctx.Err())
+				common.SetJobError(ctx, ctx.Err())
 			}
 			return nil
 		})
@@ -306,8 +310,10 @@ func (rc *RunContext) CompositeExecutor() common.Executor {
 		steps = append(steps, func(ctx context.Context) error {
 			err := stepExec(ctx)
 			if err != nil {
+				common.Logger(ctx).Errorf("%v", err)
 				common.SetJobError(ctx, err)
 			} else if ctx.Err() != nil {
+				common.Logger(ctx).Errorf("%v", ctx.Err())
 				common.SetJobError(ctx, ctx.Err())
 			}
 			return nil

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -97,6 +97,7 @@ func TestRunEvent(t *testing.T) {
 		{"testdata", "fail", "push", "exit with `FAILURE`: 1", platforms, ""},
 		{"testdata", "runs-on", "push", "", platforms, ""},
 		{"testdata", "checkout", "push", "", platforms, ""},
+		{"testdata", "non-existent-action", "push", "Job 'nopanic' failed", platforms, ""},
 		{"testdata", "shells/defaults", "push", "", platforms, ""},
 		// TODO: figure out why it fails
 		// {"testdata", "shells/custom", "push", "", map[string]string{"ubuntu-latest": "ghcr.io/justingrote/act-pwsh:latest"}, ""}, // custom image with pwsh

--- a/pkg/runner/testdata/non-existent-action/push.yml
+++ b/pkg/runner/testdata/non-existent-action/push.yml
@@ -1,0 +1,7 @@
+on: push
+name: non-existent-action
+jobs:
+  nopanic:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ./path/to/non-existent-action


### PR DESCRIPTION
Restore the old behavior of the then executor. A lot of code in act relies on the fact that the pipeline executor fails fast instead of failing later.

Here a list of regressions
- https://github.com/nektos/act/issues/946 failing to read an action => panic
- returning an error at this line https://github.com/nektos/act/pull/964/commits/f538b28a53f03e082feca382f18b1cdea0192d0c#diff-3ca8bf2cdff0ec928622b093c6af8793a24f0f5f9a397c86e1df94a385be6e44R130 => panic
- failed to connect to docker => panic
- no cleanup on panic, the finally executor doesn't run
This broke error handling of act. I prefer to revert this function to it's previous version and create a new finally executor to archive the same in a less error prone.

Also print the error of the step, since it is useful to know why my action failed. E.g. if you used continue-on-error in a composite action.

Resolves https://github.com/nektos/act/issues/946

@KnisterPeter @ZauberNerd You introduced the regression in https://github.com/nektos/act/commit/1891c72ab158508e36009d16b24913fa5836422b

The observation of the edit of this comment https://github.com/nektos/act/pull/948#issuecomment-1022949930 is caused by the same regression, job failure without reason.