### PR TITLE
refactor: remove `NewExpressionEvaluator()` from `StepContext`

### DIFF
--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -75,7 +75,7 @@ func createRunContext(t *testing.T) *RunContext {
 
 func TestEvaluateRunContext(t *testing.T) {
 	rc := createRunContext(t)
-	ee := rc.NewExpressionEvaluator()
+	ee := rc.NewExpressionEvaluator("job")
 
 	tables := []struct {
 		in      string
@@ -150,10 +150,7 @@ func TestEvaluateRunContext(t *testing.T) {
 func TestEvaluateStepContext(t *testing.T) {
 	rc := createRunContext(t)
 
-	sc := &StepContext{
-		RunContext: rc,
-	}
-	ee := sc.NewExpressionEvaluator()
+	ee := rc.NewExpressionEvaluator("step")
 
 	tables := []struct {
 		in      string
@@ -212,7 +209,7 @@ func TestInterpolate(t *testing.T) {
 			},
 		},
 	}
-	ee := rc.NewExpressionEvaluator()
+	ee := rc.NewExpressionEvaluator("job")
 	tables := []struct {
 		in  string
 		out string

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -233,7 +233,7 @@ func (rc *RunContext) ActionCacheDir() string {
 // Interpolate outputs after a job is done
 func (rc *RunContext) interpolateOutputs() common.Executor {
 	return func(ctx context.Context) error {
-		ee := rc.NewExpressionEvaluator()
+		ee := rc.NewExpressionEvaluator("job")
 		for k, v := range rc.Run.Job().Outputs {
 			interpolated := ee.Interpolate(v)
 			if v != interpolated {
@@ -717,7 +717,7 @@ func (rc *RunContext) handleCredentials() (username, password string, err error)
 		return
 	}
 
-	ee := rc.NewExpressionEvaluator()
+	ee := rc.NewExpressionEvaluator("job")
 	if username = ee.Interpolate(container.Credentials["username"]); username == "" {
 		err = fmt.Errorf("failed to interpolate container.credentials.username")
 		return

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -63,7 +63,7 @@ func TestRunContext_EvalBool(t *testing.T) {
 			},
 		},
 	}
-	rc.ExprEval = rc.NewExpressionEvaluator()
+	rc.ExprEval = rc.NewExpressionEvaluator("job")
 
 	tables := []struct {
 		in      string
@@ -75,7 +75,7 @@ func TestRunContext_EvalBool(t *testing.T) {
 		{in: "success()", out: true},
 		{in: "cancelled()", out: false},
 		{in: "always()", out: true},
-		// TODO: move to sc.NewExpressionEvaluator(), because "steps" context is not available here
+		// TODO: move to rc.NewExpressionEvaluator("step"), because "steps" context is not available here
 		// {in: "steps.id1.conclusion == 'success'", out: true},
 		// {in: "steps.id1.conclusion != 'success'", out: false},
 		// {in: "steps.id1.outcome == 'failure'", out: true},
@@ -368,7 +368,7 @@ func createIfTestRunContext(jobs map[string]*model.Job) *RunContext {
 			},
 		},
 	}
-	rc.ExprEval = rc.NewExpressionEvaluator()
+	rc.ExprEval = rc.NewExpressionEvaluator("job")
 
 	return rc
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -191,7 +191,7 @@ func (runner *runnerImpl) newRunContext(run *model.Run, matrix map[string]interf
 		StepResults: make(map[string]*model.StepResult),
 		Matrix:      matrix,
 	}
-	rc.ExprEval = rc.NewExpressionEvaluator()
+	rc.ExprEval = rc.NewExpressionEvaluator("job")
 	rc.Name = rc.ExprEval.Interpolate(run.String())
 	return rc
 }


### PR DESCRIPTION
Except for the `exprparser.Config.Context` (which can be either "job"
or "step"), both expression evaluators (on the `RunContext` and on the
`StepContext`) were identical.
In the future we might want to have different evaluators, because the
`Steps` and `Inputs` should be different based on the context, but at
the moment both evaluators need access to all inputs in order to allow
composite actions to function properly.

This commit removes the `NewExpressionEvaluator()` method on the
`StepContext` and uses `NewExpressionEvaluator("step")` when a step
evaluator is needed.