### PR TITLE
Added instructions to install on fedora using copr package

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ scoop install act
 yay -S act
 ```
 
+### [COPR](https://copr.fedorainfracloud.org/coprs/rubemlrm/act-cli/) (Linux)
+
+[![copr-shield](https://img.shields.io/copr/version/act)](https://copr.fedorainfracloud.org/coprs/rubemlrm/act-cli/)
+
+```shell
+dnf copr enable rubemlrm/act-cli
+dnf install act-cli
+```
+
 ### [Nix](https://nixos.org) (Linux/macOS)
 
 [Nix recipe](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/misc/act/default.nix)

--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ yay -S act
 
 ### [COPR](https://copr.fedorainfracloud.org/coprs/rubemlrm/act-cli/) (Linux)
 
-[![copr-shield](https://img.shields.io/copr/version/act)](https://copr.fedorainfracloud.org/coprs/rubemlrm/act-cli/)
-
 ```shell
 dnf copr enable rubemlrm/act-cli
 dnf install act-cli


### PR DESCRIPTION
Added information on README.MD about the installation of act on Fedora based distros.

At this moment this is installed by COPR only, despite this i had to use the `act-cli`instead of `act`since exists already a package with the name of `act` that is the short name for another software.

Fix #992  