### PR TITLE
Set default GIT_TERMINAL_PROMPT env var to disable git prompts

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,12 @@ import (
 	"github.com/nektos/act/pkg/runner"
 )
 
+var (
+	defaultEnvVars = map[string]string{
+		"GIT_TERMINAL_PROMPT": "0", // Disable terminal prompts from Git
+	}
+)
+
 // Execute is the entry point to running the CLI
 func Execute(ctx context.Context, version string) {
 	input := new(Input)
@@ -166,7 +172,15 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		}
 
 		log.Debugf("Loading environment from %s", input.Envfile())
-		envs := make(map[string]string)
+		envs := map[string]string{}
+
+		// Set the default environment variables for the run.
+		// Environment variables could be overridden by a user.
+		for k, v := range defaultEnvVars {
+			log.Debugf("Setting default env var %s=%s", k, v)
+			envs[k] = v
+		}
+
 		if input.envs != nil {
 			for _, envVar := range input.envs {
 				e := strings.SplitN(envVar, `=`, 2)


### PR DESCRIPTION
I've recently hit the same issue as https://github.com/nektos/act/issues/977 - `act` hangs when project needs to pull a private repo. While there are a few ways to go about fixing the access (configure github tokem, setup creds, use ssh endpoint, etc), we should def drop any git prompts as the act environment is not interactive. 

With this PR, `act` will error out with ```fatal: could not read Username for 'https://github.com': terminal prompts disabled``` message. 