### PR TITLE
feat: run jobs in parallel

### DIFF
--- a/pkg/common/executor_test.go
+++ b/pkg/common/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -79,14 +80,19 @@ func TestNewParallelExecutor(t *testing.T) {
 	ctx := context.Background()
 
 	count := 0
+	maxCount := 0
 	emptyWorkflow := NewPipelineExecutor(func(ctx context.Context) error {
 		count++
+
+		time.Sleep(2 * time.Second)
+
 		return nil
 	})
 
-	err := NewParallelExecutor(2, emptyWorkflow, emptyWorkflow)(ctx)
-	assert.Equal(2, count)
+	err := NewParallelExecutor(2, emptyWorkflow, emptyWorkflow, emptyWorkflow)(ctx)
 
+	assert.Equal(2, count)
+	assert.Equal(2, maxCount)
 	assert.Nil(err)
 }
 

--- a/pkg/common/executor_test.go
+++ b/pkg/common/executor_test.go
@@ -84,7 +84,7 @@ func TestNewParallelExecutor(t *testing.T) {
 		return nil
 	})
 
-	err := NewParallelExecutor(emptyWorkflow, emptyWorkflow)(ctx)
+	err := NewParallelExecutor(2, emptyWorkflow, emptyWorkflow)(ctx)
 	assert.Equal(2, count)
 
 	assert.Nil(err)
@@ -101,7 +101,7 @@ func TestNewParallelExecutorFailed(t *testing.T) {
 		count++
 		return fmt.Errorf("fake error")
 	})
-	err := NewParallelExecutor(errorWorkflow)(ctx)
+	err := NewParallelExecutor(1, errorWorkflow)(ctx)
 	assert.Equal(1, count)
 	assert.ErrorIs(context.Canceled, err)
 }
@@ -123,7 +123,7 @@ func TestNewParallelExecutorCanceled(t *testing.T) {
 		count++
 		return errExpected
 	})
-	err := NewParallelExecutor(errorWorkflow, successWorkflow, successWorkflow)(ctx)
+	err := NewParallelExecutor(3, errorWorkflow, successWorkflow, successWorkflow)(ctx)
 	assert.Equal(3, count)
 	assert.Error(errExpected, err)
 }

--- a/pkg/common/executor_test.go
+++ b/pkg/common/executor_test.go
@@ -80,19 +80,25 @@ func TestNewParallelExecutor(t *testing.T) {
 	ctx := context.Background()
 
 	count := 0
+	activeCount := 0
 	maxCount := 0
 	emptyWorkflow := NewPipelineExecutor(func(ctx context.Context) error {
 		count++
 
+		activeCount++
+		if activeCount > maxCount {
+			maxCount = activeCount
+		}
 		time.Sleep(2 * time.Second)
+		activeCount--
 
 		return nil
 	})
 
 	err := NewParallelExecutor(2, emptyWorkflow, emptyWorkflow, emptyWorkflow)(ctx)
 
-	assert.Equal(2, count)
-	assert.Equal(2, maxCount)
+	assert.Equal(3, count, "should run all 3 executors")
+	assert.Equal(2, maxCount, "should run at most 2 executors in parallel")
 	assert.Nil(err)
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -121,8 +121,8 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 		stage := plan.Stages[i]
 		stagePipeline = append(stagePipeline, func(ctx context.Context) error {
 			pipeline := make([]common.Executor, 0)
-			stageExecutor := make([]common.Executor, 0)
 			for r, run := range stage.Runs {
+				stageExecutor := make([]common.Executor, 0)
 				job := run.Job()
 				if job.Strategy != nil {
 					strategyRc := runner.newRunContext(run, nil)
@@ -140,7 +140,6 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 					maxParallel = len(matrixes)
 				}
 
-				b := 0
 				for i, matrix := range matrixes {
 					rc := runner.newRunContext(run, matrix)
 					rc.JobName = rc.Name
@@ -167,13 +166,8 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 							return nil
 						})(common.WithJobErrorContainer(WithJobLogger(ctx, jobName, rc.Config.Secrets, rc.Config.InsecureSecrets)))
 					})
-					b++
-					if b == maxParallel {
-						pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))
-						stageExecutor = make([]common.Executor, 0)
-						b = 0
-					}
 				}
+				pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))
 			}
 			return common.NewParallelExecutor(runtime.NumCPU(), pipeline...)(ctx)
 		})

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -169,13 +169,13 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 					})
 					b++
 					if b == maxParallel {
-						pipeline = append(pipeline, common.NewParallelExecutor(stageExecutor...))
+						pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))
 						stageExecutor = make([]common.Executor, 0)
 						b = 0
 					}
 				}
 			}
-			return common.NewPipelineExecutor(pipeline...)(ctx)
+			return common.NewParallelExecutor(runtime.NumCPU(), pipeline...)(ctx)
 		})
 	}
 


### PR DESCRIPTION
This changes fixes and restructures the parallel execution of jobs.
The previous changes limiting the parallel execution did break this
and allowed only one job in parallel.

While we run #CPU jobs in parallel now, the jobs added per job-matrix
add to this. So we might over-commit to the capacity, but at least
it is limited.
