### PR TITLE
Expression evaluator fixes

### DIFF
--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -136,7 +136,6 @@ func (e Executor) Then(then Executor) Executor {
 			case Warning:
 				log.Warning(err.Error())
 			default:
-				log.Debugf("%+v", err)
 				return err
 			}
 		}

--- a/pkg/exprparser/interpreter.go
+++ b/pkg/exprparser/interpreter.go
@@ -274,7 +274,7 @@ func (impl *interperterImpl) evaluateNot(notNode *actionlint.NotOpNode) (interfa
 		return nil, err
 	}
 
-	return !impl.isTruthy(reflect.ValueOf(operand)), nil
+	return !IsTruthy(operand), nil
 }
 
 func (impl *interperterImpl) evaluateCompare(compareNode *actionlint.CompareOpNode) (interface{}, error) {
@@ -434,7 +434,8 @@ func (impl *interperterImpl) compareNumber(left float64, right float64, kind act
 	}
 }
 
-func (impl *interperterImpl) isTruthy(value reflect.Value) bool {
+func IsTruthy(input interface{}) bool {
+	value := reflect.ValueOf(input)
 	switch value.Kind() {
 	case reflect.Bool:
 		return value.Bool()
@@ -452,10 +453,7 @@ func (impl *interperterImpl) isTruthy(value reflect.Value) bool {
 
 		return value.Float() != 0
 
-	case reflect.Map:
-		return true
-
-	case reflect.Slice:
+	case reflect.Map, reflect.Slice:
 		return true
 
 	default:
@@ -503,14 +501,14 @@ func (impl *interperterImpl) evaluateLogicalCompare(compareNode *actionlint.Logi
 
 	switch compareNode.Kind {
 	case actionlint.LogicalOpNodeKindAnd:
-		if impl.isTruthy(leftValue) {
+		if IsTruthy(left) {
 			return impl.getSafeValue(rightValue), nil
 		}
 
 		return impl.getSafeValue(leftValue), nil
 
 	case actionlint.LogicalOpNodeKindOr:
-		if impl.isTruthy(leftValue) {
+		if IsTruthy(left) {
 			return impl.getSafeValue(leftValue), nil
 		}
 

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -142,9 +142,6 @@ func (ee expressionEvaluator) evaluateScalarYamlNode(node *yaml.Node) error {
 		return nil
 	}
 	expr, _ := rewriteSubExpression(in, false)
-	if in != expr {
-		log.Debugf("expression '%s' rewritten to '%s'", in, expr)
-	}
 	res, err := ee.evaluate(expr, false)
 	if err != nil {
 		return err
@@ -215,10 +212,6 @@ func (ee expressionEvaluator) Interpolate(in string) string {
 	}
 
 	expr, _ := rewriteSubExpression(in, true)
-	if in != expr {
-		log.Debugf("expression '%s' rewritten to '%s'", in, expr)
-	}
-
 	evaluated, err := ee.evaluate(expr, false)
 	if err != nil {
 		log.Errorf("Unable to interpolate expression '%s': %s", expr, err)
@@ -236,9 +229,6 @@ func (ee expressionEvaluator) Interpolate(in string) string {
 // EvalBool evaluates an expression against given evaluator
 func EvalBool(evaluator ExpressionEvaluator, expr string) (bool, error) {
 	nextExpr, _ := rewriteSubExpression(expr, false)
-	if expr != nextExpr {
-		log.Debugf("expression '%s' rewritten to '%s'", expr, nextExpr)
-	}
 
 	evaluated, err := evaluator.evaluate(nextExpr, true)
 	if err != nil {
@@ -312,5 +302,9 @@ func rewriteSubExpression(in string, forceFormat bool) (string, error) {
 		return in, nil
 	}
 
-	return fmt.Sprintf("format('%s', %s)", strings.ReplaceAll(formatOut, "'", "''"), strings.Join(results, ", ")), nil
+	out := fmt.Sprintf("format('%s', %s)", strings.ReplaceAll(formatOut, "'", "''"), strings.Join(results, ", "))
+	if in != out {
+		log.Debugf("expression '%s' rewritten to '%s'", in, out)
+	}
+	return out, nil
 }

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -128,7 +128,9 @@ type expressionEvaluator struct {
 }
 
 func (ee expressionEvaluator) evaluate(in string, isIfExpression bool) (interface{}, error) {
+	log.Debugf("evaluating expression '%s'", in)
 	evaluated, err := ee.interpreter.Evaluate(in, isIfExpression)
+	log.Debugf("expression '%s' evaluated to '%t'", in, evaluated)
 	return evaluated, err
 }
 
@@ -224,8 +226,6 @@ func (ee expressionEvaluator) Interpolate(in string) string {
 		return ""
 	}
 
-	log.Debugf("expression '%s' evaluated to '%s'", expr, evaluated)
-
 	value, ok := evaluated.(string)
 	if !ok {
 		panic(fmt.Sprintf("Expression %s did not evaluate to a string", expr))
@@ -262,10 +262,8 @@ func EvalBool(evaluator ExpressionEvaluator, expr string) (bool, error) {
 			result = t != 0
 		}
 	default:
-		return false, fmt.Errorf("Unable to map return type to boolean for '%s'", expr)
+		return false, fmt.Errorf("Unable to map type '%t' to boolean for '%s'", evaluated, expr)
 	}
-
-	log.Debugf("expression '%s' evaluated to '%t'", nextExpr, result)
 
 	return result, nil
 }

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"strings"
 
@@ -246,28 +245,7 @@ func EvalBool(evaluator ExpressionEvaluator, expr string) (bool, error) {
 		return false, err
 	}
 
-	var result bool
-
-	switch t := evaluated.(type) {
-	case nil:
-		result = false
-	case bool:
-		result = t
-	case string:
-		result = t != ""
-	case int:
-		result = t != 0
-	case float64:
-		if math.IsNaN(t) {
-			result = false
-		} else {
-			result = t != 0
-		}
-	default:
-		return false, fmt.Errorf("Unable to map type '%t' to boolean for '%s'", evaluated, expr)
-	}
-
-	return result, nil
+	return exprparser.IsTruthy(evaluated), nil
 }
 
 func escapeFormatString(in string) string {

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -249,6 +249,8 @@ func EvalBool(evaluator ExpressionEvaluator, expr string) (bool, error) {
 	var result bool
 
 	switch t := evaluated.(type) {
+	case nil:
+		result = false
 	case bool:
 		result = t
 	case string:

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -171,13 +171,7 @@ func (sc *StepContext) interpolateEnv(exprEval ExpressionEvaluator) {
 func (sc *StepContext) isEnabled(ctx context.Context) (bool, error) {
 	runStep, err := EvalBool(sc.NewExpressionEvaluator(), sc.Step.If.Value)
 	if err != nil {
-		common.Logger(ctx).Errorf("  \u274C  Error in if: expression - %s", sc.Step)
-		exprEval, err := sc.setupEnv(ctx)
-		if err != nil {
-			return false, err
-		}
-		sc.RunContext.ExprEval = exprEval
-		return false, err
+		return false, fmt.Errorf("  \u274C  Error in if-expression: \"if: %s\" (%s)", sc.Step.If.Value, err)
 	}
 
 	return runStep, nil

--- a/pkg/runner/testdata/issue-597/spelling.yaml
+++ b/pkg/runner/testdata/issue-597/spelling.yaml
@@ -1,10 +1,10 @@
 name: issue-597
 on: push
-  
+
 
 jobs:
   my_first_job:
-    
+
     runs-on: ubuntu-latest
     steps:
       - name: My first false step
@@ -14,7 +14,7 @@ jobs:
           ref: refs/pull/${{github.event.pull_request.number}}/merge
           fetch-depth: 5
       - name: My first true step
-        if: ${{"endsWith('Hello world', 'ld')"}}
+        if: ${{endsWith('Hello world', 'ld')}}
         uses: actions/hello-world-javascript-action@main
         with:
           who-to-greet: "Renst the Octocat"

--- a/pkg/runner/testdata/uses-composite/push.yml
+++ b/pkg/runner/testdata/uses-composite/push.yml
@@ -17,7 +17,7 @@ jobs:
         secret_input: ${{secrets.test_input_optional || 'NO SUCH SECRET'}}
       env:
         secret_input: ${{secrets.test_input_optional || 'NO SUCH SECRET'}}
-    - if: steps.composite.outputs.test_output != "test_output_value"
+    - if: steps.composite.outputs.test_output != 'test_output_value'
       run: |
         echo "steps.composite.outputs.test_output=${{ steps.composite.outputs.test_output }}"
         exit 1
@@ -38,7 +38,7 @@ jobs:
         test_input_optional_with_default_overriden: 'test_input_optional_with_default_overriden'
         test_input_required_with_default_overriden: 'test_input_required_with_default_overriden'
 
-    - if: steps.composite2.outputs.test_output != "test_output_value"
+    - if: steps.composite2.outputs.test_output != 'test_output_value'
       run: |
         echo "steps.composite.outputs.test_output=${{ steps.composite2.outputs.test_output }}"
         exit 1


### PR DESCRIPTION
This PR contains a few fixes and improvements for the new expression evaluator:
* Adds more debug output about which expression is going to be evaluated
* Use exported `IsTruthy()` function from the `exprparser` package inside `EvalBool()`
* Fail act when an expression contains errors and cannot be evaluated

Fixes: #1008 
Ref: #971 