### PR TITLE
feat: implement post steps

### DIFF
--- a/pkg/model/action.go
+++ b/pkg/model/action.go
@@ -49,6 +49,10 @@ type ActionRuns struct {
 	Using      ActionRunsUsing   `yaml:"using"`
 	Env        map[string]string `yaml:"env"`
 	Main       string            `yaml:"main"`
+	Pre        string            `yaml:"pre"`
+	PreIf      string            `yaml:"pre-if"`
+	Post       string            `yaml:"post"`
+	PostIf     string            `yaml:"post-if"`
 	Image      string            `yaml:"image"`
 	Entrypoint string            `yaml:"entrypoint"`
 	Args       []string          `yaml:"args"`
@@ -88,6 +92,14 @@ func ReadAction(in io.Reader) (*Action, error) {
 	err := yaml.NewDecoder(in).Decode(a)
 	if err != nil {
 		return nil, err
+	}
+
+	// set defaults
+	if a.Runs.Pre != "" && a.Runs.PreIf == "" {
+		a.Runs.PreIf = "always()"
+	}
+	if a.Runs.Post != "" && a.Runs.PostIf == "" {
+		a.Runs.PostIf = "always()"
 	}
 
 	return a, nil

--- a/pkg/model/step_result.go
+++ b/pkg/model/step_result.go
@@ -42,4 +42,5 @@ type StepResult struct {
 	Outputs    map[string]string `json:"outputs"`
 	Conclusion stepStatus        `json:"conclusion"`
 	Outcome    stepStatus        `json:"outcome"`
+	State      map[string]string
 }

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -126,6 +126,7 @@ func runActionImpl(step actionStep, actionDir string, remoteAction *remoteAction
 		action := step.getActionModel()
 		log.Debugf("About to run action %v", action)
 
+		populateEnvsFromSavedState(step.getEnv(), step, rc)
 		populateEnvsFromInput(step.getEnv(), action, rc)
 
 		actionLocation := path.Join(actionDir, actionPath)
@@ -432,6 +433,16 @@ func execAsComposite(step actionStep) common.Executor {
 	}
 }
 
+func populateEnvsFromSavedState(env *map[string]string, step actionStep, rc *RunContext) {
+	stepResult := rc.StepResults[step.getStepModel().ID]
+	if stepResult != nil {
+		for name, value := range stepResult.State {
+			envName := fmt.Sprintf("STATE_%s", name)
+			(*env)[envName] = value
+		}
+	}
+}
+
 func populateEnvsFromInput(env *map[string]string, action *model.Action, rc *RunContext) {
 	for inputID, input := range action.Inputs {
 		envKey := regexp.MustCompile("[^A-Z0-9-]").ReplaceAllString(strings.ToUpper(inputID), "_")
@@ -471,4 +482,69 @@ func getOsSafeRelativePath(s, prefix string) string {
 	actionName = strings.TrimPrefix(actionName, "/")
 
 	return actionName
+}
+
+func shouldRunPostStep(step actionStep) common.Conditional {
+	return func(ctx context.Context) bool {
+		stepResults := step.getRunContext().getStepsContext()
+
+		if stepResults[step.getStepModel().ID].Conclusion == model.StepStatusSkipped {
+			return false
+		}
+
+		if step.getActionModel() == nil {
+			return false
+		}
+
+		return true
+	}
+}
+
+func hasPostStep(step actionStep) common.Conditional {
+	return func(ctx context.Context) bool {
+		action := step.getActionModel()
+		return (action.Runs.Using == model.ActionRunsUsingNode12 ||
+			action.Runs.Using == model.ActionRunsUsingNode16) &&
+			action.Runs.Post != ""
+	}
+}
+
+func runPostStep(step actionStep) common.Executor {
+	return func(ctx context.Context) error {
+		rc := step.getRunContext()
+		stepModel := step.getStepModel()
+		action := step.getActionModel()
+
+		switch action.Runs.Using {
+		case model.ActionRunsUsingNode12, model.ActionRunsUsingNode16:
+
+			populateEnvsFromSavedState(step.getEnv(), step, rc)
+
+			var actionDir string
+			var actionPath string
+			if _, ok := step.(*stepActionRemote); ok {
+				actionPath = newRemoteAction(stepModel.Uses).Path
+				actionDir = fmt.Sprintf("%s/%s", rc.ActionCacheDir(), strings.ReplaceAll(stepModel.Uses, "/", "-"))
+			} else {
+				actionDir = filepath.Join(rc.Config.Workdir, stepModel.Uses)
+				actionPath = ""
+			}
+
+			actionLocation := ""
+			if actionPath != "" {
+				actionLocation = path.Join(actionDir, actionPath)
+			} else {
+				actionLocation = actionDir
+			}
+
+			_, containerActionDir := getContainerActionPaths(stepModel, actionLocation, rc)
+
+			containerArgs := []string{"node", path.Join(containerActionDir, action.Runs.Post)}
+			log.Debugf("executing remote job container: %s", containerArgs)
+
+			return rc.execJobContainer(containerArgs, *step.getEnv(), "", "")(ctx)
+		default:
+			return nil
+		}
+	}
 }

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -1,0 +1,9 @@
+package runner
+
+import "github.com/nektos/act/pkg/common"
+
+type compositeSteps struct {
+	pre  common.Executor
+	main common.Executor
+	post common.Executor
+}

--- a/pkg/runner/action_test.go
+++ b/pkg/runner/action_test.go
@@ -156,10 +156,10 @@ func TestActionRunner(t *testing.T) {
 			name: "with-input",
 			step: &stepActionRemote{
 				Step: &model.Step{
-					Uses: "repo@ref",
+					Uses: "org/repo/path@ref",
 				},
 				RunContext: &RunContext{
-					ActionRepository: "repo",
+					ActionRepository: "org/repo",
 					ActionPath:       "path",
 					ActionRef:        "ref",
 					Config:           &Config{},
@@ -193,10 +193,10 @@ func TestActionRunner(t *testing.T) {
 			step: &stepActionRemote{
 				Step: &model.Step{
 					ID:   "step",
-					Uses: "repo@ref",
+					Uses: "org/repo/path@ref",
 				},
 				RunContext: &RunContext{
-					ActionRepository: "repo",
+					ActionRepository: "org/repo",
 					ActionPath:       "path",
 					ActionRef:        "ref",
 					Config:           &Config{},

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -63,6 +63,9 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		case resumeCommand:
 			resumeCommand = ""
 			logger.Infof("  \U00002699  %s", line)
+		case "save-state":
+			logger.Infof("  \U0001f4be  %s", line)
+			rc.saveState(ctx, kvPairs, arg)
 		default:
 			logger.Infof("  \U00002753  %s", line)
 		}
@@ -140,4 +143,16 @@ func unescapeKvPairs(kvPairs map[string]string) map[string]string {
 		kvPairs[k] = unescapeCommandProperty(v)
 	}
 	return kvPairs
+}
+
+func (rc *RunContext) saveState(ctx context.Context, kvPairs map[string]string, arg string) {
+	if rc.CurrentStep != "" {
+		stepResult := rc.StepResults[rc.CurrentStep]
+		if stepResult != nil {
+			if stepResult.State == nil {
+				stepResult.State = map[string]string{}
+			}
+			stepResult.State[kvPairs["name"]] = arg
+		}
+	}
 }

--- a/pkg/runner/command_test.go
+++ b/pkg/runner/command_test.go
@@ -173,3 +173,21 @@ func TestAddmaskUsemask(t *testing.T) {
 
 	a.Equal("[testjob]   \U00002699  ***\n[testjob]   \U00002699  ::set-output:: = token=***\n", re)
 }
+
+func TestSaveState(t *testing.T) {
+	rc := &RunContext{
+		CurrentStep: "step",
+		StepResults: map[string]*model.StepResult{
+			"step": {
+				State: map[string]string{},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	handler := rc.commandHandler(ctx)
+	handler("::save-state name=state-name::state-value\n")
+
+	assert.Equal(t, "state-value", rc.StepResults["step"].State["state-name"])
+}

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -18,14 +18,49 @@ type step interface {
 	getRunContext() *RunContext
 	getStepModel() *model.Step
 	getEnv() *map[string]string
+	getIfExpression(stage stepStage) string
 }
 
-func runStepExecutor(step step, executor common.Executor) common.Executor {
+type stepStage int
+
+const (
+	stepStagePre stepStage = iota
+	stepStageMain
+	stepStagePost
+)
+
+func (s stepStage) String() string {
+	switch s {
+	case stepStagePre:
+		return "Pre"
+	case stepStageMain:
+		return "Run"
+	case stepStagePost:
+		return "Post"
+	}
+	return "Unknown"
+}
+
+func (s stepStage) getStepName(stepModel *model.Step) string {
+	switch s {
+	case stepStagePre:
+		return fmt.Sprintf("pre-%s", stepModel.ID)
+	case stepStageMain:
+		return stepModel.ID
+	case stepStagePost:
+		return fmt.Sprintf("post-%s", stepModel.ID)
+	}
+	return "unknown"
+}
+
+func runStepExecutor(step step, stage stepStage, executor common.Executor) common.Executor {
 	return func(ctx context.Context) error {
 		rc := step.getRunContext()
 		stepModel := step.getStepModel()
 
-		rc.CurrentStep = stepModel.ID
+		ifExpression := step.getIfExpression(stage)
+		rc.CurrentStep = stage.getStepName(stepModel)
+
 		rc.StepResults[rc.CurrentStep] = &model.StepResult{
 			Outcome:    model.StepStatusSuccess,
 			Conclusion: model.StepStatusSuccess,
@@ -37,7 +72,7 @@ func runStepExecutor(step step, executor common.Executor) common.Executor {
 			return err
 		}
 
-		runStep, err := isStepEnabled(ctx, step)
+		runStep, err := isStepEnabled(ctx, ifExpression, step)
 		if err != nil {
 			rc.StepResults[rc.CurrentStep].Conclusion = model.StepStatusFailure
 			rc.StepResults[rc.CurrentStep].Outcome = model.StepStatusFailure
@@ -45,13 +80,13 @@ func runStepExecutor(step step, executor common.Executor) common.Executor {
 		}
 
 		if !runStep {
-			log.Debugf("Skipping step '%s' due to '%s'", stepModel.String(), stepModel.If.Value)
+			log.Debugf("Skipping step '%s' due to '%s'", stepModel, stepModel.If.Value)
 			rc.StepResults[rc.CurrentStep].Conclusion = model.StepStatusSkipped
 			rc.StepResults[rc.CurrentStep].Outcome = model.StepStatusSkipped
 			return nil
 		}
 
-		common.Logger(ctx).Infof("\u2B50  Run %s", stepModel)
+		common.Logger(ctx).Infof("\u2B50  %s %s", stage, stepModel)
 
 		err = executor(ctx)
 
@@ -125,10 +160,10 @@ func mergeEnv(step step) {
 	mergeIntoMap(env, rc.withGithubEnv(*env))
 }
 
-func isStepEnabled(ctx context.Context, step step) (bool, error) {
+func isStepEnabled(ctx context.Context, expr string, step step) (bool, error) {
 	rc := step.getRunContext()
 
-	runStep, err := EvalBool(rc.NewStepExpressionEvaluator(step), step.getStepModel().If.Value)
+	runStep, err := EvalBool(rc.NewStepExpressionEvaluator(step), expr)
 	if err != nil {
 		return false, fmt.Errorf("  \u274C  Error in if-expression: \"if: %s\" (%s)", step.getStepModel().If.Value, err)
 	}

--- a/pkg/runner/step_action_local.go
+++ b/pkg/runner/step_action_local.go
@@ -32,7 +32,7 @@ func (sal *stepActionLocal) pre() common.Executor {
 func (sal *stepActionLocal) main() common.Executor {
 	sal.env = map[string]string{}
 
-	return runStepExecutor(sal, func(ctx context.Context) error {
+	return runStepExecutor(sal, stepStageMain, func(ctx context.Context) error {
 		actionDir := filepath.Join(sal.getRunContext().Config.Workdir, sal.Step.Uses)
 
 		localReader := func(ctx context.Context) actionYamlReader {
@@ -63,9 +63,7 @@ func (sal *stepActionLocal) main() common.Executor {
 }
 
 func (sal *stepActionLocal) post() common.Executor {
-	return func(ctx context.Context) error {
-		return nil
-	}
+	return runStepExecutor(sal, stepStagePost, runPostStep(sal)).If(hasPostStep(sal)).If(shouldRunPostStep(sal))
 }
 
 func (sal *stepActionLocal) getRunContext() *RunContext {
@@ -78,6 +76,16 @@ func (sal *stepActionLocal) getStepModel() *model.Step {
 
 func (sal *stepActionLocal) getEnv() *map[string]string {
 	return &sal.env
+}
+
+func (sal *stepActionLocal) getIfExpression(stage stepStage) string {
+	switch stage {
+	case stepStageMain:
+		return sal.Step.If.Value
+	case stepStagePost:
+		return sal.action.Runs.PostIf
+	}
+	return ""
 }
 
 func (sal *stepActionLocal) getActionModel() *model.Action {

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -2,12 +2,14 @@ package runner
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"gopkg.in/yaml.v3"
 )
 
 type stepActionLocalMocks struct {
@@ -88,14 +90,205 @@ func TestStepActionLocalTest(t *testing.T) {
 	salm.AssertExpectations(t)
 }
 
-func TestStepActionLocalPrePost(t *testing.T) {
+func TestStepActionLocalPre(t *testing.T) {
 	ctx := context.Background()
 
 	sal := &stepActionLocal{}
 
 	err := sal.pre()(ctx)
 	assert.Nil(t, err)
+}
 
-	err = sal.post()(ctx)
-	assert.Nil(t, err)
+func TestStepActionLocalPost(t *testing.T) {
+	table := []struct {
+		name                   string
+		stepModel              *model.Step
+		actionModel            *model.Action
+		initialStepResults     map[string]*model.StepResult
+		expectedPostStepResult *model.StepResult
+		err                    error
+		mocks                  struct {
+			env  bool
+			exec bool
+		}
+	}{
+		{
+			name: "main-success",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "./local/action",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "always()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusSuccess,
+					Outcome:    model.StepStatusSuccess,
+					Outputs:    map[string]string{},
+				},
+			},
+			expectedPostStepResult: &model.StepResult{
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusSuccess,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  true,
+				exec: true,
+			},
+		},
+		{
+			name: "main-failed",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "./local/action",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "always()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusFailure,
+					Outcome:    model.StepStatusFailure,
+					Outputs:    map[string]string{},
+				},
+			},
+			expectedPostStepResult: &model.StepResult{
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusSuccess,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  true,
+				exec: true,
+			},
+		},
+		{
+			name: "skip-if-failed",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "./local/action",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "success()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusFailure,
+					Outcome:    model.StepStatusFailure,
+					Outputs:    map[string]string{},
+				},
+			},
+			expectedPostStepResult: &model.StepResult{
+				Conclusion: model.StepStatusSkipped,
+				Outcome:    model.StepStatusSkipped,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  true,
+				exec: false,
+			},
+		},
+		{
+			name: "skip-if-main-skipped",
+			stepModel: &model.Step{
+				ID:   "step",
+				If:   yaml.Node{Value: "failure()"},
+				Uses: "./local/action",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "always()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusSkipped,
+					Outcome:    model.StepStatusSkipped,
+					Outputs:    map[string]string{},
+				},
+			},
+			expectedPostStepResult: nil,
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  false,
+				exec: false,
+			},
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			cm := &containerMock{}
+
+			sal := &stepActionLocal{
+				env: map[string]string{},
+				RunContext: &RunContext{
+					Config: &Config{
+						GitHubInstance: "https://github.com",
+					},
+					JobContainer: cm,
+					Run: &model.Run{
+						JobID: "1",
+						Workflow: &model.Workflow{
+							Jobs: map[string]*model.Job{
+								"1": {},
+							},
+						},
+					},
+					StepResults: tt.initialStepResults,
+				},
+				Step:   tt.stepModel,
+				action: tt.actionModel,
+			}
+
+			if tt.mocks.env {
+				cm.On("UpdateFromImageEnv", &sal.env).Return(func(ctx context.Context) error { return nil })
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", &sal.env).Return(func(ctx context.Context) error { return nil })
+				cm.On("UpdateFromPath", &sal.env).Return(func(ctx context.Context) error { return nil })
+			}
+			if tt.mocks.exec {
+				suffixMatcher := func(suffix string) interface{} {
+					return mock.MatchedBy(func(array []string) bool {
+						return strings.HasSuffix(array[1], suffix)
+					})
+				}
+				cm.On("Exec", suffixMatcher("pkg/runner/local/action/post.js"), sal.env, "", "").Return(func(ctx context.Context) error { return tt.err })
+			}
+
+			err := sal.post()(ctx)
+
+			assert.Equal(t, tt.err, err)
+			assert.Equal(t, tt.expectedPostStepResult, sal.RunContext.StepResults["post-step"])
+			cm.AssertExpectations(t)
+		})
+	}
 }

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/nektos/act/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"gopkg.in/yaml.v3"
 )
 
 type stepActionRemoteMocks struct {
@@ -25,78 +27,369 @@ func (sarm *stepActionRemoteMocks) runAction(step actionStep, actionDir string, 
 	return args.Get(0).(func(context.Context) error)
 }
 
-func TestStepActionRemoteTest(t *testing.T) {
-	ctx := context.Background()
-
-	cm := &containerMock{}
-
-	sarm := &stepActionRemoteMocks{}
-
-	clonedAction := false
-
-	origStepAtionRemoteNewCloneExecutor := stepActionRemoteNewCloneExecutor
-	stepActionRemoteNewCloneExecutor = func(input common.NewGitCloneExecutorInput) common.Executor {
-		return func(ctx context.Context) error {
-			clonedAction = true
-			return nil
+func TestStepActionRemote(t *testing.T) {
+	table := []struct {
+		name      string
+		stepModel *model.Step
+		result    *model.StepResult
+		mocks     struct {
+			env    bool
+			cloned bool
+			read   bool
+			run    bool
 		}
-	}
-	defer (func() {
-		stepActionRemoteNewCloneExecutor = origStepAtionRemoteNewCloneExecutor
-	})()
-
-	sar := &stepActionRemote{
-		RunContext: &RunContext{
-			Config: &Config{
-				GitHubInstance: "github.com",
+		runError error
+	}{
+		{
+			name: "run-successful",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "remote/action@v1",
 			},
-			Run: &model.Run{
-				JobID: "1",
-				Workflow: &model.Workflow{
-					Jobs: map[string]*model.Job{
-						"1": {},
+			result: &model.StepResult{
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusSuccess,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env    bool
+				cloned bool
+				read   bool
+				run    bool
+			}{
+				env:    true,
+				cloned: true,
+				read:   true,
+				run:    true,
+			},
+		},
+		{
+			name: "run-skipped",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "remote/action@v1",
+				If:   yaml.Node{Value: "false"},
+			},
+			result: &model.StepResult{
+				Conclusion: model.StepStatusSkipped,
+				Outcome:    model.StepStatusSkipped,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env    bool
+				cloned bool
+				read   bool
+				run    bool
+			}{
+				env:    true,
+				cloned: false,
+				read:   false,
+				run:    false,
+			},
+		},
+		{
+			name: "run-error",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "remote/action@v1",
+			},
+			result: &model.StepResult{
+				Conclusion: model.StepStatusFailure,
+				Outcome:    model.StepStatusFailure,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env    bool
+				cloned bool
+				read   bool
+				run    bool
+			}{
+				env:    true,
+				cloned: true,
+				read:   true,
+				run:    true,
+			},
+			runError: errors.New("error"),
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			cm := &containerMock{}
+			sarm := &stepActionRemoteMocks{}
+
+			clonedAction := false
+
+			origStepAtionRemoteNewCloneExecutor := stepActionRemoteNewCloneExecutor
+			stepActionRemoteNewCloneExecutor = func(input common.NewGitCloneExecutorInput) common.Executor {
+				return func(ctx context.Context) error {
+					clonedAction = true
+					return nil
+				}
+			}
+			defer (func() {
+				stepActionRemoteNewCloneExecutor = origStepAtionRemoteNewCloneExecutor
+			})()
+
+			sar := &stepActionRemote{
+				RunContext: &RunContext{
+					Config: &Config{
+						GitHubInstance: "github.com",
 					},
+					Run: &model.Run{
+						JobID: "1",
+						Workflow: &model.Workflow{
+							Jobs: map[string]*model.Job{
+								"1": {},
+							},
+						},
+					},
+					StepResults:  map[string]*model.StepResult{},
+					JobContainer: cm,
 				},
-			},
-			StepResults:  map[string]*model.StepResult{},
-			JobContainer: cm,
-		},
-		Step: &model.Step{
-			Uses: "remote/action@v1",
-		},
-		readAction: sarm.readAction,
-		runAction:  sarm.runAction,
-	}
+				Step:       tt.stepModel,
+				readAction: sarm.readAction,
+				runAction:  sarm.runAction,
+			}
 
-	suffixMatcher := func(suffix string) interface{} {
-		return mock.MatchedBy(func(actionDir string) bool {
-			return strings.HasSuffix(actionDir, suffix)
+			suffixMatcher := func(suffix string) interface{} {
+				return mock.MatchedBy(func(actionDir string) bool {
+					return strings.HasSuffix(actionDir, suffix)
+				})
+			}
+
+			if tt.mocks.env {
+				cm.On("UpdateFromImageEnv", &sar.env).Return(func(ctx context.Context) error { return nil })
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", &sar.env).Return(func(ctx context.Context) error { return nil })
+				cm.On("UpdateFromPath", &sar.env).Return(func(ctx context.Context) error { return nil })
+			}
+			if tt.mocks.read {
+				sarm.On("readAction", sar.Step, suffixMatcher("act/remote-action@v1"), "", mock.Anything, mock.Anything).Return(&model.Action{}, nil)
+			}
+			if tt.mocks.run {
+				sarm.On("runAction", sar, suffixMatcher("act/remote-action@v1"), newRemoteAction(sar.Step.Uses)).Return(func(ctx context.Context) error { return tt.runError })
+			}
+
+			err := sar.main()(ctx)
+
+			assert.Equal(t, tt.runError, err)
+			assert.Equal(t, tt.mocks.cloned, clonedAction)
+			assert.Equal(t, tt.result, sar.RunContext.StepResults["step"])
+
+			sarm.AssertExpectations(t)
+			cm.AssertExpectations(t)
 		})
 	}
-
-	cm.On("UpdateFromImageEnv", &sar.env).Return(func(ctx context.Context) error { return nil })
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", &sar.env).Return(func(ctx context.Context) error { return nil })
-	cm.On("UpdateFromPath", &sar.env).Return(func(ctx context.Context) error { return nil })
-
-	sarm.On("readAction", sar.Step, suffixMatcher("act/remote-action@v1"), "", mock.Anything, mock.Anything).Return(&model.Action{}, nil)
-	sarm.On("runAction", sar, suffixMatcher("act/remote-action@v1"), newRemoteAction(sar.Step.Uses)).Return(func(ctx context.Context) error { return nil })
-
-	err := sar.main()(ctx)
-
-	assert.Nil(t, err)
-	assert.True(t, clonedAction)
-	sarm.AssertExpectations(t)
-	cm.AssertExpectations(t)
 }
 
-func TestStepActionRemotePrePost(t *testing.T) {
+func TestStepActionRemotePre(t *testing.T) {
 	ctx := context.Background()
 
 	sar := &stepActionRemote{}
 
 	err := sar.pre()(ctx)
 	assert.Nil(t, err)
+}
 
-	err = sar.post()(ctx)
-	assert.Nil(t, err)
+func TestStepActionRemotePost(t *testing.T) {
+	table := []struct {
+		name                   string
+		stepModel              *model.Step
+		actionModel            *model.Action
+		initialStepResults     map[string]*model.StepResult
+		expectedEnv            map[string]string
+		expectedPostStepResult *model.StepResult
+		err                    error
+		mocks                  struct {
+			env  bool
+			exec bool
+		}
+	}{
+		{
+			name: "main-success",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "remote/action@v1",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "always()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusSuccess,
+					Outcome:    model.StepStatusSuccess,
+					Outputs:    map[string]string{},
+					State: map[string]string{
+						"key": "value",
+					},
+				},
+			},
+			expectedEnv: map[string]string{
+				"STATE_key": "value",
+			},
+			expectedPostStepResult: &model.StepResult{
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusSuccess,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  true,
+				exec: true,
+			},
+		},
+		{
+			name: "main-failed",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "remote/action@v1",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "always()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusFailure,
+					Outcome:    model.StepStatusFailure,
+					Outputs:    map[string]string{},
+				},
+			},
+			expectedPostStepResult: &model.StepResult{
+				Conclusion: model.StepStatusSuccess,
+				Outcome:    model.StepStatusSuccess,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  true,
+				exec: true,
+			},
+		},
+		{
+			name: "skip-if-failed",
+			stepModel: &model.Step{
+				ID:   "step",
+				Uses: "remote/action@v1",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "success()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusFailure,
+					Outcome:    model.StepStatusFailure,
+					Outputs:    map[string]string{},
+				},
+			},
+			expectedPostStepResult: &model.StepResult{
+				Conclusion: model.StepStatusSkipped,
+				Outcome:    model.StepStatusSkipped,
+				Outputs:    map[string]string{},
+			},
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  true,
+				exec: false,
+			},
+		},
+		{
+			name: "skip-if-main-skipped",
+			stepModel: &model.Step{
+				ID:   "step",
+				If:   yaml.Node{Value: "failure()"},
+				Uses: "remote/action@v1",
+			},
+			actionModel: &model.Action{
+				Runs: model.ActionRuns{
+					Using:  "node16",
+					Post:   "post.js",
+					PostIf: "always()",
+				},
+			},
+			initialStepResults: map[string]*model.StepResult{
+				"step": {
+					Conclusion: model.StepStatusSkipped,
+					Outcome:    model.StepStatusSkipped,
+					Outputs:    map[string]string{},
+				},
+			},
+			expectedPostStepResult: nil,
+			mocks: struct {
+				env  bool
+				exec bool
+			}{
+				env:  false,
+				exec: false,
+			},
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			cm := &containerMock{}
+
+			sar := &stepActionRemote{
+				env: map[string]string{},
+				RunContext: &RunContext{
+					Config: &Config{
+						GitHubInstance: "https://github.com",
+					},
+					JobContainer: cm,
+					Run: &model.Run{
+						JobID: "1",
+						Workflow: &model.Workflow{
+							Jobs: map[string]*model.Job{
+								"1": {},
+							},
+						},
+					},
+					StepResults: tt.initialStepResults,
+				},
+				Step:   tt.stepModel,
+				action: tt.actionModel,
+			}
+
+			if tt.mocks.env {
+				cm.On("UpdateFromImageEnv", &sar.env).Return(func(ctx context.Context) error { return nil })
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", &sar.env).Return(func(ctx context.Context) error { return nil })
+				cm.On("UpdateFromPath", &sar.env).Return(func(ctx context.Context) error { return nil })
+			}
+			if tt.mocks.exec {
+				cm.On("Exec", []string{"node", "/var/run/act/actions/remote-action@v1/post.js"}, sar.env, "", "").Return(func(ctx context.Context) error { return tt.err })
+			}
+
+			err := sar.post()(ctx)
+
+			assert.Equal(t, tt.err, err)
+			if tt.expectedEnv != nil {
+				for key, value := range tt.expectedEnv {
+					assert.Equal(t, value, sar.env[key])
+				}
+			}
+			assert.Equal(t, tt.expectedPostStepResult, sar.RunContext.StepResults["post-step"])
+			cm.AssertExpectations(t)
+		})
+	}
 }

--- a/pkg/runner/step_docker.go
+++ b/pkg/runner/step_docker.go
@@ -26,7 +26,7 @@ func (sd *stepDocker) pre() common.Executor {
 func (sd *stepDocker) main() common.Executor {
 	sd.env = map[string]string{}
 
-	return runStepExecutor(sd, sd.runUsesContainer())
+	return runStepExecutor(sd, stepStageMain, sd.runUsesContainer())
 }
 
 func (sd *stepDocker) post() common.Executor {
@@ -45,6 +45,10 @@ func (sd *stepDocker) getStepModel() *model.Step {
 
 func (sd *stepDocker) getEnv() *map[string]string {
 	return &sd.env
+}
+
+func (sd *stepDocker) getIfExpression(stage stepStage) string {
+	return sd.Step.If.Value
 }
 
 func (sd *stepDocker) runUsesContainer() common.Executor {

--- a/pkg/runner/step_run.go
+++ b/pkg/runner/step_run.go
@@ -28,7 +28,7 @@ func (sr *stepRun) pre() common.Executor {
 func (sr *stepRun) main() common.Executor {
 	sr.env = map[string]string{}
 
-	return runStepExecutor(sr, common.NewPipelineExecutor(
+	return runStepExecutor(sr, stepStageMain, common.NewPipelineExecutor(
 		sr.setupShellCommandExecutor(),
 		func(ctx context.Context) error {
 			return sr.getRunContext().JobContainer.Exec(sr.cmd, sr.env, "", sr.Step.WorkingDirectory)(ctx)
@@ -52,6 +52,10 @@ func (sr *stepRun) getStepModel() *model.Step {
 
 func (sr *stepRun) getEnv() *map[string]string {
 	return &sr.env
+}
+
+func (sr *stepRun) getIfExpression(stage stepStage) string {
+	return sr.Step.If.Value
 }
 
 func (sr *stepRun) setupShellCommandExecutor() common.Executor {

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -228,49 +228,49 @@ func TestIsStepEnabled(t *testing.T) {
 
 	// success()
 	step := createTestStep(t, "if: success()")
-	assertObject.True(isStepEnabled(context.Background(), step))
+	assertObject.True(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	step = createTestStep(t, "if: success()")
 	step.getRunContext().StepResults["a"] = &model.StepResult{
 		Conclusion: model.StepStatusSuccess,
 	}
-	assertObject.True(isStepEnabled(context.Background(), step))
+	assertObject.True(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	step = createTestStep(t, "if: success()")
 	step.getRunContext().StepResults["a"] = &model.StepResult{
 		Conclusion: model.StepStatusFailure,
 	}
-	assertObject.False(isStepEnabled(context.Background(), step))
+	assertObject.False(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	// failure()
 	step = createTestStep(t, "if: failure()")
-	assertObject.False(isStepEnabled(context.Background(), step))
+	assertObject.False(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	step = createTestStep(t, "if: failure()")
 	step.getRunContext().StepResults["a"] = &model.StepResult{
 		Conclusion: model.StepStatusSuccess,
 	}
-	assertObject.False(isStepEnabled(context.Background(), step))
+	assertObject.False(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	step = createTestStep(t, "if: failure()")
 	step.getRunContext().StepResults["a"] = &model.StepResult{
 		Conclusion: model.StepStatusFailure,
 	}
-	assertObject.True(isStepEnabled(context.Background(), step))
+	assertObject.True(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	// always()
 	step = createTestStep(t, "if: always()")
-	assertObject.True(isStepEnabled(context.Background(), step))
+	assertObject.True(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	step = createTestStep(t, "if: always()")
 	step.getRunContext().StepResults["a"] = &model.StepResult{
 		Conclusion: model.StepStatusSuccess,
 	}
-	assertObject.True(isStepEnabled(context.Background(), step))
+	assertObject.True(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 
 	step = createTestStep(t, "if: always()")
 	step.getRunContext().StepResults["a"] = &model.StepResult{
 		Conclusion: model.StepStatusFailure,
 	}
-	assertObject.True(isStepEnabled(context.Background(), step))
+	assertObject.True(isStepEnabled(context.Background(), step.getStepModel().If.Value, step))
 }


### PR DESCRIPTION
This change implements [action post step](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runspost) in combination with the [save-state command](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#sending-values-to-the-pre-and-post-actions).
It does support the `post-if` condition.

There are a few preparations for action pre steps, but it's not fully implemented in this PR.

Closes #626
