### PR TITLE
fix: hide masked values in log files

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -55,6 +55,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		case "error":
 			logger.Infof("  \U00002757  %s", line)
 		case "add-mask":
+			rc.AddMask(arg)
 			logger.Infof("  \U00002699  %s", "***")
 		case "stop-commands":
 			resumeCommand = arg

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -46,6 +46,11 @@ type RunContext struct {
 	Composite        *model.Action
 	Inputs           map[string]interface{}
 	Parent           *RunContext
+	Masks            []string
+}
+
+func (rc *RunContext) AddMask(mask string) {
+	rc.Masks = append(rc.Masks, mask)
 }
 
 func (rc *RunContext) Clone() *RunContext {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -164,7 +164,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 							}
 
 							return nil
-						})(common.WithJobErrorContainer(WithJobLogger(ctx, jobName, rc.Config.Secrets, rc.Config.InsecureSecrets)))
+						})(common.WithJobErrorContainer(WithJobLogger(ctx, jobName, rc.Config.Secrets, rc.Config.InsecureSecrets, &rc.Masks)))
 					})
 				}
 				pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -671,6 +671,8 @@ func (sc *StepContext) execAsComposite(ctx context.Context, step *model.Step, _ 
 			"name": outputName,
 		}, eval.Interpolate(output.Value))
 	}
+
+	backup.Masks = append(backup.Masks, compositerc.Masks...)
 	// Test if evaluated parent env was altered by this composite step
 	// Known Issues:
 	// - you try to set an env variable to the same value as a scoped step env, will be discared


### PR DESCRIPTION
this commit adds support for the `::add-mask::` command, which was
implemented as a stub before.

it does not cover debug output that appears when you run act in
verbose mode
