### PR TITLE
Revert: Don't stop JobContainer on failure

### DIFF
--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -53,15 +53,14 @@ func newJobExecutor(info jobInfo) common.Executor {
 	}
 
 	steps = append(steps, func(ctx context.Context) error {
-		err := info.stopContainer()(ctx)
-		if err != nil {
-			return err
-		}
-
 		jobError := common.JobError(ctx)
 		if jobError != nil {
 			info.result("failure")
 		} else {
+			err := info.stopContainer()(ctx)
+			if err != nil {
+				return err
+			}
 			info.result("success")
 		}
 

--- a/pkg/runner/job_executor_test.go
+++ b/pkg/runner/job_executor_test.go
@@ -103,7 +103,6 @@ func TestNewJobExecutor(t *testing.T) {
 			executedSteps: []string{
 				"startContainer",
 				"step1",
-				"stopContainer",
 				"interpolateOutputs",
 				"closeContainer",
 			},


### PR DESCRIPTION
This was a breaking change of [nektos/act#840](https://github.com/nektos/act/pull/840)