### PR TITLE
feat: add flag to always run the checkout action

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -39,6 +39,7 @@ type Input struct {
 	artifactServerPath    string
 	artifactServerPort    string
 	jsonLogger            bool
+	noSkipCheckout        bool
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().StringVarP(&input.githubInstance, "github-instance", "", "github.com", "GitHub instance to use. Don't use this if you are not using GitHub Enterprise Server.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerPath, "artifact-server-path", "", "", "Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified the artifact server will not start.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerPort, "artifact-server-port", "", "34567", "Defines the port where the artifact server listens (will only bind to localhost).")
+	rootCmd.PersistentFlags().BoolVarP(&input.noSkipCheckout, "no-skip-checkout", "", false, "Do not skip actions/checkout")
 	rootCmd.SetArgs(args())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -287,6 +288,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			AutoRemove:            input.autoRemove,
 			ArtifactServerPath:    input.artifactServerPath,
 			ArtifactServerPort:    input.artifactServerPort,
+			NoSkipCheckout:        input.noSkipCheckout,
 		}
 		r, err := runner.New(config)
 		if err != nil {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -708,6 +708,10 @@ func setActionRuntimeVars(rc *RunContext, env map[string]string) {
 }
 
 func (rc *RunContext) localCheckoutPath() (string, bool) {
+	if rc.Config.NoSkipCheckout {
+		return "", false
+	}
+
 	ghContext := rc.getGithubContext()
 	for _, step := range rc.Run.Job().Steps {
 		if isLocalCheckout(ghContext, step) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -48,6 +48,7 @@ type Config struct {
 	ArtifactServerPath    string                       // the path where the artifact server stores uploads
 	ArtifactServerPort    string                       // the port the artifact server binds to
 	CompositeRestrictions *model.CompositeRestrictions // describes which features are available in composite actions
+	NoSkipCheckout        bool                         // do not skip actions/checkout
 }
 
 // Resolves the equivalent host path inside the container

--- a/pkg/runner/step_context.go
+++ b/pkg/runner/step_context.go
@@ -92,7 +92,7 @@ func (sc *StepContext) Executor(ctx context.Context) common.Executor {
 		remoteAction.URL = rc.Config.GitHubInstance
 
 		github := rc.getGithubContext()
-		if remoteAction.IsCheckout() && isLocalCheckout(github, step) {
+		if remoteAction.IsCheckout() && isLocalCheckout(github, step) && !rc.Config.NoSkipCheckout {
 			return func(ctx context.Context) error {
 				common.Logger(ctx).Debugf("Skipping local actions/checkout because workdir was already copied")
 				return nil


### PR DESCRIPTION
act has a feature that skips the checkout action to do a remote
checkout when a local checkout exists. in some cases, e.g. when
running act in a CI, you always want to clone the repository.