### PR TITLE
Fix: call of reflect.Value.Interface on zero Value

### DIFF
--- a/pkg/exprparser/interpreter.go
+++ b/pkg/exprparser/interpreter.go
@@ -195,7 +195,7 @@ func (impl *interperterImpl) evaluateArrayDeref(arrayDerefNode *actionlint.Array
 		return nil, err
 	}
 
-	return reflect.ValueOf(left).Interface(), nil
+	return impl.getSafeValue(reflect.ValueOf(left)), nil
 }
 
 func (impl *interperterImpl) getPropertyValue(left reflect.Value, property string) (value interface{}, err error) {


### PR DESCRIPTION
panic: reflect: call of reflect.Value.Interface on zero Value

panics are very bad

Resolves https://github.com/nektos/act/issues/1065