### PR TITLE
fix(editorconfig): correct braces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ indent_size = 4
 indent_style = unset
 indent_size = unset
 
-[*.{yml,yaml,js{,on}}]
+[*.{yml,yaml,js,json}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Apparently it's wrong in current form, and it doesn't work in JetBrains IDEs but it seemed to work in VSCode, so fixing
Signed-off-by: Ryan <me@hackerc.at>