### PR TITLE
tests(runner): move arm64 test to own func

### DIFF
--- a/pkg/runner/job_executor_test.go
+++ b/pkg/runner/job_executor_test.go
@@ -12,18 +12,15 @@ import (
 )
 
 func TestJobExecutor(t *testing.T) {
-	platforms := map[string]string{
-		"ubuntu-latest": baseImage,
-	}
 	tables := []TestJobFileInfo{
-		{"testdata", "uses-and-run-in-one-step", "push", "Invalid run/uses syntax for job:test step:Test", platforms, ""},
-		{"testdata", "uses-github-empty", "push", "Expected format {org}/{repo}[/path]@ref", platforms, ""},
-		{"testdata", "uses-github-noref", "push", "Expected format {org}/{repo}[/path]@ref", platforms, ""},
-		{"testdata", "uses-github-root", "push", "", platforms, ""},
-		{"testdata", "uses-github-path", "push", "", platforms, ""},
-		{"testdata", "uses-docker-url", "push", "", platforms, ""},
-		{"testdata", "uses-github-full-sha", "push", "", platforms, ""},
-		{"testdata", "uses-github-short-sha", "push", "Unable to resolve action `actions/hello-world-docker-action@b136eb8`, the provided ref `b136eb8` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `b136eb8894c5cb1dd5807da824be97ccdf9b5423` instead", platforms, ""},
+		{workdir, "uses-and-run-in-one-step", "push", "Invalid run/uses syntax for job:test step:Test", platforms},
+		{workdir, "uses-github-empty", "push", "Expected format {org}/{repo}[/path]@ref", platforms},
+		{workdir, "uses-github-noref", "push", "Expected format {org}/{repo}[/path]@ref", platforms},
+		{workdir, "uses-github-root", "push", "", platforms},
+		{workdir, "uses-github-path", "push", "", platforms},
+		{workdir, "uses-docker-url", "push", "", platforms},
+		{workdir, "uses-github-full-sha", "push", "", platforms},
+		{workdir, "uses-github-short-sha", "push", "Unable to resolve action `actions/hello-world-docker-action@b136eb8`, the provided ref `b136eb8` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `b136eb8894c5cb1dd5807da824be97ccdf9b5423` instead", platforms},
 	}
 	// These tests are sufficient to only check syntax.
 	ctx := common.WithDryrun(context.Background(), true)

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nektos/act/pkg/model"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	assert "github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -26,7 +25,6 @@ func TestRunContext_EvalBool(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	hook := test.NewGlobal()
 	rc := &RunContext{
 		Config: &Config{
 			Workdir: ".",
@@ -157,14 +155,12 @@ func TestRunContext_EvalBool(t *testing.T) {
 		table := table
 		t.Run(table.in, func(t *testing.T) {
 			assertObject := assert.New(t)
-			defer hook.Reset()
 			b, err := EvalBool(rc.ExprEval, table.in)
 			if table.wantErr {
 				assertObject.Error(err)
 			}
 
 			assertObject.Equal(table.out, b, fmt.Sprintf("Expected %s to be %v, was %v", table.in, table.out, b))
-			assertObject.Empty(hook.LastEntry(), table.in)
 		})
 	}
 }


### PR DESCRIPTION
Prevents random failing of all other runs when qemu binfmt is not set up
but also clean up since we need `ContainerArchitecture` in single test only

Signed-off-by: Ryan <me@hackerc.at>