### PR TITLE
docs(README): remove go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,26 +100,6 @@ or through `nix-shell`:
 nix-shell -p act
 ```
 
-### [Go](https://golang.org) (Linux/Windows/macOS/any other platform supported by Go)
-
-If you have Go 1.18+, you can install latest released version of `act` directly from source by running:
-
-```sh
-go install github.com/nektos/act@latest
-```
-
-or if you want to install latest unreleased version:
-
-```sh
-go install github.com/nektos/act@master
-```
-
-If you want a smaller binary size, run above commands with `-ldflags="-s -w"`
-
-```sh
-go install -ldflags="-s -w" github.com/nektos/act@...
-```
-
 ## Other install options
 
 ### Bash script


### PR DESCRIPTION
fixes #1122 

it's better to not advertise `go install` as recommended way since it has it's own quirks
and people who know Go enough will know about it anyway

I removed that part from wiki but forgot to do same for README