### PR TITLE
tests: remove runTestJobFile

### DIFF
--- a/pkg/runner/job_executor_test.go
+++ b/pkg/runner/job_executor_test.go
@@ -25,7 +25,9 @@ func TestJobExecutor(t *testing.T) {
 	// These tests are sufficient to only check syntax.
 	ctx := common.WithDryrun(context.Background(), true)
 	for _, table := range tables {
-		runTestJobFile(ctx, t, table)
+		t.Run(table.workflowPath, func(t *testing.T) {
+			table.runTest(ctx, t, &Config{})
+		})
 	}
 }
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -105,12 +105,6 @@ func (j *TestJobFileInfo) runTest(ctx context.Context, t *testing.T, cfg *Config
 	}
 }
 
-func runTestJobFile(ctx context.Context, t *testing.T, j TestJobFileInfo) {
-	t.Run(j.workflowPath, func(t *testing.T) {
-		j.runTest(ctx, t, &Config{})
-	})
-}
-
 func TestRunEvent(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -179,7 +173,9 @@ func TestRunEvent(t *testing.T) {
 	}
 
 	for _, table := range tables {
-		runTestJobFile(ctx, t, table)
+		t.Run(table.workflowPath, func(t *testing.T) {
+			table.runTest(ctx, t, &Config{})
+		})
 	}
 }
 


### PR DESCRIPTION
This prevented ~~CLion~~ GoLand 🤦‍♂️ from recognising subtests and treated it all as single big test, VSCode seems to be still broken in that regard
before:
![image](https://user-images.githubusercontent.com/31106839/163491670-aa189571-8fdf-4619-bee8-fe2aacad02bb.png)

after:
![image](https://user-images.githubusercontent.com/31106839/163491491-eccfb60e-0109-4ece-9877-10df3bc467e5.png)

