### PR TITLE
fix: conclusion and outcome are no integers

### DIFF
--- a/pkg/exprparser/interpreter.go
+++ b/pkg/exprparser/interpreter.go
@@ -1,6 +1,7 @@
 package exprparser
 
 import (
+	"encoding"
 	"fmt"
 	"math"
 	"reflect"
@@ -224,7 +225,16 @@ func (impl *interperterImpl) getPropertyValue(left reflect.Value, property strin
 			return "", nil
 		}
 
-		return fieldValue.Interface(), nil
+		i := fieldValue.Interface()
+		// The type stepStatus int is an integer, but should be treated as string
+		if m, ok := i.(encoding.TextMarshaler); ok {
+			text, err := m.MarshalText()
+			if err != nil {
+				return nil, err
+			}
+			return string(text), nil
+		}
+		return i, nil
 
 	case reflect.Map:
 		iter := left.MapRange()

--- a/pkg/exprparser/interpreter_test.go
+++ b/pkg/exprparser/interpreter_test.go
@@ -527,6 +527,22 @@ func TestContexts(t *testing.T) {
 		{"env.TEST", "value", "env-context"},
 		{"job.status", "success", "job-context"},
 		{"steps.step-id.outputs.name", "value", "steps-context"},
+		{"steps.step-id.conclusion", "success", "steps-context-conclusion"},
+		{"steps.step-id.conclusion && true", true, "steps-context-conclusion"},
+		{"steps.step-id2.conclusion", "skipped", "steps-context-conclusion"},
+		{"steps.step-id2.conclusion && true", true, "steps-context-conclusion"},
+		{"steps.step-id.outcome", "success", "steps-context-outcome"},
+		{"steps.step-id['outcome']", "success", "steps-context-outcome"},
+		{"steps.step-id.outcome == 'success'", true, "steps-context-outcome"},
+		{"steps.step-id['outcome'] == 'success'", true, "steps-context-outcome"},
+		{"steps.step-id.outcome && true", true, "steps-context-outcome"},
+		{"steps['step-id']['outcome'] && true", true, "steps-context-outcome"},
+		{"steps.step-id2.outcome", "failure", "steps-context-outcome"},
+		{"steps.step-id2.outcome && true", true, "steps-context-outcome"},
+		// Disabled, since the interpreter is still too broken
+		// {"contains(steps.*.outcome, 'success')", true, "steps-context-array-outcome"},
+		// {"contains(steps.*.outcome, 'failure')", true, "steps-context-array-outcome"},
+		// {"contains(steps.*.outputs.name, 'value')", true, "steps-context-array-outputs"},
 		{"runner.os", "Linux", "runner-context"},
 		{"secrets.name", "value", "secrets-context"},
 		{"strategy.fail-fast", true, "strategy-context"},
@@ -550,6 +566,10 @@ func TestContexts(t *testing.T) {
 				Outputs: map[string]string{
 					"name": "value",
 				},
+			},
+			"step-id2": {
+				Outcome:    model.StepStatusFailure,
+				Conclusion: model.StepStatusSkipped,
 			},
 		},
 		Runner: map[string]interface{}{

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -160,14 +160,14 @@ func TestEvaluateStep(t *testing.T) {
 		out     interface{}
 		errMesg string
 	}{
-		{"steps.idwithnothing.conclusion", model.StepStatusSuccess, ""},
-		{"steps.idwithnothing.outcome", model.StepStatusFailure, ""},
+		{"steps.idwithnothing.conclusion", model.StepStatusSuccess.String(), ""},
+		{"steps.idwithnothing.outcome", model.StepStatusFailure.String(), ""},
 		{"steps.idwithnothing.outputs.foowithnothing", "barwithnothing", ""},
-		{"steps.id-with-hyphens.conclusion", model.StepStatusSuccess, ""},
-		{"steps.id-with-hyphens.outcome", model.StepStatusFailure, ""},
+		{"steps.id-with-hyphens.conclusion", model.StepStatusSuccess.String(), ""},
+		{"steps.id-with-hyphens.outcome", model.StepStatusFailure.String(), ""},
 		{"steps.id-with-hyphens.outputs.foo-with-hyphens", "bar-with-hyphens", ""},
-		{"steps.id_with_underscores.conclusion", model.StepStatusSuccess, ""},
-		{"steps.id_with_underscores.outcome", model.StepStatusFailure, ""},
+		{"steps.id_with_underscores.conclusion", model.StepStatusSuccess.String(), ""},
+		{"steps.id_with_underscores.outcome", model.StepStatusFailure.String(), ""},
 		{"steps.id_with_underscores.outputs.foo_with_underscores", "bar_with_underscores", ""},
 	}
 


### PR DESCRIPTION
Closes #1109

If I'm not mistaken there might be still some cases which are invalid for the stepStatus structure.

I'm a bit confused how the expression evaluator is working:
I can't get `contains(steps.*.outputs.name, 'value')` working.