### PR TITLE
fix: expression evaluator do not error that much

### DIFF
--- a/pkg/exprparser/interpreter.go
+++ b/pkg/exprparser/interpreter.go
@@ -175,11 +175,11 @@ func (impl *interperterImpl) evaluateIndexAccess(indexAccessNode *actionlint.Ind
 			}
 			return leftValue.Index(int(rightValue.Int())).Interface(), nil
 		default:
-			return nil, fmt.Errorf("Unable to index on non-slice value: %s", leftValue.Kind())
+			return nil, nil
 		}
 
 	default:
-		return nil, fmt.Errorf("Unknown index type: %s", rightValue.Kind())
+		return nil, nil
 	}
 }
 
@@ -260,7 +260,7 @@ func (impl *interperterImpl) getPropertyValue(left reflect.Value, property strin
 		return values, nil
 	}
 
-	return nil, fmt.Errorf("Unable to dereference '%s' on non-struct '%s'", property, left.Kind())
+	return nil, nil
 }
 
 func (impl *interperterImpl) getMapValue(value reflect.Value) (interface{}, error) {

--- a/pkg/exprparser/interpreter_test.go
+++ b/pkg/exprparser/interpreter_test.go
@@ -47,8 +47,12 @@ func TestOperators(t *testing.T) {
 		{"(false || (false || true))", true, "logical-grouping", ""},
 		{"github.action", "push", "property-dereference", ""},
 		{"github['action']", "push", "property-index", ""},
-		{"github.action[0]", nil, "string-index", "Unable to index on non-slice value: string"},
+		{"github.action[0]", nil, "string-index", ""},
+		{"github.action['0']", nil, "string-index", ""},
 		{"fromJSON('[0,1]')[1]", 1.0, "array-index", ""},
+		{"fromJSON('[0,1]')[1.1]", nil, "array-index", ""},
+		// Disabled weird things are happening
+		// {"fromJSON('[0,1]')['1.1']", nil, "array-index", ""},
 		{"(github.event.commits.*.author.username)[0]", "someone", "array-index-0", ""},
 		{"fromJSON('[0,1]')[2]", nil, "array-index-out-of-bounds-0", ""},
 		{"fromJSON('[0,1]')[34553]", nil, "array-index-out-of-bounds-1", ""},
@@ -524,6 +528,9 @@ func TestContexts(t *testing.T) {
 		name     string
 	}{
 		{"github.action", "push", "github-context"},
+		{"github.event.commits[0].message", nil, "github-context-noexist-prop"},
+		{"fromjson('{\"commits\":[]}').commits[0].message", nil, "github-context-noexist-prop"},
+		{"github.event.pull_request.labels.*.name", nil, "github-context-noexist-prop"},
 		{"env.TEST", "value", "env-context"},
 		{"job.status", "success", "job-context"},
 		{"steps.step-id.outputs.name", "value", "steps-context"},


### PR DESCRIPTION
Why does the new expression evaluator returns far more errors than the original?
I can't get `fromJSON('[0,1]')['1.1']` to work, it doesn't return null.

Closes #1071
Closes #1115