### PR TITLE
fix: panic while running DRYRUN with local actions

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -161,6 +161,9 @@ func (cr *containerReference) CopyDir(destPath string, srcPath string, useGitIgn
 }
 
 func (cr *containerReference) GetContainerArchive(ctx context.Context, srcPath string) (io.ReadCloser, error) {
+	if common.Dryrun(ctx) {
+		return nil, fmt.Errorf("DRYRUN is not supported in GetContainerArchive")
+	}
 	a, _, err := cr.cli.CopyFromContainer(ctx, cr.id, srcPath)
 	return a, err
 }


### PR DESCRIPTION
With this change act's dryrun no longer panics after my previous change #719. An error is better than a panic.

We need to consider how act can support dryrun for localactions.

Closes #1140