### PR TITLE
fix: panic if a step in a job is nil

### DIFF
--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -39,6 +39,12 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 	preSteps = append(preSteps, info.startContainer())
 
 	for i, stepModel := range infoSteps {
+		if stepModel == nil {
+			return func(ctx context.Context) error {
+				common.Logger(ctx).Errorf("Invalid Step %v: missing run or uses key", i)
+				return fmt.Errorf("Invalid Step %v: missing run or uses key", i)
+			}
+		}
 		if stepModel.ID == "" {
 			stepModel.ID = fmt.Sprintf("%d", i)
 		}

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -41,8 +41,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 	for i, stepModel := range infoSteps {
 		if stepModel == nil {
 			return func(ctx context.Context) error {
-				common.Logger(ctx).Errorf("Invalid Step %v: missing run or uses key", i)
-				return fmt.Errorf("Invalid Step %v: missing run or uses key", i)
+				return fmt.Errorf("invalid Step %v: missing run or uses key", i)
 			}
 		}
 		if stepModel.ID == "" {

--- a/pkg/runner/job_executor_test.go
+++ b/pkg/runner/job_executor_test.go
@@ -21,6 +21,7 @@ func TestJobExecutor(t *testing.T) {
 		{workdir, "uses-docker-url", "push", "", platforms},
 		{workdir, "uses-github-full-sha", "push", "", platforms},
 		{workdir, "uses-github-short-sha", "push", "Unable to resolve action `actions/hello-world-docker-action@b136eb8`, the provided ref `b136eb8` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `b136eb8894c5cb1dd5807da824be97ccdf9b5423` instead", platforms},
+		{workdir, "job-nil-step", "push", "invalid Step 0: missing run or uses key", platforms},
 	}
 	// These tests are sufficient to only check syntax.
 	ctx := common.WithDryrun(context.Background(), true)

--- a/pkg/runner/testdata/job-nil-step/push.yml
+++ b/pkg/runner/testdata/job-nil-step/push.yml
@@ -1,0 +1,7 @@
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    -
+    - run: exit 0


### PR DESCRIPTION
__We need to be careful__
Closes #1144

```yaml
on: push
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
    -
    - run: exit 0
```

```
go run . -W .\w.yml -P ubuntu-latest=ubuntu:latest --no-skip-checkout
Error: invalid Step 0: missing run or uses key
exit status 1
```