### PR TITLE
fix: return invalid step type

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -414,6 +414,10 @@ const (
 
 // Type returns the type of the step
 func (s *Step) Type() StepType {
+	if s.Run == "" && s.Uses == "" {
+		return StepTypeInvalid
+	}
+
 	if s.Run != "" {
 		if s.Uses != "" {
 			return StepTypeInvalid


### PR DESCRIPTION
If a step does not have either a `run` or `uses` directive it is
considered invalid.
