### PR TITLE
feat: handle context cancelation during docker exec

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/nektos/act/cmd"
 )
@@ -16,7 +17,7 @@ func main() {
 
 	// trap Ctrl+C and call cancel on the context
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	defer func() {
 		signal.Stop(c)
 		cancel()

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -89,7 +89,7 @@ func NewContainer(input *NewContainerInput) Container {
 
 // supportsContainerImagePlatform returns true if the underlying Docker server
 // API version is 1.41 and beyond
-func supportsContainerImagePlatform(ctx context.Context, cli *client.Client) bool {
+func supportsContainerImagePlatform(ctx context.Context, cli client.APIClient) bool {
 	logger := common.Logger(ctx)
 	ver, err := cli.ServerVersion(ctx)
 	if err != nil {
@@ -210,12 +210,12 @@ func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Write
 }
 
 type containerReference struct {
-	cli   *client.Client
+	cli   client.APIClient
 	id    string
 	input *NewContainerInput
 }
 
-func GetDockerClient(ctx context.Context) (cli *client.Client, err error) {
+func GetDockerClient(ctx context.Context) (cli client.APIClient, err error) {
 	// TODO: this should maybe need to be a global option, not hidden in here?
 	//       though i'm not sure how that works out when there's another Executor :D
 	//		 I really would like something that works on OSX native for eg
@@ -244,7 +244,7 @@ func GetDockerClient(ctx context.Context) (cli *client.Client, err error) {
 }
 
 func GetHostInfo(ctx context.Context) (info types.Info, err error) {
-	var cli *client.Client
+	var cli client.APIClient
 	cli, err = GetDockerClient(ctx)
 	if err != nil {
 		return info, err
@@ -604,7 +604,7 @@ func (cr *containerReference) waitForCommand(ctx context.Context, isTerminal boo
 	select {
 	case <-ctx.Done():
 		// send ctrl + c
-		_, err := resp.Conn.Write([]byte("\x03"))
+		_, err := resp.Conn.Write([]byte{3})
 		if err != nil {
 			logger.Warnf("Failed to send CTRL+C: %+s", err)
 		}

--- a/pkg/container/docker_run_test.go
+++ b/pkg/container/docker_run_test.go
@@ -1,10 +1,17 @@
 package container
 
 import (
+	"bufio"
 	"context"
+	"io"
+	"net"
 	"testing"
+	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestDocker(t *testing.T) {
@@ -44,4 +51,79 @@ func TestDocker(t *testing.T) {
 		"ANOTHER_ONE":     "BUT_I_HAVE_VALUE",
 		"CONFLICT_VAR":    "I_EXIST_IN_MULTIPLE_PLACES",
 	}, env)
+}
+
+type mockDockerClient struct {
+	client.APIClient
+	mock.Mock
+}
+
+func (m *mockDockerClient) ContainerExecCreate(ctx context.Context, id string, opts types.ExecConfig) (types.IDResponse, error) {
+	args := m.Called(ctx, id, opts)
+	return args.Get(0).(types.IDResponse), args.Error(1)
+}
+
+func (m *mockDockerClient) ContainerExecAttach(ctx context.Context, id string, opts types.ExecStartCheck) (types.HijackedResponse, error) {
+	args := m.Called(ctx, id, opts)
+	return args.Get(0).(types.HijackedResponse), args.Error(1)
+}
+
+type endlessReader struct {
+	io.Reader
+}
+
+func (r endlessReader) Read(p []byte) (n int, err error) {
+	return 1, nil
+}
+
+type mockConn struct {
+	net.Conn
+	mock.Mock
+}
+
+func (m *mockConn) Write(b []byte) (n int, err error) {
+	args := m.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *mockConn) Close() (err error) {
+	return nil
+}
+
+func TestDockerExec(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	conn := &mockConn{}
+	conn.On("Write", mock.AnythingOfType("[]uint8")).Return(1, nil)
+
+	client := &mockDockerClient{}
+	client.On("ContainerExecCreate", ctx, "123", mock.AnythingOfType("types.ExecConfig")).Return(types.IDResponse{ID: "id"}, nil)
+	client.On("ContainerExecAttach", ctx, "id", mock.AnythingOfType("types.ExecStartCheck")).Return(types.HijackedResponse{
+		Conn:   conn,
+		Reader: bufio.NewReader(endlessReader{}),
+	}, nil)
+
+	cr := &containerReference{
+		id:  "123",
+		cli: client,
+		input: &NewContainerInput{
+			Image: "image",
+		},
+	}
+
+	channel := make(chan error)
+
+	go func() {
+		channel <- cr.exec([]string{""}, map[string]string{}, "user", "workdir")(ctx)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	cancel()
+
+	err := <-channel
+	assert.ErrorIs(t, err, context.Canceled)
+
+	conn.AssertExpectations(t)
+	client.AssertExpectations(t)
 }


### PR DESCRIPTION
To allow interrupting docker exec (which could be long running)
we process the log output in a go routine and handle
context cancelation as well as command result.

In case of context cancelation a CTRL+C is written into the docker
container. This should be enough to terminate the running
command.
