### PR TITLE
Improve logging

### DIFF
--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -3,8 +3,6 @@ package common
 import (
 	"context"
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // Warning that implements `error` but safe to ignore
@@ -132,7 +130,7 @@ func (e Executor) Then(then Executor) Executor {
 		if err != nil {
 			switch err.(type) {
 			case Warning:
-				log.Warning(err.Error())
+				Logger(ctx).Warning(err.Error())
 			default:
 				return err
 			}

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -54,7 +54,8 @@ func (e *Error) Commit() string {
 }
 
 // FindGitRevision get the current git revision
-func FindGitRevision(file string) (shortSha string, sha string, err error) {
+func FindGitRevision(ctx context.Context, file string) (shortSha string, sha string, err error) {
+	logger := common.Logger(ctx)
 	gitDir, err := findGitDirectory(file)
 	if err != nil {
 		return "", "", err
@@ -77,24 +78,25 @@ func FindGitRevision(file string) (shortSha string, sha string, err error) {
 		refBuf = []byte(ref)
 	}
 
-	log.Debugf("Found revision: %s", refBuf)
+	logger.Debugf("Found revision: %s", refBuf)
 	return string(refBuf[:7]), strings.TrimSpace(string(refBuf)), nil
 }
 
 // FindGitRef get the current git ref
-func FindGitRef(file string) (string, error) {
+func FindGitRef(ctx context.Context, file string) (string, error) {
+	logger := common.Logger(ctx)
 	gitDir, err := findGitDirectory(file)
 	if err != nil {
 		return "", err
 	}
-	log.Debugf("Loading revision from git directory '%s'", gitDir)
+	logger.Debugf("Loading revision from git directory '%s'", gitDir)
 
-	_, ref, err := FindGitRevision(file)
+	_, ref, err := FindGitRevision(ctx, file)
 	if err != nil {
 		return "", err
 	}
 
-	log.Debugf("HEAD points to '%s'", ref)
+	logger.Debugf("HEAD points to '%s'", ref)
 
 	// Prefer the git library to iterate over the references and find a matching tag or branch.
 	var refTag = ""
@@ -108,7 +110,7 @@ func FindGitRef(file string) (string, error) {
 				if r == nil || err != nil {
 					break
 				}
-				// log.Debugf("Reference: name=%s sha=%s", r.Name().String(), r.Hash().String())
+				// logger.Debugf("Reference: name=%s sha=%s", r.Name().String(), r.Hash().String())
 				if r.Hash().String() == ref {
 					if r.Name().IsTag() {
 						refTag = r.Name().String()
@@ -131,15 +133,15 @@ func FindGitRef(file string) (string, error) {
 	// If the above doesn't work, fall back to the old way
 
 	// try tags first
-	tag, err := findGitPrettyRef(ref, gitDir, "refs/tags")
+	tag, err := findGitPrettyRef(ctx, ref, gitDir, "refs/tags")
 	if err != nil || tag != "" {
 		return tag, err
 	}
 	// and then branches
-	return findGitPrettyRef(ref, gitDir, "refs/heads")
+	return findGitPrettyRef(ctx, ref, gitDir, "refs/heads")
 }
 
-func findGitPrettyRef(head, root, sub string) (string, error) {
+func findGitPrettyRef(ctx context.Context, head, root, sub string) (string, error) {
 	var name string
 	var err = filepath.Walk(filepath.Join(root, sub), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -156,7 +158,7 @@ func findGitPrettyRef(head, root, sub string) (string, error) {
 		if head == pointsTo {
 			// On Windows paths are separated with backslash character so they should be replaced to provide proper git refs format
 			name = strings.TrimPrefix(strings.ReplaceAll(strings.Replace(path, root, "", 1), `\`, `/`), "/")
-			log.Debugf("HEAD matches %s", name)
+			common.Logger(ctx).Debugf("HEAD matches %s", name)
 		}
 		return nil
 	})
@@ -164,12 +166,12 @@ func findGitPrettyRef(head, root, sub string) (string, error) {
 }
 
 // FindGithubRepo get the repo
-func FindGithubRepo(file, githubInstance, remoteName string) (string, error) {
+func FindGithubRepo(ctx context.Context, file, githubInstance, remoteName string) (string, error) {
 	if remoteName == "" {
 		remoteName = "origin"
 	}
 
-	url, err := findGitRemoteURL(file, remoteName)
+	url, err := findGitRemoteURL(ctx, file, remoteName)
 	if err != nil {
 		return "", err
 	}
@@ -177,12 +179,12 @@ func FindGithubRepo(file, githubInstance, remoteName string) (string, error) {
 	return slug, err
 }
 
-func findGitRemoteURL(file, remoteName string) (string, error) {
+func findGitRemoteURL(ctx context.Context, file, remoteName string) (string, error) {
 	gitDir, err := findGitDirectory(file)
 	if err != nil {
 		return "", err
 	}
-	log.Debugf("Loading slug from git directory '%s'", gitDir)
+	common.Logger(ctx).Debugf("Loading slug from git directory '%s'", gitDir)
 
 	gitconfig, err := ini.InsensitiveLoad(fmt.Sprintf("%s/config", gitDir))
 	if err != nil {

--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -86,7 +86,7 @@ func TestFindGitRemoteURL(t *testing.T) {
 	err = gitCmd("config", "-f", fmt.Sprintf("%s/.git/config", basedir), "--add", "remote.origin.url", remoteURL)
 	assert.NoError(err)
 
-	u, err := findGitRemoteURL(basedir, "origin")
+	u, err := findGitRemoteURL(context.Background(), basedir, "origin")
 	assert.NoError(err)
 	assert.Equal(remoteURL, u)
 }
@@ -165,7 +165,7 @@ func TestGitFindRef(t *testing.T) {
 			require.NoError(t, gitCmd("-C", dir, "init", "--initial-branch=master"))
 			require.NoError(t, cleanGitHooks(dir))
 			tt.Prepare(t, dir)
-			ref, err := FindGitRef(dir)
+			ref, err := FindGitRef(context.Background(), dir)
 			tt.Assert(t, ref, err)
 		})
 	}

--- a/pkg/container/docker_auth.go
+++ b/pkg/container/docker_auth.go
@@ -1,18 +1,20 @@
 package container
 
 import (
+	"context"
 	"strings"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/docker/api/types"
-	log "github.com/sirupsen/logrus"
+	"github.com/nektos/act/pkg/common"
 )
 
-func LoadDockerAuthConfig(image string) (types.AuthConfig, error) {
+func LoadDockerAuthConfig(ctx context.Context, image string) (types.AuthConfig, error) {
+	logger := common.Logger(ctx)
 	config, err := config.Load(config.Dir())
 	if err != nil {
-		log.Warnf("Could not load docker config: %v", err)
+		logger.Warnf("Could not load docker config: %v", err)
 		return types.AuthConfig{}, err
 	}
 
@@ -28,7 +30,7 @@ func LoadDockerAuthConfig(image string) (types.AuthConfig, error) {
 
 	authConfig, err := config.GetAuthConfig(hostName)
 	if err != nil {
-		log.Warnf("Could not get auth config from docker config: %v", err)
+		logger.Warnf("Could not get auth config from docker config: %v", err)
 		return types.AuthConfig{}, err
 	}
 

--- a/pkg/container/docker_build.go
+++ b/pkg/container/docker_build.go
@@ -12,7 +12,6 @@ import (
 
 	// github.com/docker/docker/builder/dockerignore is deprecated
 	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/nektos/act/pkg/common"
 )
@@ -56,7 +55,7 @@ func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 		if input.Container != nil {
 			buildContext, err = input.Container.GetContainerArchive(ctx, input.ContextDir+"/.")
 		} else {
-			buildContext, err = createBuildContext(input.ContextDir, "Dockerfile")
+			buildContext, err = createBuildContext(ctx, input.ContextDir, "Dockerfile")
 		}
 		if err != nil {
 			return err
@@ -74,8 +73,8 @@ func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 		return nil
 	}
 }
-func createBuildContext(contextDir string, relDockerfile string) (io.ReadCloser, error) {
-	log.Debugf("Creating archive for build context dir '%s' with relative dockerfile '%s'", contextDir, relDockerfile)
+func createBuildContext(ctx context.Context, contextDir string, relDockerfile string) (io.ReadCloser, error) {
+	common.Logger(ctx).Debugf("Creating archive for build context dir '%s' with relative dockerfile '%s'", contextDir, relDockerfile)
 
 	// And canonicalize dockerfile name to a platform-independent one
 	relDockerfile = archive.CanonicalTarNameForPath(relDockerfile)

--- a/pkg/container/docker_pull_test.go
+++ b/pkg/container/docker_pull_test.go
@@ -29,7 +29,7 @@ func TestCleanImage(t *testing.T) {
 	}
 
 	for _, table := range tables {
-		imageOut := cleanImage(table.imageIn)
+		imageOut := cleanImage(context.Background(), table.imageIn)
 		assert.Equal(t, table.imageOut, imageOut)
 	}
 }

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -28,7 +28,6 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/Masterminds/semver"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/term"
 
 	"github.com/nektos/act/pkg/common"
@@ -634,7 +633,7 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string, useGitIgno
 		if err != nil {
 			return err
 		}
-		log.Debugf("Writing tarball %s from %s", tarFile.Name(), srcPath)
+		logger.Debugf("Writing tarball %s from %s", tarFile.Name(), srcPath)
 		defer func(tarFile *os.File) {
 			name := tarFile.Name()
 			err := tarFile.Close()
@@ -652,13 +651,13 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string, useGitIgno
 		if !strings.HasSuffix(srcPrefix, string(filepath.Separator)) {
 			srcPrefix += string(filepath.Separator)
 		}
-		log.Debugf("Stripping prefix:%s src:%s", srcPrefix, srcPath)
+		logger.Debugf("Stripping prefix:%s src:%s", srcPrefix, srcPath)
 
 		var ignorer gitignore.Matcher
 		if useGitIgnore {
 			ps, err := gitignore.ReadPatterns(polyfill.New(osfs.New(srcPath)), nil)
 			if err != nil {
-				log.Debugf("Error loading .gitignore: %v", err)
+				logger.Debugf("Error loading .gitignore: %v", err)
 			}
 
 			ignorer = gitignore.NewMatcher(ps)
@@ -701,7 +700,7 @@ func (cr *containerReference) copyContent(dstPath string, files ...*FileEntry) c
 		var buf bytes.Buffer
 		tw := tar.NewWriter(&buf)
 		for _, file := range files {
-			log.Debugf("Writing entry to tarball %s len:%d", file.Name, len(file.Body))
+			logger.Debugf("Writing entry to tarball %s len:%d", file.Name, len(file.Body))
 			hdr := &tar.Header{
 				Name: file.Name,
 				Mode: file.Mode,

--- a/pkg/model/github_context_test.go
+++ b/pkg/model/github_context_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,11 +17,11 @@ func TestSetRefAndSha(t *testing.T) {
 	defer func() { findGitRef = oldFindGitRef }()
 	defer func() { findGitRevision = oldFindGitRevision }()
 
-	findGitRef = func(file string) (string, error) {
+	findGitRef = func(ctx context.Context, file string) (string, error) {
 		return "refs/heads/master", nil
 	}
 
-	findGitRevision = func(file string) (string, string, error) {
+	findGitRevision = func(ctx context.Context, file string) (string, string, error) {
 		return "", "1234fakesha", nil
 	}
 
@@ -107,7 +108,7 @@ func TestSetRefAndSha(t *testing.T) {
 				Event:     table.event,
 			}
 
-			ghc.SetRefAndSha("main", "/some/dir")
+			ghc.SetRefAndSha(context.Background(), "main", "/some/dir")
 
 			assert.Equal(t, table.ref, ghc.Ref)
 			assert.Equal(t, table.sha, ghc.Sha)
@@ -115,7 +116,7 @@ func TestSetRefAndSha(t *testing.T) {
 	}
 
 	t.Run("no-default-branch", func(t *testing.T) {
-		findGitRef = func(file string) (string, error) {
+		findGitRef = func(ctx context.Context, file string) (string, error) {
 			return "", fmt.Errorf("no default branch")
 		}
 
@@ -124,7 +125,7 @@ func TestSetRefAndSha(t *testing.T) {
 			Event:     map[string]interface{}{},
 		}
 
-		ghc.SetRefAndSha("", "/some/dir")
+		ghc.SetRefAndSha(context.Background(), "", "/some/dir")
 
 		assert.Equal(t, "master", ghc.Ref)
 		assert.Equal(t, "1234fakesha", ghc.Sha)

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -526,17 +526,17 @@ func shouldRunPostStep(step actionStep) common.Conditional {
 		stepResult := stepResults[step.getStepModel().ID]
 
 		if stepResult == nil {
-			log.Debugf("skip post step for '%s'; step was not executed", step.getStepModel())
+			log.WithField("stepResult", model.StepStatusSkipped).Debugf("skipping post step for '%s'; step was not executed", step.getStepModel())
 			return false
 		}
 
 		if stepResult.Conclusion == model.StepStatusSkipped {
-			log.Debugf("skip post step for '%s'; main step was skipped", step.getStepModel())
+			log.WithField("stepResult", model.StepStatusSkipped).Debugf("skipping post step for '%s'; main step was skipped", step.getStepModel())
 			return false
 		}
 
 		if step.getActionModel() == nil {
-			log.Debugf("skip post step for '%s': no action model available", step.getStepModel())
+			log.WithField("stepResult", model.StepStatusSkipped).Debugf("skipping post step for '%s': no action model available", step.getStepModel())
 			return false
 		}
 

--- a/pkg/runner/action_test.go
+++ b/pkg/runner/action_test.go
@@ -130,7 +130,7 @@ runs:
 				closerMock.On("Close")
 			}
 
-			action, err := readActionImpl(tt.step, "actionDir", "actionPath", readFile, writeFile)
+			action, err := readActionImpl(context.Background(), tt.step, "actionDir", "actionPath", readFile, writeFile)
 
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, action)

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -82,6 +82,7 @@ func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg
 	rc.Env[kvPairs["name"]] = arg
 }
 func (rc *RunContext) setOutput(ctx context.Context, kvPairs map[string]string, arg string) {
+	logger := common.Logger(ctx)
 	stepID := rc.CurrentStep
 	outputName := kvPairs["name"]
 	if outputMapping, ok := rc.OutputMappings[MappableOutput{StepID: stepID, OutputName: outputName}]; ok {
@@ -91,11 +92,11 @@ func (rc *RunContext) setOutput(ctx context.Context, kvPairs map[string]string, 
 
 	result, ok := rc.StepResults[stepID]
 	if !ok {
-		common.Logger(ctx).Infof("  \U00002757  no outputs used step '%s'", stepID)
+		logger.Infof("  \U00002757  no outputs used step '%s'", stepID)
 		return
 	}
 
-	common.Logger(ctx).Infof("  \U00002699  ::set-output:: %s=%s", outputName, arg)
+	logger.Infof("  \U00002699  ::set-output:: %s=%s", outputName, arg)
 	result.Outputs[outputName] = arg
 }
 func (rc *RunContext) addPath(ctx context.Context, arg string) {

--- a/pkg/runner/command_test.go
+++ b/pkg/runner/command_test.go
@@ -164,7 +164,7 @@ func TestAddmaskUsemask(t *testing.T) {
 
 	re := captureOutput(t, func() {
 		ctx := context.Background()
-		ctx = WithJobLogger(ctx, "testjob", config, &rc.Masks)
+		ctx = WithJobLogger(ctx, "0", "testjob", config, &rc.Masks)
 
 		handler := rc.commandHandler(ctx)
 		handler("::add-mask::secret\n")

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -120,7 +120,10 @@ func (ee expressionEvaluator) evaluate(ctx context.Context, in string, defaultSt
 	logger := common.Logger(ctx)
 	logger.Debugf("evaluating expression '%s'", in)
 	evaluated, err := ee.interpreter.Evaluate(in, defaultStatusCheck)
-	logger.Debugf("expression '%s' evaluated to '%t'", in, evaluated)
+
+	printable := regexp.MustCompile(`::add-mask::.*`).ReplaceAllString(fmt.Sprintf("%t", evaluated), "::add-mask::***)")
+	logger.Debugf("expression '%s' evaluated to '%s'", in, printable)
+
 	return evaluated, err
 }
 

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -1,24 +1,25 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/exprparser"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
 
 // ExpressionEvaluator is the interface for evaluating expressions
 type ExpressionEvaluator interface {
-	evaluate(string, exprparser.DefaultStatusCheck) (interface{}, error)
-	EvaluateYamlNode(node *yaml.Node) error
-	Interpolate(string) string
+	evaluate(context.Context, string, exprparser.DefaultStatusCheck) (interface{}, error)
+	EvaluateYamlNode(context.Context, *yaml.Node) error
+	Interpolate(context.Context, string) string
 }
 
 // NewExpressionEvaluator creates a new evaluator
-func (rc *RunContext) NewExpressionEvaluator() ExpressionEvaluator {
+func (rc *RunContext) NewExpressionEvaluator(ctx context.Context) ExpressionEvaluator {
 	// todo: cleanup EvaluationEnvironment creation
 	job := rc.Run.Job()
 	strategy := make(map[string]interface{})
@@ -38,7 +39,7 @@ func (rc *RunContext) NewExpressionEvaluator() ExpressionEvaluator {
 	}
 
 	ee := &exprparser.EvaluationEnvironment{
-		Github: rc.getGithubContext(),
+		Github: rc.getGithubContext(ctx),
 		Env:    rc.GetEnv(),
 		Job:    rc.getJobContext(),
 		// todo: should be unavailable
@@ -65,7 +66,7 @@ func (rc *RunContext) NewExpressionEvaluator() ExpressionEvaluator {
 }
 
 // NewExpressionEvaluator creates a new evaluator
-func (rc *RunContext) NewStepExpressionEvaluator(step step) ExpressionEvaluator {
+func (rc *RunContext) NewStepExpressionEvaluator(ctx context.Context, step step) ExpressionEvaluator {
 	// todo: cleanup EvaluationEnvironment creation
 	job := rc.Run.Job()
 	strategy := make(map[string]interface{})
@@ -85,7 +86,7 @@ func (rc *RunContext) NewStepExpressionEvaluator(step step) ExpressionEvaluator 
 	}
 
 	ee := &exprparser.EvaluationEnvironment{
-		Github: rc.getGithubContext(),
+		Github: rc.getGithubContext(ctx),
 		Env:    *step.getEnv(),
 		Job:    rc.getJobContext(),
 		Steps:  rc.getStepsContext(),
@@ -115,14 +116,15 @@ type expressionEvaluator struct {
 	interpreter exprparser.Interpreter
 }
 
-func (ee expressionEvaluator) evaluate(in string, defaultStatusCheck exprparser.DefaultStatusCheck) (interface{}, error) {
-	log.Debugf("evaluating expression '%s'", in)
+func (ee expressionEvaluator) evaluate(ctx context.Context, in string, defaultStatusCheck exprparser.DefaultStatusCheck) (interface{}, error) {
+	logger := common.Logger(ctx)
+	logger.Debugf("evaluating expression '%s'", in)
 	evaluated, err := ee.interpreter.Evaluate(in, defaultStatusCheck)
-	log.Debugf("expression '%s' evaluated to '%t'", in, evaluated)
+	logger.Debugf("expression '%s' evaluated to '%t'", in, evaluated)
 	return evaluated, err
 }
 
-func (ee expressionEvaluator) evaluateScalarYamlNode(node *yaml.Node) error {
+func (ee expressionEvaluator) evaluateScalarYamlNode(ctx context.Context, node *yaml.Node) error {
 	var in string
 	if err := node.Decode(&in); err != nil {
 		return err
@@ -130,21 +132,21 @@ func (ee expressionEvaluator) evaluateScalarYamlNode(node *yaml.Node) error {
 	if !strings.Contains(in, "${{") || !strings.Contains(in, "}}") {
 		return nil
 	}
-	expr, _ := rewriteSubExpression(in, false)
-	res, err := ee.evaluate(expr, exprparser.DefaultStatusCheckNone)
+	expr, _ := rewriteSubExpression(ctx, in, false)
+	res, err := ee.evaluate(ctx, expr, exprparser.DefaultStatusCheckNone)
 	if err != nil {
 		return err
 	}
 	return node.Encode(res)
 }
 
-func (ee expressionEvaluator) evaluateMappingYamlNode(node *yaml.Node) error {
+func (ee expressionEvaluator) evaluateMappingYamlNode(ctx context.Context, node *yaml.Node) error {
 	// GitHub has this undocumented feature to merge maps, called insert directive
 	insertDirective := regexp.MustCompile(`\${{\s*insert\s*}}`)
 	for i := 0; i < len(node.Content)/2; {
 		k := node.Content[i*2]
 		v := node.Content[i*2+1]
-		if err := ee.EvaluateYamlNode(v); err != nil {
+		if err := ee.EvaluateYamlNode(ctx, v); err != nil {
 			return err
 		}
 		var sk string
@@ -153,7 +155,7 @@ func (ee expressionEvaluator) evaluateMappingYamlNode(node *yaml.Node) error {
 			node.Content = append(append(node.Content[:i*2], v.Content...), node.Content[(i+1)*2:]...)
 			i += len(v.Content) / 2
 		} else {
-			if err := ee.EvaluateYamlNode(k); err != nil {
+			if err := ee.EvaluateYamlNode(ctx, k); err != nil {
 				return err
 			}
 			i++
@@ -162,12 +164,12 @@ func (ee expressionEvaluator) evaluateMappingYamlNode(node *yaml.Node) error {
 	return nil
 }
 
-func (ee expressionEvaluator) evaluateSequenceYamlNode(node *yaml.Node) error {
+func (ee expressionEvaluator) evaluateSequenceYamlNode(ctx context.Context, node *yaml.Node) error {
 	for i := 0; i < len(node.Content); {
 		v := node.Content[i]
 		// Preserve nested sequences
 		wasseq := v.Kind == yaml.SequenceNode
-		if err := ee.EvaluateYamlNode(v); err != nil {
+		if err := ee.EvaluateYamlNode(ctx, v); err != nil {
 			return err
 		}
 		// GitHub has this undocumented feature to merge sequences / arrays
@@ -182,28 +184,28 @@ func (ee expressionEvaluator) evaluateSequenceYamlNode(node *yaml.Node) error {
 	return nil
 }
 
-func (ee expressionEvaluator) EvaluateYamlNode(node *yaml.Node) error {
+func (ee expressionEvaluator) EvaluateYamlNode(ctx context.Context, node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.ScalarNode:
-		return ee.evaluateScalarYamlNode(node)
+		return ee.evaluateScalarYamlNode(ctx, node)
 	case yaml.MappingNode:
-		return ee.evaluateMappingYamlNode(node)
+		return ee.evaluateMappingYamlNode(ctx, node)
 	case yaml.SequenceNode:
-		return ee.evaluateSequenceYamlNode(node)
+		return ee.evaluateSequenceYamlNode(ctx, node)
 	default:
 		return nil
 	}
 }
 
-func (ee expressionEvaluator) Interpolate(in string) string {
+func (ee expressionEvaluator) Interpolate(ctx context.Context, in string) string {
 	if !strings.Contains(in, "${{") || !strings.Contains(in, "}}") {
 		return in
 	}
 
-	expr, _ := rewriteSubExpression(in, true)
-	evaluated, err := ee.evaluate(expr, exprparser.DefaultStatusCheckNone)
+	expr, _ := rewriteSubExpression(ctx, in, true)
+	evaluated, err := ee.evaluate(ctx, expr, exprparser.DefaultStatusCheckNone)
 	if err != nil {
-		log.Errorf("Unable to interpolate expression '%s': %s", expr, err)
+		common.Logger(ctx).Errorf("Unable to interpolate expression '%s': %s", expr, err)
 		return ""
 	}
 
@@ -216,10 +218,10 @@ func (ee expressionEvaluator) Interpolate(in string) string {
 }
 
 // EvalBool evaluates an expression against given evaluator
-func EvalBool(evaluator ExpressionEvaluator, expr string, defaultStatusCheck exprparser.DefaultStatusCheck) (bool, error) {
-	nextExpr, _ := rewriteSubExpression(expr, false)
+func EvalBool(ctx context.Context, evaluator ExpressionEvaluator, expr string, defaultStatusCheck exprparser.DefaultStatusCheck) (bool, error) {
+	nextExpr, _ := rewriteSubExpression(ctx, expr, false)
 
-	evaluated, err := evaluator.evaluate(nextExpr, defaultStatusCheck)
+	evaluated, err := evaluator.evaluate(ctx, nextExpr, defaultStatusCheck)
 	if err != nil {
 		return false, err
 	}
@@ -232,7 +234,7 @@ func escapeFormatString(in string) string {
 }
 
 //nolint:gocyclo
-func rewriteSubExpression(in string, forceFormat bool) (string, error) {
+func rewriteSubExpression(ctx context.Context, in string, forceFormat bool) (string, error) {
 	if !strings.Contains(in, "${{") || !strings.Contains(in, "}}") {
 		return in, nil
 	}
@@ -293,7 +295,7 @@ func rewriteSubExpression(in string, forceFormat bool) (string, error) {
 
 	out := fmt.Sprintf("format('%s', %s)", strings.ReplaceAll(formatOut, "'", "''"), strings.Join(results, ", "))
 	if in != out {
-		log.Debugf("expression '%s' rewritten to '%s'", in, out)
+		common.Logger(ctx).Debugf("expression '%s' rewritten to '%s'", in, out)
 	}
 	return out, nil
 }

--- a/pkg/runner/expression_test.go
+++ b/pkg/runner/expression_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -76,7 +77,7 @@ func createRunContext(t *testing.T) *RunContext {
 
 func TestEvaluateRunContext(t *testing.T) {
 	rc := createRunContext(t)
-	ee := rc.NewExpressionEvaluator()
+	ee := rc.NewExpressionEvaluator(context.Background())
 
 	tables := []struct {
 		in      string
@@ -136,7 +137,7 @@ func TestEvaluateRunContext(t *testing.T) {
 		table := table
 		t.Run(table.in, func(t *testing.T) {
 			assertObject := assert.New(t)
-			out, err := ee.evaluate(table.in, exprparser.DefaultStatusCheckNone)
+			out, err := ee.evaluate(context.Background(), table.in, exprparser.DefaultStatusCheckNone)
 			if table.errMesg == "" {
 				assertObject.NoError(err, table.in)
 				assertObject.Equal(table.out, out, table.in)
@@ -154,7 +155,7 @@ func TestEvaluateStep(t *testing.T) {
 		RunContext: rc,
 	}
 
-	ee := rc.NewStepExpressionEvaluator(step)
+	ee := rc.NewStepExpressionEvaluator(context.Background(), step)
 
 	tables := []struct {
 		in      string
@@ -176,7 +177,7 @@ func TestEvaluateStep(t *testing.T) {
 		table := table
 		t.Run(table.in, func(t *testing.T) {
 			assertObject := assert.New(t)
-			out, err := ee.evaluate(table.in, exprparser.DefaultStatusCheckNone)
+			out, err := ee.evaluate(context.Background(), table.in, exprparser.DefaultStatusCheckNone)
 			if table.errMesg == "" {
 				assertObject.NoError(err, table.in)
 				assertObject.Equal(table.out, out, table.in)
@@ -213,7 +214,7 @@ func TestInterpolate(t *testing.T) {
 			},
 		},
 	}
-	ee := rc.NewExpressionEvaluator()
+	ee := rc.NewExpressionEvaluator(context.Background())
 	tables := []struct {
 		in  string
 		out string
@@ -255,7 +256,7 @@ func TestInterpolate(t *testing.T) {
 		table := table
 		t.Run("interpolate", func(t *testing.T) {
 			assertObject := assert.New(t)
-			out := ee.Interpolate(table.in)
+			out := ee.Interpolate(context.Background(), table.in)
 			assertObject.Equal(table.out, out, table.in)
 		})
 	}
@@ -332,7 +333,7 @@ func TestRewriteSubExpression(t *testing.T) {
 	for _, table := range table {
 		t.Run("TestRewriteSubExpression", func(t *testing.T) {
 			assertObject := assert.New(t)
-			out, err := rewriteSubExpression(table.in, false)
+			out, err := rewriteSubExpression(context.Background(), table.in, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -356,7 +357,7 @@ func TestRewriteSubExpressionForceFormat(t *testing.T) {
 	for _, table := range table {
 		t.Run("TestRewriteSubExpressionForceFormat", func(t *testing.T) {
 			assertObject := assert.New(t)
-			out, err := rewriteSubExpression(table.in, true)
+			out, err := rewriteSubExpression(context.Background(), table.in, true)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -25,8 +25,9 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 	var postExecutor common.Executor
 
 	steps = append(steps, func(ctx context.Context) error {
+		logger := common.Logger(ctx)
 		if len(info.matrix()) > 0 {
-			common.Logger(ctx).Infof("\U0001F9EA  Matrix: %v", info.matrix())
+			logger.Infof("\U0001F9EA  Matrix: %v", info.matrix())
 		}
 		return nil
 	})
@@ -61,12 +62,13 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		steps = append(steps, func(ctx context.Context) error {
 			stepName := stepModel.String()
 			return (func(ctx context.Context) error {
+				logger := common.Logger(ctx)
 				err := stepExec(ctx)
 				if err != nil {
-					common.Logger(ctx).Errorf("%v", err)
+					logger.Errorf("%v", err)
 					common.SetJobError(ctx, err)
 				} else if ctx.Err() != nil {
-					common.Logger(ctx).Errorf("%v", ctx.Err())
+					logger.Errorf("%v", ctx.Err())
 					common.SetJobError(ctx, ctx.Err())
 				}
 				return nil

--- a/pkg/runner/job_executor_test.go
+++ b/pkg/runner/job_executor_test.go
@@ -3,9 +3,11 @@ package runner
 import (
 	"context"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -73,6 +75,14 @@ func (jim *jobInfoMock) interpolateOutputs() common.Executor {
 
 func (jim *jobInfoMock) result(result string) {
 	jim.Called(result)
+}
+
+type jobContainerMock struct {
+	container.Container
+}
+
+func (jcm *jobContainerMock) ReplaceLogWriter(stdout, stderr io.Writer) (io.Writer, io.Writer) {
+	return nil, nil
 }
 
 type stepFactoryMock struct {
@@ -236,7 +246,9 @@ func TestNewJobExecutor(t *testing.T) {
 			ctx := common.WithJobErrorContainer(context.Background())
 			jim := &jobInfoMock{}
 			sfm := &stepFactoryMock{}
-			rc := &RunContext{}
+			rc := &RunContext{
+				JobContainer: &jobContainerMock{},
+			}
 			executorOrder := make([]string, 0)
 
 			jim.On("steps").Return(tt.steps)

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -153,26 +153,34 @@ func (f *jobLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 func (f *jobLogFormatter) printColored(b *bytes.Buffer, entry *logrus.Entry) {
 	entry.Message = strings.TrimSuffix(entry.Message, "\n")
 	jobName := entry.Data["job"]
+	debugFlag := ""
+	if entry.Level == logrus.DebugLevel {
+		debugFlag = "[DEBUG] "
+	}
 
 	if entry.Data["raw_output"] == true {
 		fmt.Fprintf(b, "\x1b[%dm|\x1b[0m %s", f.color, entry.Message)
 	} else if entry.Data["dryrun"] == true {
-		fmt.Fprintf(b, "\x1b[1m\x1b[%dm\x1b[7m*DRYRUN*\x1b[0m \x1b[%dm[%s] \x1b[0m%s", gray, f.color, jobName, entry.Message)
+		fmt.Fprintf(b, "\x1b[1m\x1b[%dm\x1b[7m*DRYRUN*\x1b[0m \x1b[%dm[%s] \x1b[0m%s%s", gray, f.color, jobName, debugFlag, entry.Message)
 	} else {
-		fmt.Fprintf(b, "\x1b[%dm[%s] \x1b[0m%s", f.color, jobName, entry.Message)
+		fmt.Fprintf(b, "\x1b[%dm[%s] \x1b[0m%s%s", f.color, jobName, debugFlag, entry.Message)
 	}
 }
 
 func (f *jobLogFormatter) print(b *bytes.Buffer, entry *logrus.Entry) {
 	entry.Message = strings.TrimSuffix(entry.Message, "\n")
 	jobName := entry.Data["job"]
+	debugFlag := ""
+	if entry.Level == logrus.DebugLevel {
+		debugFlag = "[DEBUG] "
+	}
 
 	if entry.Data["raw_output"] == true {
 		fmt.Fprintf(b, "[%s]   | %s", jobName, entry.Message)
 	} else if entry.Data["dryrun"] == true {
-		fmt.Fprintf(b, "*DRYRUN* [%s] %s", jobName, entry.Message)
+		fmt.Fprintf(b, "*DRYRUN* [%s] %s%s", jobName, debugFlag, entry.Message)
 	} else {
-		fmt.Fprintf(b, "[%s] %s", jobName, entry.Message)
+		fmt.Fprintf(b, "[%s] %s%s", jobName, debugFlag, entry.Message)
 	}
 }
 

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -96,10 +96,11 @@ func WithCompositeLogger(ctx context.Context, masks *[]string) context.Context {
 	return common.WithLogger(ctx, common.Logger(ctx).WithFields(logrus.Fields{}).WithContext(ctx))
 }
 
-func withStepLogger(ctx context.Context, stepID string, stepName string) context.Context {
+func withStepLogger(ctx context.Context, stepID string, stepName string, stageName string) context.Context {
 	rtn := common.Logger(ctx).WithFields(logrus.Fields{
 		"step":   stepName,
 		"stepID": stepID,
+		"stage":  stageName,
 	})
 	return common.WithLogger(ctx, rtn)
 }

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -58,7 +58,7 @@ func WithMasks(ctx context.Context, masks *[]string) context.Context {
 }
 
 // WithJobLogger attaches a new logger to context that is aware of steps
-func WithJobLogger(ctx context.Context, jobName string, config *Config, masks *[]string) context.Context {
+func WithJobLogger(ctx context.Context, jobID string, jobName string, config *Config, masks *[]string) context.Context {
 	mux.Lock()
 	defer mux.Unlock()
 
@@ -82,7 +82,11 @@ func WithJobLogger(ctx context.Context, jobName string, config *Config, masks *[
 	logger.SetFormatter(formatter)
 	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logrus.GetLevel())
-	rtn := logger.WithFields(logrus.Fields{"job": jobName, "dryrun": common.Dryrun(ctx)}).WithContext(ctx)
+	rtn := logger.WithFields(logrus.Fields{
+		"job":    jobName,
+		"jobID":  jobID,
+		"dryrun": common.Dryrun(ctx),
+	}).WithContext(ctx)
 
 	return common.WithLogger(ctx, rtn)
 }
@@ -92,8 +96,11 @@ func WithCompositeLogger(ctx context.Context, masks *[]string) context.Context {
 	return common.WithLogger(ctx, common.Logger(ctx).WithFields(logrus.Fields{}).WithContext(ctx))
 }
 
-func withStepLogger(ctx context.Context, stepName string) context.Context {
-	rtn := common.Logger(ctx).WithFields(logrus.Fields{"step": stepName})
+func withStepLogger(ctx context.Context, stepID string, stepName string) context.Context {
+	rtn := common.Logger(ctx).WithFields(logrus.Fields{
+		"step":   stepName,
+		"stepID": stepID,
+	})
 	return common.WithLogger(ctx, rtn)
 }
 

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -353,7 +353,7 @@ func (rc *RunContext) isEnabled(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("  \u274C  Error in if-expression: \"if: %s\" (%s)", job.If.Value, err)
 	}
 	if !runJob {
-		l.Debugf("Skipping job '%s' due to '%s'", job.Name, job.If.Value)
+		l.WithField("jobResult", "skipped").Debugf("Skipping job '%s' due to '%s'", job.Name, job.If.Value)
 		return false, nil
 	}
 

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -62,7 +62,7 @@ func TestRunContext_EvalBool(t *testing.T) {
 			},
 		},
 	}
-	rc.ExprEval = rc.NewExpressionEvaluator()
+	rc.ExprEval = rc.NewExpressionEvaluator(context.Background())
 
 	tables := []struct {
 		in      string
@@ -156,7 +156,7 @@ func TestRunContext_EvalBool(t *testing.T) {
 		table := table
 		t.Run(table.in, func(t *testing.T) {
 			assertObject := assert.New(t)
-			b, err := EvalBool(rc.ExprEval, table.in, exprparser.DefaultStatusCheckSuccess)
+			b, err := EvalBool(context.Background(), rc.ExprEval, table.in, exprparser.DefaultStatusCheckSuccess)
 			if table.wantErr {
 				assertObject.Error(err)
 			}
@@ -365,7 +365,7 @@ func TestGetGitHubContext(t *testing.T) {
 		OutputMappings: map[MappableOutput]MappableOutput{},
 	}
 
-	ghc := rc.getGithubContext()
+	ghc := rc.getGithubContext(context.Background())
 
 	log.Debugf("%v", ghc)
 
@@ -413,7 +413,7 @@ func createIfTestRunContext(jobs map[string]*model.Job) *RunContext {
 			},
 		},
 	}
-	rc.ExprEval = rc.NewExpressionEvaluator()
+	rc.ExprEval = rc.NewExpressionEvaluator(context.Background())
 
 	return rc
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -139,8 +139,8 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				}
 
 				if job.Strategy != nil {
-					strategyRc := runner.newRunContext(run, nil)
-					if err := strategyRc.NewExpressionEvaluator().EvaluateYamlNode(&job.Strategy.RawMatrix); err != nil {
+					strategyRc := runner.newRunContext(ctx, run, nil)
+					if err := strategyRc.NewExpressionEvaluator(ctx).EvaluateYamlNode(ctx, &job.Strategy.RawMatrix); err != nil {
 						log.Errorf("Error while evaluating matrix: %v", err)
 					}
 				}
@@ -155,7 +155,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				}
 
 				for i, matrix := range matrixes {
-					rc := runner.newRunContext(run, matrix)
+					rc := runner.newRunContext(ctx, run, matrix)
 					rc.JobName = rc.Name
 					if len(matrixes) > 1 {
 						rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
@@ -163,7 +163,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 					// evaluate environment variables since they can contain
 					// GitHub's special environment variables.
 					for k, v := range rc.GetEnv() {
-						valueEval, err := rc.ExprEval.evaluate(v, exprparser.DefaultStatusCheckNone)
+						valueEval, err := rc.ExprEval.evaluate(ctx, v, exprparser.DefaultStatusCheckNone)
 						if err == nil {
 							rc.Env[k] = fmt.Sprintf("%v", valueEval)
 						}
@@ -172,6 +172,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 						maxJobNameLen = len(rc.String())
 					}
 					stageExecutor = append(stageExecutor, func(ctx context.Context) error {
+						logger := common.Logger(ctx)
 						jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
 						return rc.Executor().Finally(func(ctx context.Context) error {
 							isLastRunningContainer := func(currentStage int, currentRun int) bool {
@@ -188,7 +189,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 								log.Infof("Cleaning up container for job %s", rc.JobName)
 
 								if err := rc.stopJobContainer()(ctx); err != nil {
-									log.Errorf("Error while cleaning container: %v", err)
+									logger.Errorf("Error while cleaning container: %v", err)
 								}
 							}
 
@@ -226,7 +227,7 @@ func handleFailure(plan *model.Plan) common.Executor {
 	}
 }
 
-func (runner *runnerImpl) newRunContext(run *model.Run, matrix map[string]interface{}) *RunContext {
+func (runner *runnerImpl) newRunContext(ctx context.Context, run *model.Run, matrix map[string]interface{}) *RunContext {
 	rc := &RunContext{
 		Config:      runner.config,
 		Run:         run,
@@ -234,7 +235,7 @@ func (runner *runnerImpl) newRunContext(run *model.Run, matrix map[string]interf
 		StepResults: make(map[string]*model.StepResult),
 		Matrix:      matrix,
 	}
-	rc.ExprEval = rc.NewExpressionEvaluator()
-	rc.Name = rc.ExprEval.Interpolate(run.String())
+	rc.ExprEval = rc.NewExpressionEvaluator(ctx)
+	rc.Name = rc.ExprEval.Interpolate(ctx, run.String())
 	return rc
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -194,7 +194,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 							}
 
 							return nil
-						})(common.WithJobErrorContainer(WithJobLogger(ctx, jobName, rc.Config, &rc.Masks)))
+						})(common.WithJobErrorContainer(WithJobLogger(ctx, rc.Run.JobID, jobName, rc.Config, &rc.Masks)))
 					})
 				}
 				pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -261,7 +261,7 @@ func TestMaskValues(t *testing.T) {
 	})
 
 	assertNoSecret(output, "secret value")
-	assertNoSecret(output, "composite secret")
+	assertNoSecret(output, "YWJjCg==")
 }
 
 func TestRunEventSecrets(t *testing.T) {

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -81,9 +81,9 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		}
 
 		if !runStep {
-			logger.Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
 			rc.StepResults[rc.CurrentStep].Conclusion = model.StepStatusSkipped
 			rc.StepResults[rc.CurrentStep].Outcome = model.StepStatusSkipped
+			logger.Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
 			return nil
 		}
 
@@ -96,10 +96,8 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		err = executor(ctx)
 
 		if err == nil {
-			logger.Infof("  \u2705  Success - %s %s", stage, stepString)
+			logger.WithField("stepResult", rc.StepResults[rc.CurrentStep].Outcome).Infof("  \u2705  Success - %s %s", stage, stepString)
 		} else {
-			logger.Errorf("  \u274C  Failure - %s %s", stage, stepString)
-
 			rc.StepResults[rc.CurrentStep].Outcome = model.StepStatusFailure
 			if stepModel.ContinueOnError {
 				logger.Infof("Failed but continue next step")
@@ -108,6 +106,8 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			} else {
 				rc.StepResults[rc.CurrentStep].Conclusion = model.StepStatusFailure
 			}
+
+			logger.WithField("stepResult", rc.StepResults[rc.CurrentStep].Outcome).Errorf("  \u274C  Failure - %s %s", stage, stepString)
 		}
 		return err
 	}

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -83,7 +83,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		if !runStep {
 			rc.StepResults[rc.CurrentStep].Conclusion = model.StepStatusSkipped
 			rc.StepResults[rc.CurrentStep].Outcome = model.StepStatusSkipped
-			logger.Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
+			logger.WithField("stepResult", rc.StepResults[rc.CurrentStep].Outcome).Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
 			return nil
 		}
 

--- a/pkg/runner/step_action_local.go
+++ b/pkg/runner/step_action_local.go
@@ -55,7 +55,7 @@ func (sal *stepActionLocal) main() common.Executor {
 			}
 		}
 
-		actionModel, err := sal.readAction(sal.Step, actionDir, "", localReader(ctx), ioutil.WriteFile)
+		actionModel, err := sal.readAction(ctx, sal.Step, actionDir, "", localReader(ctx), ioutil.WriteFile)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func (sal *stepActionLocal) getEnv() *map[string]string {
 	return &sal.env
 }
 
-func (sal *stepActionLocal) getIfExpression(stage stepStage) string {
+func (sal *stepActionLocal) getIfExpression(context context.Context, stage stepStage) string {
 	switch stage {
 	case stepStageMain:
 		return sal.Step.If.Value
@@ -96,12 +96,12 @@ func (sal *stepActionLocal) getActionModel() *model.Action {
 	return sal.action
 }
 
-func (sal *stepActionLocal) getCompositeRunContext() *RunContext {
+func (sal *stepActionLocal) getCompositeRunContext(ctx context.Context) *RunContext {
 	if sal.compositeRunContext == nil {
 		actionDir := filepath.Join(sal.RunContext.Config.Workdir, sal.Step.Uses)
 		_, containerActionDir := getContainerActionPaths(sal.getStepModel(), actionDir, sal.RunContext)
 
-		sal.compositeRunContext = newCompositeRunContext(sal.RunContext, sal, containerActionDir)
+		sal.compositeRunContext = newCompositeRunContext(ctx, sal.RunContext, sal, containerActionDir)
 		sal.compositeSteps = sal.compositeRunContext.compositeExecutor(sal.action)
 	}
 	return sal.compositeRunContext

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -21,7 +21,7 @@ func (salm *stepActionLocalMocks) runAction(step actionStep, actionDir string, r
 	return args.Get(0).(func(context.Context) error)
 }
 
-func (salm *stepActionLocalMocks) readAction(step *model.Step, actionDir string, actionPath string, readFile actionYamlReader, writeFile fileWriter) (*model.Action, error) {
+func (salm *stepActionLocalMocks) readAction(ctx context.Context, step *model.Step, actionDir string, actionPath string, readFile actionYamlReader, writeFile fileWriter) (*model.Action, error) {
 	args := salm.Called(step, actionDir, actionPath, readFile, writeFile)
 	return args.Get(0).(*model.Action), args.Error(1)
 }

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -19,7 +19,7 @@ type stepActionRemoteMocks struct {
 	mock.Mock
 }
 
-func (sarm *stepActionRemoteMocks) readAction(step *model.Step, actionDir string, actionPath string, readFile actionYamlReader, writeFile fileWriter) (*model.Action, error) {
+func (sarm *stepActionRemoteMocks) readAction(ctx context.Context, step *model.Step, actionDir string, actionPath string, readFile actionYamlReader, writeFile fileWriter) (*model.Action, error) {
 	args := sarm.Called(step, actionDir, actionPath, readFile, writeFile)
 	return args.Get(0).(*model.Action), args.Error(1)
 }

--- a/pkg/runner/step_docker.go
+++ b/pkg/runner/step_docker.go
@@ -47,7 +47,7 @@ func (sd *stepDocker) getEnv() *map[string]string {
 	return &sd.env
 }
 
-func (sd *stepDocker) getIfExpression(stage stepStage) string {
+func (sd *stepDocker) getIfExpression(context context.Context, stage stepStage) string {
 	return sd.Step.If.Value
 }
 
@@ -57,14 +57,14 @@ func (sd *stepDocker) runUsesContainer() common.Executor {
 
 	return func(ctx context.Context) error {
 		image := strings.TrimPrefix(step.Uses, "docker://")
-		eval := rc.NewExpressionEvaluator()
-		cmd, err := shellquote.Split(eval.Interpolate(step.With["args"]))
+		eval := rc.NewExpressionEvaluator(ctx)
+		cmd, err := shellquote.Split(eval.Interpolate(ctx, step.With["args"]))
 		if err != nil {
 			return err
 		}
 
 		var entrypoint []string
-		if entry := eval.Interpolate(step.With["entrypoint"]); entry != "" {
+		if entry := eval.Interpolate(ctx, step.With["entrypoint"]); entry != "" {
 			entrypoint = []string{entry}
 		}
 

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -230,7 +230,7 @@ func TestIsStepEnabled(t *testing.T) {
 
 	// success()
 	step := createTestStep(t, "if: success()")
-	assertObject.True(isStepEnabled(context.Background(), step.getIfExpression(stepStageMain), step, stepStageMain))
+	assertObject.True(isStepEnabled(context.Background(), step.getIfExpression(context.Background(), stepStageMain), step, stepStageMain))
 
 	step = createTestStep(t, "if: success()")
 	step.getRunContext().StepResults["a"] = &model.StepResult{

--- a/pkg/runner/testdata/mask-values/composite/action.yml
+++ b/pkg/runner/testdata/mask-values/composite/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - run: echo "secret value"
       shell: bash
-    - run: echo "::add-mask::composite secret"
+    - run: echo "::add-mask::$(echo "abc" | base64)"
       shell: bash
-    - run: echo "composite secret"
+    - run: echo "abc" | base64
       shell: bash

--- a/pkg/runner/testdata/mask-values/push.yml
+++ b/pkg/runner/testdata/mask-values/push.yml
@@ -9,4 +9,4 @@ jobs:
       - run: echo "::add-mask::secret value"
       - run: echo "secret value"
       - uses: ./mask-values/composite
-      - run: echo "composite secret"
+      - run: echo "YWJjCg=="


### PR DESCRIPTION
Replace more of the global logger call sites with contextualized job/step loggers and add job/step id and results as fields to the JSON logger output.

This causes most debug logs to be printed with the job logger, which means they are now correctly prefixed with the job they belong to.
Also, having the ids and results in the JSON output helps in cases where the log is read by machines, because we now can attribute each line to a job/step.