### PR TITLE
Rough handling for local checkouts in composite actions

### DIFF
--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -34,6 +34,7 @@ type GithubContext struct {
 	RetentionDays    string                 `json:"retention_days"`
 	RunnerPerflog    string                 `json:"runner_perflog"`
 	RunnerTrackingID string                 `json:"runner_tracking_id"`
+	CopiedWorkspace  string                 `json:"copied_workspace"`
 }
 
 func asString(v interface{}) string {


### PR DESCRIPTION
This seems to work for me for #1112

Tested with:

```sh
git clone git@github.com:check-spelling/lunr.js.git
git checkout spell-check
 ~/code/nektos/act/dist/local/act -W .github/workflows/spelling.yml --container-architecture linux/arm64 -s GITHUB_TOKEN=$GITHUB_TOKEN
```
