### PR TITLE
pkg/runner: add support to replace GitHub's env

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
+	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
 )
 
@@ -158,6 +159,14 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 					rc.JobName = rc.Name
 					if len(matrixes) > 1 {
 						rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
+					}
+					// evaluate environment variables since they can contain
+					// GitHub's special environment variables.
+					for k, v := range rc.GetEnv() {
+						valueEval, err := rc.ExprEval.evaluate(v, exprparser.DefaultStatusCheckNone)
+						if err == nil {
+							rc.Env[k] = fmt.Sprintf("%v", valueEval)
+						}
 					}
 					if len(rc.String()) > maxJobNameLen {
 						maxJobNameLen = len(rc.String())

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -147,6 +147,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "evalmatrixneeds2", "push", "", platforms},
 		{workdir, "evalmatrix-merge-map", "push", "", platforms},
 		{workdir, "evalmatrix-merge-array", "push", "", platforms},
+		{workdir, "issue-1195", "push", "", platforms},
 
 		{workdir, "basic", "push", "", platforms},
 		{workdir, "fail", "push", "exit with `FAILURE`: 1", platforms},

--- a/pkg/runner/testdata/issue-1195/push.yml
+++ b/pkg/runner/testdata/issue-1195/push.yml
@@ -1,0 +1,13 @@
+on: push
+
+env:
+  variable: "${{ github.repository_owner }}"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: print env.variable
+        run: |
+          echo ${{ env.variable }}
+          exit ${{ (env.variable == 'nektos') && '0' || '1'}}


### PR DESCRIPTION
There might be use cases where users want to use GitHub's variables in
the environment variables, which is a valid use case.

This commits adds support for replacement of GitHub's env with GitHub's
values.

Signed-off-by: André Martins <aanm90@gmail.com>

Fixes: #1195 