### PR TITLE
fix: dryrun skip local actions + enable Tests

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -182,7 +182,9 @@ func TestRunEvent(t *testing.T) {
 
 	for _, table := range tables {
 		t.Run(table.workflowPath, func(t *testing.T) {
-			table.runTest(common.WithDryrun(ctx, true), t, &Config{})
+                        dryrunTable := table
+                        dryrunTable.errorMessage = ""
+			dryrunTable.runTest(common.WithDryrun(ctx, true), t, &Config{})
 			table.runTest(ctx, t, &Config{})
 		})
 	}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	assert "github.com/stretchr/testify/assert"
 
+	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/model"
 )
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -181,6 +181,7 @@ func TestRunEvent(t *testing.T) {
 
 	for _, table := range tables {
 		t.Run(table.workflowPath, func(t *testing.T) {
+			table.runTest(common.WithDryrun(ctx, true), t, &Config{})
 			table.runTest(ctx, t, &Config{})
 		})
 	}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -182,9 +182,35 @@ func TestRunEvent(t *testing.T) {
 
 	for _, table := range tables {
 		t.Run(table.workflowPath, func(t *testing.T) {
-                        dryrunTable := table
-                        dryrunTable.errorMessage = ""
-			dryrunTable.runTest(common.WithDryrun(ctx, true), t, &Config{})
+			table.runTest(ctx, t, &Config{})
+		})
+	}
+}
+
+func TestDryrunEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := common.WithDryrun(context.Background(), true)
+
+	tables := []TestJobFileInfo{
+		// Shells
+		{workdir, "shells/defaults", "push", "", platforms},
+		{workdir, "shells/pwsh", "push", "", map[string]string{"ubuntu-latest": "ghcr.io/justingrote/act-pwsh:latest"}}, // custom image with pwsh
+		{workdir, "shells/bash", "push", "", platforms},
+		{workdir, "shells/python", "push", "", map[string]string{"ubuntu-latest": "node:16-buster"}}, // slim doesn't have python
+		{workdir, "shells/sh", "push", "", platforms},
+
+		// Local action
+		{workdir, "local-action-docker-url", "push", "", platforms},
+		{workdir, "local-action-dockerfile", "push", "", platforms},
+		{workdir, "local-action-via-composite-dockerfile", "push", "", platforms},
+		{workdir, "local-action-js", "push", "", platforms},
+	}
+
+	for _, table := range tables {
+		t.Run(table.workflowPath, func(t *testing.T) {
 			table.runTest(ctx, t, &Config{})
 		})
 	}

--- a/pkg/runner/step_action_local.go
+++ b/pkg/runner/step_action_local.go
@@ -28,6 +28,9 @@ func (sal *stepActionLocal) pre() common.Executor {
 	sal.env = map[string]string{}
 
 	return func(ctx context.Context) error {
+		if common.Dryrun(ctx) {
+			return nil
+		}
 		actionDir := filepath.Join(sal.getRunContext().Config.Workdir, sal.Step.Uses)
 
 		localReader := func(ctx context.Context) actionYamlReader {
@@ -65,6 +68,9 @@ func (sal *stepActionLocal) pre() common.Executor {
 
 func (sal *stepActionLocal) main() common.Executor {
 	return runStepExecutor(sal, stepStageMain, func(ctx context.Context) error {
+		if common.Dryrun(ctx) {
+			return nil
+		}
 		actionDir := filepath.Join(sal.getRunContext().Config.Workdir, sal.Step.Uses)
 		return sal.runAction(sal, actionDir, nil)(ctx)
 	})


### PR DESCRIPTION
I broke DRYRUN for local actions last year, in a previous PR I replaced the panic with an error.

Now just skip local actions in DRYRUN, jobs using local actions now passing again.