### PR TITLE
fix: Also remove volume with same name as the container

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -218,6 +218,7 @@ func (rc *RunContext) stopJobContainer() common.Executor {
 	return func(ctx context.Context) error {
 		if rc.JobContainer != nil && !rc.Config.ReuseContainers {
 			return rc.JobContainer.Remove().
+				Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName(), false))
 				Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName()+"-env", false))(ctx)
 		}
 		return nil


### PR DESCRIPTION
I reread this function https://github.com/nektos/act/blob/859445fb94e12cc600e5a59d9c9cd687214cb801/pkg/runner/run_context.go#L79-L124, then I come to the conclusion that I made a silly mistake in #1148 that both volumes ( name, name+"-env" ) have to be removed.

