### PR TITLE
Added tests for mid-size and big artifacts (to reproduce a problem with chunked uploads)

### DIFF
--- a/pkg/artifacts/testdata/upload-and-download/artifacts.yml
+++ b/pkg/artifacts/testdata/upload-and-download/artifacts.yml
@@ -26,10 +26,14 @@ jobs:
         run: |
           mkdir -p path/to/dir-1
           mkdir -p path/to/dir-2
-          mkdir -p path/to/dir-3    
+          mkdir -p path/to/dir-3
+          mkdir -p path/to/dir-5
+          mkdir -p path/to/dir-6
           echo "Lorem ipsum dolor sit amet" > path/to/dir-1/file1.txt
           echo "Hello world from file #2" > path/to/dir-2/file2.txt
           echo "This is a going to be a test for a large enough file that should get compressed with GZip. The @actions/artifact package uses GZip to upload files. This text should have a compression ratio greater than 100% so it should get uploaded using GZip" > path/to/dir-3/gzip.txt
+          dd if=/dev/random of=path/to/dir-5/file5.rnd bs=1024 count=1024
+          dd if=/dev/random of=path/to/dir-6/file6.rnd bs=1024 count=$((10*1024))
       # Upload a single file artifact
       - name: 'Upload artifact #1'
         uses: actions/upload-artifact@v2
@@ -59,6 +63,20 @@ jobs:
             path/to/dir-1/*
             path/to/dir-[23]/*
             !path/to/dir-3/*.txt
+      
+      # Upload a mid-size file artifact
+      - name: 'Upload artifact #5'
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Mid-Size-Artifact'
+          path: path/to/dir-5/file5.rnd
+      
+      # Upload a big file artifact
+      - name: 'Upload artifact #6'
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Big-Artifact'
+          path: path/to/dir-6/file6.rnd
       # Verify artifacts. Switch to download-artifact@v2 once it's out of preview
       
       # Download Artifact #1 and verify the correctness of the content
@@ -136,5 +154,41 @@ jobs:
           fi
           if [ "$(cat $file1)" != "Lorem ipsum dolor sit amet" -o "$(cat $file2)" != "Hello world from file #2" ] ; then
             echo "File contents of downloaded artifacts are incorrect"
+            exit 1
+          fi
+      
+      - name: 'Download artifact #5'
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Mid-Size-Artifact'
+          path: mid-size/artifact/path
+      
+      - name: 'Verify Artifact #5'
+        run: |
+          file="mid-size/artifact/path/file5.rnd"
+          if [ ! -f $file ] ; then
+            echo "Expected file does not exist"
+            exit 1
+          fi
+          if ! diff $file path/to/dir-5/file5.rnd ; then
+            echo "File contents of downloaded artifact are incorrect"
+            exit 1
+          fi
+      
+      - name: 'Download artifact #6'
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Big-Artifact'
+          path: big/artifact/path
+      
+      - name: 'Verify Artifact #6'
+        run: |
+          file="big/artifact/path/file6.rnd"
+          if [ ! -f $file ] ; then
+            echo "Expected file does not exist"
+            exit 1
+          fi
+          if ! diff $file path/to/dir-6/file6.rnd ; then
+            echo "File contents of downloaded artifact are incorrect"
             exit 1
           fi


### PR DESCRIPTION
This should reproduce the problem (in [artifacts server](https://github.com/nektos/act/blob/8a473943c3dffbbf47c2a2ef8b261e845646fa6e/pkg/artifacts/server.go)?) with support for chunked uploads. Namely, artifacts cut at size of 8388608 (8M).

It adds two tests (artifacts 5 and 6):
- 5 is for mid-sized upload (1M), works fine
- 6 is for big upload (10M), gets cut on upload at 8388608.

```
$ act -W pkg/artifacts/testdata/upload-and-download/artifacts.yml --artifact-server-path artifacts
....
[Test that artifact uploads and downloads succeed/test-artifacts] ⭐ Run Main Download artifact #5
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker cp src=/Users/eg/.cache/act/actions-download-artifact@v2/ dst=/var/run/act/actions/actions-download-artifact@v2/
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/actions-download-artifact@v2/] user= workdir=
[Test that artifact uploads and downloads succeed/test-artifacts] close /var/folders/mp/3jr0hvr922v_32bx7309bntr0000gn/T/act2616194157: file already closed
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker exec cmd=[node /var/run/act/actions/actions-download-artifact@v2/dist/index.js] user= workdir=
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::Resolved path is /Users/eg/Workbench/act/mid-size/artifact/path
| Starting download for Mid-Size-Artifact
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::Artifact Url: http://192.168.2.80:34567/_apis/pipelines/workflows/1/artifacts?api-version=6.0-preview
| Directory structure has been setup for the artifact
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::Download file concurrency is set to 2
| Total number of files that will be downloaded: 1
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::/Users/eg/Workbench/act/mid-size/artifact/path/file5.rnd size:(1048576) blksize:(4096) blocks:(2048)
| Skipping download validation.
| Artifact Mid-Size-Artifact was downloaded to /Users/eg/Workbench/act/mid-size/artifact/path
[Test that artifact uploads and downloads succeed/test-artifacts]   ⚙  ::set-output:: download-path=/Users/eg/Workbench/act/mid-size/artifact/path
| Artifact download has finished successfully
[Test that artifact uploads and downloads succeed/test-artifacts]   ✅  Success - Main Download artifact #5
[Test that artifact uploads and downloads succeed/test-artifacts] ⭐ Run Main Verify Artifact #5
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/22] user= workdir=
[Test that artifact uploads and downloads succeed/test-artifacts]   ✅  Success - Main Verify Artifact #5
[Test that artifact uploads and downloads succeed/test-artifacts] ⭐ Run Main Download artifact #6
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker cp src=/Users/eg/.cache/act/actions-download-artifact@v2/ dst=/var/run/act/actions/actions-download-artifact@v2/
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/actions-download-artifact@v2/] user= workdir=
[Test that artifact uploads and downloads succeed/test-artifacts] close /var/folders/mp/3jr0hvr922v_32bx7309bntr0000gn/T/act2285776570: file already closed
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker exec cmd=[node /var/run/act/actions/actions-download-artifact@v2/dist/index.js] user= workdir=
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::Resolved path is /Users/eg/Workbench/act/big/artifact/path
| Starting download for Big-Artifact
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::Artifact Url: http://192.168.2.80:34567/_apis/pipelines/workflows/1/artifacts?api-version=6.0-preview
| Directory structure has been setup for the artifact
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::Download file concurrency is set to 2
| Total number of files that will be downloaded: 1
[Test that artifact uploads and downloads succeed/test-artifacts]   💬  ::debug::/Users/eg/Workbench/act/big/artifact/path/file6.rnd size:(8388608) blksize:(4096) blocks:(16384)
| Skipping download validation.
| Artifact Big-Artifact was downloaded to /Users/eg/Workbench/act/big/artifact/path
[Test that artifact uploads and downloads succeed/test-artifacts]   ⚙  ::set-output:: download-path=/Users/eg/Workbench/act/big/artifact/path
| Artifact download has finished successfully
[Test that artifact uploads and downloads succeed/test-artifacts]   ✅  Success - Main Download artifact #6
[Test that artifact uploads and downloads succeed/test-artifacts] ⭐ Run Main Verify Artifact #6
[Test that artifact uploads and downloads succeed/test-artifacts]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/24] user= workdir=
| Binary files big/artifact/path/file6.rnd and path/to/dir-6/file6.rnd differ
| File contents of downloaded artifact are incorrect
[Test that artifact uploads and downloads succeed/test-artifacts]   ❌  Failure - Main Verify Artifact #6
[Test that artifact uploads and downloads succeed/test-artifacts] exit with `FAILURE`: 1
Error: Job 'test-artifacts' failed

$ ls -l artifacts/1/*/file?.rnd
-rw-r--r--  1 eg  staff  8388608 Jun 10 09:44 artifacts/1/Big-Artifact/file6.rnd
-rw-r--r--  1 eg  staff  1048576 Jun 10 09:44 artifacts/1/Mid-Size-Artifact/file5.rnd
```