### PR TITLE
fix: checkout container path should always use `/`

### DIFF
--- a/pkg/runner/step_action_remote.go
+++ b/pkg/runner/step_action_remote.go
@@ -123,7 +123,7 @@ func (sar *stepActionRemote) main() common.Executor {
 					return nil
 				}
 				eval := sar.RunContext.NewExpressionEvaluator(ctx)
-				copyToPath := filepath.Join(sar.RunContext.Config.ContainerWorkdir(), eval.Interpolate(ctx, sar.Step.With["path"]))
+				copyToPath := path.Join(sar.RunContext.Config.ContainerWorkdir(), eval.Interpolate(ctx, sar.Step.With["path"]))
 				return sar.RunContext.JobContainer.CopyDir(copyToPath, sar.RunContext.Config.Workdir+string(filepath.Separator)+".", sar.RunContext.Config.UseGitIgnore)(ctx)
 			}
 


### PR DESCRIPTION
Container.CopyDir is no longer working with `\` as destpath. Should it support backslash as path separator e.g. replace with forwardslash.

It seems like my https://github.com/nektos/act/pull/1202 change causes issues with checkout on windows, files are no longer where they are expected to be.

_I wondered in the past why I saw `\mnt\c\...` in the act log, this now cause issues_