### PR TITLE
fix: allow TimeoutMinutes to be expression in Jobs

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -63,7 +63,7 @@ type Job struct {
 	Env            yaml.Node                 `yaml:"env"`
 	If             yaml.Node                 `yaml:"if"`
 	Steps          []*Step                   `yaml:"steps"`
-	TimeoutMinutes int64                     `yaml:"timeout-minutes"`
+	TimeoutMinutes string                    `yaml:"timeout-minutes"`
 	Services       map[string]*ContainerSpec `yaml:"services"`
 	Strategy       *Strategy                 `yaml:"strategy"`
 	RawContainer   yaml.Node                 `yaml:"container"`


### PR DESCRIPTION
This change stops act from rejecting valid entries such as

```
    timeout-minutes: ${{ matrix.runtime == 'v8' && 30 || 15 }}
```

at the `jobs:` level.

This change complements the fix that was already in place for the Step struct, done by @catthehacker in #1217. See: https://github.com/nektos/act/commit/52f5c4592cbbf2e4dde3b35ad42f4e7475ad52df
