### PR TITLE
fix: the number in the github event is of type number

### DIFF
--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -98,7 +98,7 @@ func (ghc *GithubContext) SetRefAndSha(ctx context.Context, defaultBranch string
 		ghc.Ref = ghc.BaseRef
 		ghc.Sha = asString(nestedMapLookup(ghc.Event, "pull_request", "base", "sha"))
 	case "pull_request", "pull_request_review", "pull_request_review_comment":
-		ghc.Ref = fmt.Sprintf("refs/pull/%d/merge", ghc.Event["number"])
+		ghc.Ref = fmt.Sprintf("refs/pull/%.0f/merge", ghc.Event["number"])
 	case "deployment", "deployment_status":
 		ghc.Ref = asString(nestedMapLookup(ghc.Event, "deployment", "ref"))
 		ghc.Sha = asString(nestedMapLookup(ghc.Event, "deployment", "sha"))

--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -98,7 +98,7 @@ func (ghc *GithubContext) SetRefAndSha(ctx context.Context, defaultBranch string
 		ghc.Ref = ghc.BaseRef
 		ghc.Sha = asString(nestedMapLookup(ghc.Event, "pull_request", "base", "sha"))
 	case "pull_request", "pull_request_review", "pull_request_review_comment":
-		ghc.Ref = fmt.Sprintf("refs/pull/%s/merge", ghc.Event["number"])
+		ghc.Ref = fmt.Sprintf("refs/pull/%d/merge", ghc.Event["number"])
 	case "deployment", "deployment_status":
 		ghc.Ref = asString(nestedMapLookup(ghc.Event, "deployment", "ref"))
 		ghc.Sha = asString(nestedMapLookup(ghc.Event, "deployment", "sha"))

--- a/pkg/model/github_context_test.go
+++ b/pkg/model/github_context_test.go
@@ -46,7 +46,7 @@ func TestSetRefAndSha(t *testing.T) {
 		{
 			eventName: "pull_request",
 			event: map[string]interface{}{
-				"number": "1234",
+				"number": 1234,
 			},
 			ref: "refs/pull/1234/merge",
 			sha: "1234fakesha",

--- a/pkg/model/github_context_test.go
+++ b/pkg/model/github_context_test.go
@@ -46,7 +46,7 @@ func TestSetRefAndSha(t *testing.T) {
 		{
 			eventName: "pull_request",
 			event: map[string]interface{}{
-				"number": 1234,
+				"number": 1234.,
 			},
 			ref: "refs/pull/1234/merge",
 			sha: "1234fakesha",


### PR DESCRIPTION
The go `%s` formattig option outputs the type if the given input value is not of type string.

```go
fmt.Printf("Number: %s\n", 123) // -> Number: %!s(int=123)
fmt.Printf("Number: %d\n", 123) // -> Number: 123
fmt.Printf("Number: %.0f\n", 123.) // -> Number: 123
```

Update: The parsed type is float64, therefore we should use float formatting