### PR TITLE
lint: add ReadHeaderTimeout

### DIFF
--- a/pkg/artifacts/server.go
+++ b/pkg/artifacts/server.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/nektos/act/pkg/common"
@@ -277,7 +278,11 @@ func Serve(ctx context.Context, artifactPath string, port string) context.Cancel
 	downloads(router, fs)
 	ip := common.GetOutboundIP().String()
 
-	server := &http.Server{Addr: fmt.Sprintf("%s:%s", ip, port), Handler: router}
+	server := &http.Server{
+		Addr:              fmt.Sprintf("%s:%s", ip, port),
+		ReadHeaderTimeout: 2 * time.Second,
+		Handler:           router,
+	}
 
 	// run server
 	go func() {


### PR DESCRIPTION
currently build fail with:

```
run golangci-lint
  Running [/home/runner/golangci-lint-1.47.0-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  Error: G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
```

for example in this PR:
https://github.com/nektos/act/runs/7405009660?check_suite_focus=true

this sets the required ReadHeaderTimeout