### PR TITLE
walk submodule path instead of dir name

### DIFF
--- a/pkg/container/file_collector.go
+++ b/pkg/container/file_collector.go
@@ -142,14 +142,16 @@ func (fc *fileCollector) collectFiles(ctx context.Context, submodulePath []strin
 				return nil
 			}
 		}
+
+		path := filepath.ToSlash(sansPrefix)
+
 		if err == nil && entry.Mode == filemode.Submodule {
-			err = fc.Fs.Walk(fi.Name(), fc.collectFiles(ctx, split))
+			err = fc.Fs.Walk(path, fc.collectFiles(ctx, split))
 			if err != nil {
 				return err
 			}
 			return filepath.SkipDir
 		}
-		path := filepath.ToSlash(sansPrefix)
 
 		// return on non-regular files (thanks to [kumo](https://medium.com/@komuw/just-like-you-did-fbdd7df829d3) for this suggested update)
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {

--- a/pkg/container/file_collector.go
+++ b/pkg/container/file_collector.go
@@ -142,16 +142,14 @@ func (fc *fileCollector) collectFiles(ctx context.Context, submodulePath []strin
 				return nil
 			}
 		}
-
-		path := filepath.ToSlash(sansPrefix)
-
 		if err == nil && entry.Mode == filemode.Submodule {
-			err = fc.Fs.Walk(path, fc.collectFiles(ctx, split))
+			err = fc.Fs.Walk(file, fc.collectFiles(ctx, split))
 			if err != nil {
 				return err
 			}
 			return filepath.SkipDir
 		}
+		path := filepath.ToSlash(sansPrefix)
 
 		// return on non-regular files (thanks to [kumo](https://medium.com/@komuw/just-like-you-did-fbdd7df829d3) for this suggested update)
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {


### PR DESCRIPTION
Having submodule located into a different path than submodule name will make walk file to fail.
```
[submodule "stable-asset"]
	path = ecosystem-modules/stable-asset
	url = https://github.com/nutsfinance/stable-asset.git
```
It will walk `stable-asset` and failing with `lstat stable-asset: no such file or directory`
This PR will change it and walk the path instead