### PR TITLE
refactor: ignore already closed error

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -696,16 +697,8 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string, useGitIgno
 		defer func(tarFile *os.File) {
 			name := tarFile.Name()
 			err := tarFile.Close()
-			if err != nil {
-				alreadyClosed := false
-				if err2, ok := err.(*os.PathError); ok {
-					if err2.Unwrap() == os.ErrClosed {
-						alreadyClosed = true
-					}
-				}
-				if !alreadyClosed {
-					logger.Error(err)
-				}
+			if !errors.Is(err, os.ErrClosed) {
+				logger.Error(err)
 			}
 			err = os.Remove(name)
 			if err != nil {

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -697,7 +697,15 @@ func (cr *containerReference) copyDir(dstPath string, srcPath string, useGitIgno
 			name := tarFile.Name()
 			err := tarFile.Close()
 			if err != nil {
-				logger.Error(err)
+				alreadyClosed := false
+				if err2, ok := err.(*os.PathError); ok {
+					if err2.Unwrap() == os.ErrClosed {
+						alreadyClosed = true
+					}
+				}
+				if !alreadyClosed {
+					logger.Error(err)
+				}
 			}
 			err = os.Remove(name)
 			if err != nil {


### PR DESCRIPTION
This hides the `file already cloesd` error as it is
distracting in the output and does not provide any value.
