### PR TITLE
fix: ensure all post steps are executed

### DIFF
--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -160,8 +160,7 @@ func (rc *RunContext) compositeExecutor(action *model.Action) *compositeSteps {
 		// run the post executor in reverse order
 		if postExecutor != nil {
 			stepPost := rc.newCompositeCommandExecutor(step.post())
-			postExecutor = newCompositeStepLogExecutor(stepPost, stepID)
-			stepPost.Finally(postExecutor)
+			postExecutor = newCompositeStepLogExecutor(stepPost.Finally(postExecutor), stepID)
 		} else {
 			stepPost := rc.newCompositeCommandExecutor(step.post())
 			postExecutor = newCompositeStepLogExecutor(stepPost, stepID)

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -178,6 +178,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "actions-environment-and-context-tests", "push", "", platforms},
 		{workdir, "uses-action-with-pre-and-post-step", "push", "", platforms},
 		{workdir, "evalenv", "push", "", platforms},
+		{workdir, "ensure-post-steps", "push", "Job 'second-post-step-should-fail' failed", platforms},
 		{"../model/testdata", "strategy", "push", "", platforms}, // TODO: move all testdata into pkg so we can validate it with planner and runner
 		// {"testdata", "issue-228", "push", "", platforms, }, // TODO [igni]: Remove this once everything passes
 		{"../model/testdata", "container-volumes", "push", "", platforms},

--- a/pkg/runner/testdata/ensure-post-steps/action-composite/action.yml
+++ b/pkg/runner/testdata/ensure-post-steps/action-composite/action.yml
@@ -1,0 +1,10 @@
+name: "action composite"
+description: "action composite"
+runs:
+  using: composite
+  steps:
+    # second post action should fail if executed (we do check on the exit code)
+    - uses: ./ensure-post-steps/action-post/
+      with:
+        fail: "true"
+    - uses: ./ensure-post-steps/action-post/

--- a/pkg/runner/testdata/ensure-post-steps/action-post/action.yml
+++ b/pkg/runner/testdata/ensure-post-steps/action-post/action.yml
@@ -1,0 +1,11 @@
+name: "action post"
+description: "action post"
+inputs:
+  fail:
+    description: "true if this should fail"
+    required: false
+    default: "false"
+runs:
+  using: node16
+  main: "./main.js"
+  post: "./post.js"

--- a/pkg/runner/testdata/ensure-post-steps/action-post/post.js
+++ b/pkg/runner/testdata/ensure-post-steps/action-post/post.js
@@ -1,0 +1,3 @@
+if (process.env["INPUT_FAIL"] === "true") {
+  process.exit(1);
+}

--- a/pkg/runner/testdata/ensure-post-steps/push.yml
+++ b/pkg/runner/testdata/ensure-post-steps/push.yml
@@ -1,0 +1,8 @@
+name: test
+on: push
+jobs:
+  second-post-step-should-fail:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./ensure-post-steps/action-composite/


### PR DESCRIPTION
This fixes an issue in the chain of post steps introduced
while updating the step-logger for composite actions.

It includes a test case so we make sure this does not happen
again.
