### PR TITLE
fix: CI is unstable due to new linting rules

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
           check-latest: true
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: latest
+          version: v1.47.2
       - uses: megalinter/megalinter/flavors/go@v5
         env:
           DEFAULT_BRANCH: master


### PR DESCRIPTION
Test pinning the version to a less recent one

Upgrade the linter together with code cleanup to pass  with the latest version.

Maybe we want to leave latest for feature requests etc.