### PR TITLE
help output: use consistent terminology between `-j` & `-l`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().BoolP("watch", "w", false, "watch the contents of the local repo and run when files change")
 	rootCmd.Flags().BoolP("list", "l", false, "list workflows")
 	rootCmd.Flags().BoolP("graph", "g", false, "draw workflows")
-	rootCmd.Flags().StringP("job", "j", "", "run job")
+	rootCmd.Flags().StringP("job", "j", "", "run a specific job ID")
 	rootCmd.Flags().BoolP("bug-report", "", false, "Display system information for bug report")
 
 	rootCmd.Flags().StringVar(&input.remoteName, "remote-name", "origin", "git remote name that will be used to retrieve url of git repo")


### PR DESCRIPTION
I was *very* confused for awhile trying to figure out how to go from `act -l`, to "run a specific job".

Since the column in `act -l` is titled "Job ID", i figured that adding the literal text "job ID" to the help output for `-j` would have clued me in immediately as to which command I needed to run.

Happy to make whatever changes you like, but I'm hoping this is a trivial enough change :-)