### PR TITLE
fix: show workflow info even if on.push is not defined (#1329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,16 @@ Download the [latest release](https://github.com/nektos/act/releases/latest) and
 # Command structure:
 act [<event>] [options]
 If no event name passed, will default to "on: push"
+If actions handles only one event it will be used as default instead of "on: push"
 
-# List the actions for the default event:
+# List all actions for all events:
 act -l
 
 # List the actions for a specific event:
 act workflow_dispatch -l
+
+# List the actions for a specific job:
+act -j test -l
 
 # Run the default (`push`) event:
 act

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ import (
 func Execute(ctx context.Context, version string) {
 	input := new(Input)
 	var rootCmd = &cobra.Command{
-		Use:              "act [event name to run]\nIf no event name passed, will default to \"on: push\"",
+		Use:              "act [event name to run] [flags]\n\nIf no event name passed, will default to \"on: push\"\nIf actions handles only one event it will be used as default instead of \"on: push\"",
 		Short:            "Run GitHub actions locally by specifying the event name (e.g. `push`) or an action name directly.",
 		Args:             cobra.MaximumNArgs(1),
 		RunE:             newRunCommand(ctx, input),

--- a/pkg/model/planner.go
+++ b/pkg/model/planner.go
@@ -17,6 +17,7 @@ import (
 type WorkflowPlanner interface {
 	PlanEvent(eventName string) *Plan
 	PlanJob(jobName string) *Plan
+	PlanAll() *Plan
 	GetEvents() []string
 }
 
@@ -193,6 +194,20 @@ func (wp *workflowPlanner) PlanJob(jobName string) *Plan {
 	for _, w := range wp.workflows {
 		plan.mergeStages(createStages(w, jobName))
 	}
+	return plan
+}
+
+// PlanAll builds a new run to execute in parallel all
+func (wp *workflowPlanner) PlanAll() *Plan {
+	plan := new(Plan)
+	if len(wp.workflows) == 0 {
+		log.Debugf("no jobs found for loaded workflows")
+	}
+
+	for _, w := range wp.workflows {
+		plan.mergeStages(createStages(w, w.GetJobIDs()...))
+	}
+
 	return plan
 }
 


### PR DESCRIPTION
To fix listing of workflows in such cases list/graph filtering was split with planning.

Now act supports one of the following list (-l)/graph (-g) cases:
* show all jobs of loaded workflows: act -l
* show specific job JOBNAME: act -l -j JOBNAME
* show jobs of loaded workflows in which event EVENTNAME is set up: act -l EVENTNAME
* show jobs of loaded workflows in which first defined workflow event is set up: act -l --detect-event

For planning it supports:
* running specific job JOBNAME with triggered event determined from: 
1. CLI argument: act -j JOBNAME EVENTNAME
2. first defined in loaded workflows event: act -j  JOBNAME --detect-event 
3. only defined in loaded workflows event: act -j JOBNAME 
4. or push event by default: act -j JOBNAME

*  running jobs of loaded workflows in which event is set up, event is determined from: 
1. CLI argument: act EVENTNAME
2. first defined in loaded workflows event: act --detect-event 
3. only defined in loaded workflows event: act
4. or push event by default: act

Except #1329 this PR fixes #1332, #1318