### PR TITLE
fix: crash on invalid docker credentials

### DIFF
--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -38,8 +38,6 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		return common.NewDebugExecutor("No steps found")
 	}
 
-	preSteps = append(preSteps, info.startContainer())
-
 	for i, stepModel := range infoSteps {
 		stepModel := stepModel
 		if stepModel == nil {
@@ -104,7 +102,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 	pipeline = append(pipeline, preSteps...)
 	pipeline = append(pipeline, steps...)
 
-	return common.NewPipelineExecutor(pipeline...).
+	return common.NewPipelineExecutor(info.startContainer(), common.NewPipelineExecutor(pipeline...).
 		Finally(func(ctx context.Context) error {
 			var cancel context.CancelFunc
 			if ctx.Err() == context.Canceled {
@@ -116,7 +114,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			return postExecutor(ctx)
 		}).
 		Finally(info.interpolateOutputs()).
-		Finally(info.closeContainer())
+		Finally(info.closeContainer()))
 }
 
 func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, executor common.Executor) common.Executor {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -155,6 +155,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "checkout", "push", "", platforms},
 		{workdir, "job-container", "push", "", platforms},
 		{workdir, "job-container-non-root", "push", "", platforms},
+		{workdir, "job-container-invalid-credentials", "push", "failed to handle credentials: failed to interpolate container.credentials.password", platforms},
 		{workdir, "container-hostname", "push", "", platforms},
 		{workdir, "remote-action-docker", "push", "", platforms},
 		{workdir, "remote-action-js", "push", "", platforms},

--- a/pkg/runner/testdata/job-container-invalid-credentials/push.yml
+++ b/pkg/runner/testdata/job-container-invalid-credentials/push.yml
@@ -1,0 +1,13 @@
+name: job-container-invalid-credentials
+on: push
+
+jobs:
+  fail-on-invalid-credentials:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16-buster-slim
+      credentials:
+        username: "user"
+        password: "" # Empty password caused a crash in jobexecutor
+    steps:
+      - run: exit 0


### PR DESCRIPTION
We cannot run post steps, if we have no job container.
This change skips post steps, if startContainer() fails.

Before this change see referenced issue
After this change:
```
Error: failed to handle credentials: failed to interpolate container.credentials.password
```

- [x] Add Test

Fixes #1306