### PR TITLE
fix: missing defaults in nodejs pre

### DIFF
--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -481,6 +481,8 @@ func runPreStep(step actionStep) common.Executor {
 
 		switch action.Runs.Using {
 		case model.ActionRunsUsingNode12, model.ActionRunsUsingNode16:
+			// defaults in pre steps were missing, however provided inputs are available
+			populateEnvsFromInput(ctx, step.getEnv(), action, rc)
 			// todo: refactor into step
 			var actionDir string
 			var actionPath string

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -137,6 +137,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "uses-composite", "push", "", platforms},
 		{workdir, "uses-composite-with-error", "push", "Job 'failing-composite-action' failed", platforms},
 		{workdir, "uses-nested-composite", "push", "", platforms},
+		{workdir, "remote-action-composite-js-pre-with-defaults", "push", "", platforms},
 		{workdir, "uses-workflow", "push", "reusable workflows are currently not supported (see https://github.com/nektos/act/issues/826 for updates)", platforms},
 		{workdir, "uses-docker-url", "push", "", platforms},
 		{workdir, "act-composite-env-test", "push", "", platforms},

--- a/pkg/runner/testdata/remote-action-composite-js-pre-with-defaults/push.yml
+++ b/pkg/runner/testdata/remote-action-composite-js-pre-with-defaults/push.yml
@@ -1,0 +1,23 @@
+name: remote-action-composite-js-pre-with-defaults
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: nektos/act-test-actions/composite-js-pre-with-defaults/js@main
+      with:
+        in: nix
+    - uses: nektos/act-test-actions/composite-js-pre-with-defaults@main
+      with:
+        in: secretval
+    - uses: nektos/act-test-actions/composite-js-pre-with-defaults@main
+      with:
+        in: secretval
+    - uses: nektos/act-test-actions/composite-js-pre-with-defaults/js@main
+      with:
+        pre: "true"
+        in: nix
+    - uses: nektos/act-test-actions/composite-js-pre-with-defaults/js@main
+      with:
+        in: nix


### PR DESCRIPTION
My action sets booleans to default value false, but these value was not provided by act in pre steps.
See action.yml https://github.com/ChristopherHX/script/blob/d2555954ac01dba5ed9a3f79dc11e97f9bfdf731/action.yml#L10

Before this change this fails
```
[remote-action-composite-js-pre-with-defaults/test] ⭐ Run Pre nektos/act-test-actions/composite-js-pre-with-defaults/js@main
[remote-action-composite-js-pre-with-defaults/test]   🐳  docker cp src=C:\Users\User\.cache\act/nektos-act-test-actions-composite-js-pre-with-defaults-js@main/ dst=/var/run/act/actions/nektos-act-test-actions-composite-js-pre-with-defaults-js@main/
[remote-action-composite-js-pre-with-defaults/test]   🐳  docker exec cmd=[chown -R 1001:1001 /var/run/act/actions/nektos-act-test-actions-composite-js-pre-with-defaults-js@main/] user=0 workdir=
[remote-action-composite-js-pre-with-defaults/test]   🐳  docker exec cmd=[node /var/run/act/actions/nektos-act-test-actions-composite-js-pre-with-defaults-js@main/composite-js-pre-with-defaults/js/check.js] user= workdir=
| Unexpected input value pre: 'undefined' expected 'true' or 'false'
[remote-action-composite-js-pre-with-defaults/test]   💾  ::save-state name=FAILED::1
[remote-action-composite-js-pre-with-defaults/test]   ❌  Failure - Pre nektos/act-test-actions/composite-js-pre-with-defaults/js@main
[remote-action-composite-js-pre-with-defaults/test] 🏁  Job succeeded
Error: exitcode '1': failure
```

- [x] Add Test
