### PR TITLE
feat: pass current matrix information to job logger

### DIFF
--- a/pkg/runner/command_test.go
+++ b/pkg/runner/command_test.go
@@ -164,7 +164,7 @@ func TestAddmaskUsemask(t *testing.T) {
 
 	re := captureOutput(t, func() {
 		ctx := context.Background()
-		ctx = WithJobLogger(ctx, "0", "testjob", config, &rc.Masks)
+		ctx = WithJobLogger(ctx, "0", "testjob", config, &rc.Masks, map[string]interface{}{})
 
 		handler := rc.commandHandler(ctx)
 		handler("::add-mask::secret\n")

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -58,7 +58,7 @@ func WithMasks(ctx context.Context, masks *[]string) context.Context {
 }
 
 // WithJobLogger attaches a new logger to context that is aware of steps
-func WithJobLogger(ctx context.Context, jobID string, jobName string, config *Config, masks *[]string) context.Context {
+func WithJobLogger(ctx context.Context, jobID string, jobName string, config *Config, masks *[]string, matrix map[string]interface{}) context.Context {
 	mux.Lock()
 	defer mux.Unlock()
 
@@ -86,6 +86,7 @@ func WithJobLogger(ctx context.Context, jobID string, jobName string, config *Co
 		"job":    jobName,
 		"jobID":  jobID,
 		"dryrun": common.Dryrun(ctx),
+		"matrix": matrix,
 	}).WithContext(ctx)
 
 	return common.WithLogger(ctx, rtn)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -192,7 +192,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 							}
 
 							return nil
-						})(common.WithJobErrorContainer(WithJobLogger(ctx, rc.Run.JobID, jobName, rc.Config, &rc.Masks)))
+						})(common.WithJobErrorContainer(WithJobLogger(ctx, rc.Run.JobID, jobName, rc.Config, &rc.Masks, matrix)))
 					})
 				}
 				pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))


### PR DESCRIPTION
For log processing of the JSON logs, we want to be able to know which
keys/values of the matrices were used.
This commit adds the current matrix map to the job logger.

Co-authored-by: Markus Wolf <markus.wolf@new-work.se>
