### PR TITLE
fix: restore the job logger setup after job cancelation

### DIFF
--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -108,7 +108,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			if ctx.Err() == context.Canceled {
 				// in case of an aborted run, we still should execute the
 				// post steps to allow cleanup.
-				ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+				ctx, cancel = context.WithTimeout(WithJobLogger(context.Background(), rc.Run.JobID, rc.String(), rc.Config, &rc.Masks, rc.Matrix), 5*time.Minute)
 				defer cancel()
 			}
 			return postExecutor(ctx)


### PR DESCRIPTION
To be able to tag all log-lines with appropriate fields
after a workflow run is canceled, we need to restore
the JobLogger in the cancelation context.
