### PR TITLE
fix: re-evaluate env for remote composite actions

### DIFF
--- a/pkg/runner/step_action_remote.go
+++ b/pkg/runner/step_action_remote.go
@@ -187,6 +187,15 @@ func (sar *stepActionRemote) getCompositeRunContext(ctx context.Context) *RunCon
 
 		sar.compositeRunContext = newCompositeRunContext(ctx, sar.RunContext, sar, containerActionDir)
 		sar.compositeSteps = sar.compositeRunContext.compositeExecutor(sar.action)
+	} else {
+		// Re-evaluate environment here. For remote actions the environment
+		// need to be re-created for every stage (pre, main, post) as there
+		// might be required context changes (inputs/outputs) while the action
+		// stages are executed. (e.g. the output of another action is the
+		// input for this action during the main stage, but the env
+		// was already created during the pre stage)
+		env := evaluateCompositeInputAndEnv(ctx, sar.RunContext, sar)
+		sar.compositeRunContext.Env = env
 	}
 	return sar.compositeRunContext
 }

--- a/pkg/runner/testdata/uses-composite-with-inputs/push.yml
+++ b/pkg/runner/testdata/uses-composite-with-inputs/push.yml
@@ -5,10 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - id: set-output
+      run: echo "::set-output name=var::value"
     - name: use simple composite action
       uses: ./uses-composite-with-inputs/action
       with:
-        some: value
+        some: ${{ steps.set-output.outputs.var }}
     - name: use nested composite action
       uses: ./uses-composite-with-inputs/composite
       with:
@@ -21,7 +23,7 @@ jobs:
       id: remote-composite
       uses: nektos/act-test-actions/composite@main
       with:
-        input: value
+        input: ${{ steps.set-output.outputs.var }}
     - name: test remote composite output
       run: |
         echo "steps.remote-composite.outputs.output=${{ steps.remote-composite.outputs.output }}"


### PR DESCRIPTION
The env for remote composite actions need to be re-evaluated
at every stage (pre, main, post) as it is created during the
pre stage but there might be changes used as input to this
actions main stage (e.g. outputs for another action).

This is not required for local actions as their env is created
for the main stage (there is no pre stage).
Post stages do not need an updated env since they cannot recieve
inputs from other actions.
