### PR TITLE
feat: GITHUB_STATE and GITHUB_OUTPUT file commands

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,7 +50,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: go test -v -cover -coverprofile=coverage.txt -covermode=atomic ./...
+      - run: go test -v -cover -coverprofile=coverage.txt -covermode=atomic -timeout 15m ./...
       - name: Upload Codecov report
         uses: codecov/codecov-action@v3.1.1
         with:

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -97,7 +97,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		logger.Infof("\u2B50 Run %s %s", stage, stepString)
 
 		// Prepare and clean Runner File Commands
-		actPath := ActPath
+		actPath := rc.JobContainer.GetActPath()
 		outputFileCommand := path.Join("workflow", "outputcmd.txt")
 		stateFileCommand := path.Join("workflow", "statecmd.txt")
 		(*step.getEnv())["GITHUB_OUTPUT"] = path.Join(actPath, outputFileCommand)

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -3,9 +3,11 @@ package runner
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
 )
@@ -94,6 +96,20 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		}
 		logger.Infof("\u2B50 Run %s %s", stage, stepString)
 
+		// Prepare and clean Runner File Commands
+		actPath := ActPath
+		outputFileCommand := path.Join("workflow", "outputcmd.txt")
+		stateFileCommand := path.Join("workflow", "statecmd.txt")
+		(*step.getEnv())["GITHUB_OUTPUT"] = path.Join(actPath, outputFileCommand)
+		(*step.getEnv())["GITHUB_STATE"] = path.Join(actPath, stateFileCommand)
+		_ = rc.JobContainer.Copy(actPath, &container.FileEntry{
+			Name: outputFileCommand,
+			Mode: 0666,
+		}, &container.FileEntry{
+			Name: stateFileCommand,
+			Mode: 0666,
+		})(ctx)
+
 		err = executor(ctx)
 
 		if err == nil {
@@ -116,6 +132,27 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			}
 
 			logger.WithField("stepResult", rc.StepResults[rc.CurrentStep].Outcome).Errorf("  \u274C  Failure - %s %s", stage, stepString)
+		}
+		// Process Runner File Commands
+		orgerr := err
+		state := map[string]string{}
+		err = rc.JobContainer.UpdateFromEnv(path.Join(actPath, stateFileCommand), &state)(ctx)
+		if err != nil {
+			return err
+		}
+		for k, v := range state {
+			rc.saveState(ctx, map[string]string{"name": k}, v)
+		}
+		output := map[string]string{}
+		err = rc.JobContainer.UpdateFromEnv(path.Join(actPath, outputFileCommand), &output)(ctx)
+		if err != nil {
+			return err
+		}
+		for k, v := range output {
+			rc.setOutput(ctx, map[string]string{"name": k}, v)
+		}
+		if orgerr != nil {
+			return orgerr
 		}
 		return err
 	}

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestStepActionLocalTest(t *testing.T) {
 		},
 	}
 
-	salm.On("readAction", sal.Step, "/tmp/path/to/action", "", mock.Anything, mock.Anything).
+	salm.On("readAction", sal.Step, filepath.Clean("/tmp/path/to/action"), "", mock.Anything, mock.Anything).
 		Return(&model.Action{}, nil)
 
 	cm.On("UpdateFromImageEnv", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
@@ -78,7 +79,19 @@ func TestStepActionLocalTest(t *testing.T) {
 		return nil
 	})
 
-	salm.On("runAction", sal, "/tmp/path/to/action", (*remoteAction)(nil)).Return(func(ctx context.Context) error {
+	cm.On("Copy", "/var/run/act", mock.AnythingOfType("[]*container.FileEntry")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
+	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
+	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
+	salm.On("runAction", sal, filepath.Clean("/tmp/path/to/action"), (*remoteAction)(nil)).Return(func(ctx context.Context) error {
 		return nil
 	})
 
@@ -275,6 +288,18 @@ func TestStepActionLocalPost(t *testing.T) {
 					})
 				}
 				cm.On("Exec", suffixMatcher("pkg/runner/local/action/post.js"), sal.env, "", "").Return(func(ctx context.Context) error { return tt.err })
+
+				cm.On("Copy", "/var/run/act", mock.AnythingOfType("[]*container.FileEntry")).Return(func(ctx context.Context) error {
+					return nil
+				})
+
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+					return nil
+				})
+
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+					return nil
+				})
 			}
 
 			err := sal.post()(ctx)

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -172,6 +172,18 @@ func TestStepActionRemote(t *testing.T) {
 			}
 			if tt.mocks.run {
 				sarm.On("runAction", sar, suffixMatcher("act/remote-action@v1"), newRemoteAction(sar.Step.Uses)).Return(func(ctx context.Context) error { return tt.runError })
+
+				cm.On("Copy", "/var/run/act", mock.AnythingOfType("[]*container.FileEntry")).Return(func(ctx context.Context) error {
+					return nil
+				})
+
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+					return nil
+				})
+
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+					return nil
+				})
 			}
 
 			err := sar.pre()(ctx)
@@ -582,6 +594,18 @@ func TestStepActionRemotePost(t *testing.T) {
 			}
 			if tt.mocks.exec {
 				cm.On("Exec", []string{"node", "/var/run/act/actions/remote-action@v1/post.js"}, sar.env, "", "").Return(func(ctx context.Context) error { return tt.err })
+
+				cm.On("Copy", "/var/run/act", mock.AnythingOfType("[]*container.FileEntry")).Return(func(ctx context.Context) error {
+					return nil
+				})
+
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+					return nil
+				})
+
+				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+					return nil
+				})
 			}
 
 			err := sar.post()(ctx)

--- a/pkg/runner/step_docker_test.go
+++ b/pkg/runner/step_docker_test.go
@@ -86,6 +86,18 @@ func TestStepDockerMain(t *testing.T) {
 		return nil
 	})
 
+	cm.On("Copy", "/var/run/act", mock.AnythingOfType("[]*container.FileEntry")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
+	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
+	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
 	err := sd.main()(ctx)
 	assert.Nil(t, err)
 

--- a/pkg/runner/step_run_test.go
+++ b/pkg/runner/step_run_test.go
@@ -65,6 +65,18 @@ func TestStepRun(t *testing.T) {
 		return nil
 	})
 
+	cm.On("Copy", "/var/run/act", mock.AnythingOfType("[]*container.FileEntry")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
+	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
+	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
+		return nil
+	})
+
 	ctx := context.Background()
 
 	err := sr.main()(ctx)


### PR DESCRIPTION
Retargeted to master.

_One problem with the GITHUB_ENV logic, seem to be that it is never cleaned or recreated if deleted._

~~**DO NOT MERGE, before "feat: Host Environment" has been merged**~~

~~_I don't like merge conflicts due to actpath changes_~~

Resolves #1386, #1442