### PR TITLE
fix: ci is failing since 2022-10-17

### DIFF
--- a/pkg/runner/testdata/issue-104/main.yaml
+++ b/pkg/runner/testdata/issue-104/main.yaml
@@ -10,6 +10,6 @@ jobs:
     steps:
 
     - name: hello
-      uses: actions/hello-world-docker-action@master
+      uses: actions/hello-world-docker-action@v1
       with:
         who-to-greet: "World"

--- a/pkg/runner/testdata/local-action-via-composite-dockerfile/action.yml
+++ b/pkg/runner/testdata/local-action-via-composite-dockerfile/action.yml
@@ -32,7 +32,7 @@ runs:
     shell: bash
   - uses: ./localdockerimagetest_
   # Also test a remote docker action here
-  - uses: actions/hello-world-docker-action@main
+  - uses: actions/hello-world-docker-action@v1
     with:
       who-to-greet: 'Mona the Octocat'
   # Test if GITHUB_ACTION_PATH is set correctly after all steps

--- a/pkg/runner/testdata/remote-action-docker/push.yml
+++ b/pkg/runner/testdata/remote-action-docker/push.yml
@@ -5,6 +5,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/hello-world-docker-action@main
+    - uses: actions/hello-world-docker-action@v1
       with:
         who-to-greet: 'Mona the Octocat'


### PR DESCRIPTION
We shall not use unsafe versions of test actions, the new https://github.com/actions/hello-world-docker-action/releases/tag/v2 release uses GITHUB_OUTPUT env file command and the PR of this feature is not merged as of opening this hotfix.