### PR TITLE
refactor: allow error state on conditional executor

### DIFF
--- a/pkg/common/dryrun.go
+++ b/pkg/common/dryrun.go
@@ -9,14 +9,14 @@ type dryrunContextKey string
 const dryrunContextKeyVal = dryrunContextKey("dryrun")
 
 // Dryrun returns true if the current context is dryrun
-func Dryrun(ctx context.Context) bool {
+func Dryrun(ctx context.Context) (bool, error) {
 	val := ctx.Value(dryrunContextKeyVal)
 	if val != nil {
 		if dryrun, ok := val.(bool); ok {
-			return dryrun
+			return dryrun, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // WithDryrun adds a value to the context for dryrun

--- a/pkg/common/executor_test.go
+++ b/pkg/common/executor_test.go
@@ -45,8 +45,8 @@ func TestNewConditionalExecutor(t *testing.T) {
 	trueCount := 0
 	falseCount := 0
 
-	err := NewConditionalExecutor(func(ctx context.Context) bool {
-		return false
+	err := NewConditionalExecutor(func(ctx context.Context) (bool, error) {
+		return false, nil
 	}, func(ctx context.Context) error {
 		trueCount++
 		return nil
@@ -59,8 +59,8 @@ func TestNewConditionalExecutor(t *testing.T) {
 	assert.Equal(0, trueCount)
 	assert.Equal(1, falseCount)
 
-	err = NewConditionalExecutor(func(ctx context.Context) bool {
-		return true
+	err = NewConditionalExecutor(func(ctx context.Context) (bool, error) {
+		return true, nil
 	}, func(ctx context.Context) error {
 		trueCount++
 		return nil

--- a/pkg/container/docker_build.go
+++ b/pkg/container/docker_build.go
@@ -33,7 +33,11 @@ func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 		} else {
 			logger.Infof("%sdocker build -t %s %s", logPrefix, input.ImageTag, input.ContextDir)
 		}
-		if common.Dryrun(ctx) {
+		dryRun, err := common.Dryrun(ctx)
+		if err != nil {
+			return err
+		}
+		if dryRun {
 			return nil
 		}
 

--- a/pkg/container/docker_pull.go
+++ b/pkg/container/docker_pull.go
@@ -27,7 +27,11 @@ func NewDockerPullExecutor(input NewDockerPullExecutorInput) common.Executor {
 		logger := common.Logger(ctx)
 		logger.Debugf("%sdocker pull %v", logPrefix, input.Image)
 
-		if common.Dryrun(ctx) {
+		dryRun, err := common.Dryrun(ctx)
+		if err != nil {
+			return err
+		}
+		if dryRun {
 			return nil
 		}
 

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -181,7 +181,11 @@ func (cr *containerReference) CopyDir(destPath string, srcPath string, useGitIgn
 }
 
 func (cr *containerReference) GetContainerArchive(ctx context.Context, srcPath string) (io.ReadCloser, error) {
-	if common.Dryrun(ctx) {
+	dryRun, err := common.Dryrun(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if dryRun {
 		return nil, fmt.Errorf("DRYRUN is not supported in GetContainerArchive")
 	}
 	a, _, err := cr.cli.CopyFromContainer(ctx, cr.id, srcPath)

--- a/pkg/container/docker_volume.go
+++ b/pkg/container/docker_volume.go
@@ -36,7 +36,11 @@ func removeExecutor(volume string, force bool) common.Executor {
 		logger := common.Logger(ctx)
 		logger.Debugf("%sdocker volume rm %s", logPrefix, volume)
 
-		if common.Dryrun(ctx) {
+		dryRun, err := common.Dryrun(ctx)
+		if err != nil {
+			return err
+		}
+		if dryRun {
 			return nil
 		}
 

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -423,25 +423,25 @@ func getOsSafeRelativePath(s, prefix string) string {
 }
 
 func shouldRunPreStep(step actionStep) common.Conditional {
-	return func(ctx context.Context) bool {
+	return func(ctx context.Context) (bool, error) {
 		log := common.Logger(ctx)
 
 		if step.getActionModel() == nil {
 			log.Debugf("skip pre step for '%s': no action model available", step.getStepModel())
-			return false
+			return false, nil
 		}
 
-		return true
+		return true, nil
 	}
 }
 
 func hasPreStep(step actionStep) common.Conditional {
-	return func(ctx context.Context) bool {
+	return func(ctx context.Context) (bool, error) {
 		action := step.getActionModel()
 		return action.Runs.Using == model.ActionRunsUsingComposite ||
 			((action.Runs.Using == model.ActionRunsUsingNode12 ||
 				action.Runs.Using == model.ActionRunsUsingNode16) &&
-				action.Runs.Pre != "")
+				action.Runs.Pre != ""), nil
 	}
 }
 
@@ -501,37 +501,37 @@ func runPreStep(step actionStep) common.Executor {
 }
 
 func shouldRunPostStep(step actionStep) common.Conditional {
-	return func(ctx context.Context) bool {
+	return func(ctx context.Context) (bool, error) {
 		log := common.Logger(ctx)
 		stepResults := step.getRunContext().getStepsContext()
 		stepResult := stepResults[step.getStepModel().ID]
 
 		if stepResult == nil {
 			log.WithField("stepResult", model.StepStatusSkipped).Debugf("skipping post step for '%s'; step was not executed", step.getStepModel())
-			return false
+			return false, nil
 		}
 
 		if stepResult.Conclusion == model.StepStatusSkipped {
 			log.WithField("stepResult", model.StepStatusSkipped).Debugf("skipping post step for '%s'; main step was skipped", step.getStepModel())
-			return false
+			return false, nil
 		}
 
 		if step.getActionModel() == nil {
 			log.WithField("stepResult", model.StepStatusSkipped).Debugf("skipping post step for '%s': no action model available", step.getStepModel())
-			return false
+			return false, nil
 		}
 
-		return true
+		return true, nil
 	}
 }
 
 func hasPostStep(step actionStep) common.Conditional {
-	return func(ctx context.Context) bool {
+	return func(ctx context.Context) (bool, error) {
 		action := step.getActionModel()
 		return action.Runs.Using == model.ActionRunsUsingComposite ||
 			((action.Runs.Using == model.ActionRunsUsingNode12 ||
 				action.Runs.Using == model.ActionRunsUsingNode16) &&
-				action.Runs.Post != "")
+				action.Runs.Post != ""), nil
 	}
 }
 

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -82,10 +82,15 @@ func WithJobLogger(ctx context.Context, jobID string, jobName string, config *Co
 	logger.SetFormatter(formatter)
 	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logrus.GetLevel())
+
+	dryRun, err := common.Dryrun(ctx)
+	if err != nil {
+		logger.Fatal("Failed to configure logger", err)
+	}
 	rtn := logger.WithFields(logrus.Fields{
 		"job":    jobName,
 		"jobID":  jobID,
-		"dryrun": common.Dryrun(ctx),
+		"dryrun": dryRun,
 		"matrix": matrix,
 	}).WithContext(ctx)
 

--- a/pkg/runner/step_action_local.go
+++ b/pkg/runner/step_action_local.go
@@ -33,7 +33,11 @@ func (sal *stepActionLocal) pre() common.Executor {
 
 func (sal *stepActionLocal) main() common.Executor {
 	return runStepExecutor(sal, stepStageMain, func(ctx context.Context) error {
-		if common.Dryrun(ctx) {
+		dryRun, err := common.Dryrun(ctx)
+		if err != nil {
+			return err
+		}
+		if dryRun {
 			return nil
 		}
 


### PR DESCRIPTION
The conditional executor should be able to handle
an error during conditional evaluation.
Not being able to abort execution in case of an error is a severe limitation which complicates using code by opt-out of executor chaining.