### PR TITLE
Add user level Docker socket to common paths

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,6 +127,7 @@ func bugReport(ctx context.Context, version string) error {
 		"$HOME/.colima/docker.sock",
 		"$XDG_RUNTIME_DIR/docker.sock",
 		`\\.\pipe\docker_engine`,
+		"$HOME/.docker/run/docker.sock",
 	}
 
 	sprintf := func(key, val string) string {


### PR DESCRIPTION
In v4.13.0, Docker for Mac stopped providing `/var/run/docker.sock`, resulting in `act` failing on macOS. By default, it listens on `~/.docker/run/docker.sock` instead.

This was a breaking change in a non-major release and a rollback is planned:

https://github.com/docker/for-mac/issues/6529#issuecomment-1292135881

This PR adds the new socket path to the `bugReport` output. Hopefully seeing that the user-level socket is available will help users set `DOCKER_HOST` rather than filing a report.

In the long run, it sounds like Docker wants people to move away from hardcoding a Docker host, default or otherwise, in their clients. `docker context list` will return the user's configured endpoints.

See #1411