### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -48,9 +48,7 @@ func CopyDir(source string, dest string) (err error) {
 		return err
 	}
 
-	directory, _ := os.Open(source)
-
-	objects, err := directory.Readdir(-1)
+	objects, err := os.ReadDir(source)
 
 	for _, obj := range objects {
 		sourcefilepointer := source + "/" + obj.Name()

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -61,7 +60,7 @@ func FindGitRevision(ctx context.Context, file string) (shortSha string, sha str
 		return "", "", err
 	}
 
-	bts, err := ioutil.ReadFile(filepath.Join(gitDir, "HEAD"))
+	bts, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
 	if err != nil {
 		return "", "", err
 	}
@@ -70,7 +69,7 @@ func FindGitRevision(ctx context.Context, file string) (shortSha string, sha str
 	var refBuf []byte
 	if strings.HasPrefix(ref, "refs/") {
 		// load commitid ref
-		refBuf, err = ioutil.ReadFile(filepath.Join(gitDir, ref))
+		refBuf, err = os.ReadFile(filepath.Join(gitDir, ref))
 		if err != nil {
 			return "", "", err
 		}
@@ -151,7 +150,7 @@ func findGitPrettyRef(ctx context.Context, head, root, sub string) (string, erro
 			return nil
 		}
 		var bts []byte
-		if bts, err = ioutil.ReadFile(path); err != nil {
+		if bts, err = os.ReadFile(path); err != nil {
 			return err
 		}
 		var pointsTo = strings.TrimSpace(string(bts))

--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -3,7 +3,6 @@ package git
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +44,7 @@ func TestFindGitSlug(t *testing.T) {
 }
 
 func testDir(t *testing.T) string {
-	basedir, err := ioutil.TempDir("", "act-test")
+	basedir, err := os.MkdirTemp("", "act-test")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = os.RemoveAll(basedir) })
 	return basedir
@@ -53,7 +52,7 @@ func testDir(t *testing.T) string {
 
 func cleanGitHooks(dir string) error {
 	hooksDir := filepath.Join(dir, ".git", "hooks")
-	files, err := ioutil.ReadDir(hooksDir)
+	files, err := os.ReadDir(hooksDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/pkg/container/docker_images_test.go
+++ b/pkg/container/docker_images_test.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -45,7 +45,7 @@ func TestImageExistsLocally(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	defer readerDefault.Close()
-	_, err = ioutil.ReadAll(readerDefault)
+	_, err = io.ReadAll(readerDefault)
 	assert.Nil(t, err)
 
 	imageDefaultArchExists, err := ImageExistsLocally(ctx, "node:16-buster-slim", "linux/amd64")
@@ -58,7 +58,7 @@ func TestImageExistsLocally(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	defer readerArm64.Close()
-	_, err = ioutil.ReadAll(readerArm64)
+	_, err = io.ReadAll(readerArm64)
 	assert.Nil(t, err)
 
 	imageArm64Exists, err := ImageExistsLocally(ctx, "node:16-buster-slim", "linux/arm64")

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -769,7 +768,7 @@ func (cr *containerReference) waitForCommand(ctx context.Context, isTerminal boo
 func (cr *containerReference) copyDir(dstPath string, srcPath string, useGitIgnore bool) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
-		tarFile, err := ioutil.TempFile("", "act")
+		tarFile, err := os.CreateTemp("", "act")
 		if err != nil {
 			return err
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -3,7 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -111,7 +111,7 @@ func New(runnerConfig *Config) (Runner, error) {
 	runner.eventJSON = "{}"
 	if runnerConfig.EventPath != "" {
 		log.Debugf("Reading event.json from %s", runner.config.EventPath)
-		eventJSONBytes, err := ioutil.ReadFile(runner.config.EventPath)
+		eventJSONBytes, err := os.ReadFile(runner.config.EventPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir