### PR TITLE
feat: interpolate the step names

### DIFF
--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -70,6 +70,7 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		ExtraPath:    parent.ExtraPath,
 		Parent:       parent,
 	}
+	compositerc.ExprEval = compositerc.NewExpressionEvaluator(ctx)
 
 	return compositerc
 }

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -119,7 +119,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 
 func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, executor common.Executor) common.Executor {
 	return func(ctx context.Context) error {
-		ctx = withStepLogger(ctx, stepModel.ID, stepModel.String(), stage.String())
+		ctx = withStepLogger(ctx, stepModel.ID, rc.ExprEval.Interpolate(ctx, stepModel.String()), stage.String())
 
 		rawLogger := common.Logger(ctx).WithField("raw_output", true)
 		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {

--- a/pkg/runner/job_executor_test.go
+++ b/pkg/runner/job_executor_test.go
@@ -248,7 +248,17 @@ func TestNewJobExecutor(t *testing.T) {
 			sfm := &stepFactoryMock{}
 			rc := &RunContext{
 				JobContainer: &jobContainerMock{},
+				Run: &model.Run{
+					JobID: "test",
+					Workflow: &model.Workflow{
+						Jobs: map[string]*model.Job{
+							"test": {},
+						},
+					},
+				},
+				Config: &Config{},
 			}
+			rc.ExprEval = rc.NewExpressionEvaluator(ctx)
 			executorOrder := make([]string, 0)
 
 			jim.On("steps").Return(tt.steps)

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -88,7 +88,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			return nil
 		}
 
-		stepString := stepModel.String()
+		stepString := rc.ExprEval.Interpolate(ctx, stepModel.String())
 		if strings.Contains(stepString, "::add-mask::") {
 			stepString = "add-mask command"
 		}

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -262,6 +262,7 @@ func TestStepActionLocalPost(t *testing.T) {
 				Step:   tt.stepModel,
 				action: tt.actionModel,
 			}
+			sal.RunContext.ExprEval = sal.RunContext.NewExpressionEvaluator(ctx)
 
 			if tt.mocks.env {
 				cm.On("UpdateFromImageEnv", &sal.env).Return(func(ctx context.Context) error { return nil })

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -155,6 +155,7 @@ func TestStepActionRemote(t *testing.T) {
 				readAction: sarm.readAction,
 				runAction:  sarm.runAction,
 			}
+			sar.RunContext.ExprEval = sar.RunContext.NewExpressionEvaluator(ctx)
 
 			suffixMatcher := func(suffix string) interface{} {
 				return mock.MatchedBy(func(actionDir string) bool {
@@ -574,6 +575,7 @@ func TestStepActionRemotePost(t *testing.T) {
 				Step:   tt.stepModel,
 				action: tt.actionModel,
 			}
+			sar.RunContext.ExprEval = sar.RunContext.NewExpressionEvaluator(ctx)
 
 			if tt.mocks.env {
 				cm.On("UpdateFromImageEnv", &sar.env).Return(func(ctx context.Context) error { return nil })

--- a/pkg/runner/step_docker_test.go
+++ b/pkg/runner/step_docker_test.go
@@ -25,6 +25,8 @@ func TestStepDockerMain(t *testing.T) {
 		ContainerNewContainer = origContainerNewContainer
 	})()
 
+	ctx := context.Background()
+
 	sd := &stepDocker{
 		RunContext: &RunContext{
 			StepResults: map[string]*model.StepResult{},
@@ -51,8 +53,7 @@ func TestStepDockerMain(t *testing.T) {
 			WorkingDirectory: "workdir",
 		},
 	}
-
-	ctx := context.Background()
+	sd.RunContext.ExprEval = sd.RunContext.NewExpressionEvaluator(ctx)
 
 	cm.On("UpdateFromImageEnv", mock.AnythingOfType("*map[string]string")).Return(func(ctx context.Context) error {
 		return nil


### PR DESCRIPTION
Step names could contain expressions refering to event data.

Fixes #1353
