### PR TITLE
fix: keep path to event json file in composite actions

### DIFF
--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -69,6 +69,7 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		Masks:        parent.Masks,
 		ExtraPath:    parent.ExtraPath,
 		Parent:       parent,
+		EventJSON:    parent.EventJSON,
 	}
 
 	return compositerc

--- a/pkg/runner/testdata/pull-request/main.yaml
+++ b/pkg/runner/testdata/pull-request/main.yaml
@@ -8,19 +8,19 @@ jobs:
       # test refs from event.json
       - run: echo '${{github.ref}}'
       - run: echo '${{github.head_ref}}' | grep sample-head-ref
-      - run: echo '${{github.base_ref}}' | grep sample-base-
+      - run: echo '${{github.base_ref}}' | grep sample-base-ref
       # test main/composite context equality with data from event.json
       - run: |
-        runs:
-          using: composite
-          steps:
-          - run: |
-              echo WORKFLOW_GITHUB_CONTEXT="$WORKFLOW_GITHUB_CONTEXT"
-              echo COMPOSITE_GITHUB_CONTEXT="$COMPOSITE_GITHUB_CONTEXT"
-              [[ "$WORKFLOW_GITHUB_CONTEXT" = "$COMPOSITE_GITHUB_CONTEXT" ]]
-            env:
-              WORKFLOW_GITHUB_CONTEXT: ${{ tojson(tojson(github.event)) }}
-              COMPOSITE_GITHUB_CONTEXT: ${{ '${{tojson(github.event)}}' }}
-            shell: bash
+          runs:
+            using: composite
+            steps:
+            - run: |
+                echo WORKFLOW_GITHUB_CONTEXT="$WORKFLOW_GITHUB_CONTEXT"
+                echo COMPOSITE_GITHUB_CONTEXT="$COMPOSITE_GITHUB_CONTEXT"
+                [[ "$WORKFLOW_GITHUB_CONTEXT" = "$COMPOSITE_GITHUB_CONTEXT" ]]
+              env:
+                WORKFLOW_GITHUB_CONTEXT: ${{ tojson(tojson(github.event)) }}
+                COMPOSITE_GITHUB_CONTEXT: ${{ '${{tojson(github.event)}}' }}
+              shell: bash
         shell: cp {0} action.yml
       - uses: ./

--- a/pkg/runner/testdata/pull-request/main.yaml
+++ b/pkg/runner/testdata/pull-request/main.yaml
@@ -5,6 +5,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: echo '${{github.ref}}' 
+      # test refs from event.json
+      - run: echo '${{github.ref}}'
       - run: echo '${{github.head_ref}}' | grep sample-head-ref
-      - run: echo '${{github.base_ref}}' | grep sample-base-ref
+      - run: echo '${{github.base_ref}}' | grep sample-base-
+      # test main/composite context equality with data from event.json
+      - run: |
+        runs:
+          using: composite
+          steps:
+          - run: |
+              echo WORKFLOW_GITHUB_CONTEXT="$WORKFLOW_GITHUB_CONTEXT"
+              echo COMPOSITE_GITHUB_CONTEXT="$COMPOSITE_GITHUB_CONTEXT"
+              [[ "$WORKFLOW_GITHUB_CONTEXT" = "$COMPOSITE_GITHUB_CONTEXT" ]]
+            env:
+              WORKFLOW_GITHUB_CONTEXT: ${{ tojson(tojson(github.event)) }}
+              COMPOSITE_GITHUB_CONTEXT: ${{ '${{tojson(github.event)}}' }}
+            shell: bash
+        shell: cp {0} action.yml
+      - uses: ./


### PR DESCRIPTION
The event.json paths need to be copied over, since it the
GithubContext is recreated from the composite RC. And that
does read some value from the event file if available.

Fixes #1401
