### PR TITLE
feat: add support for writing to GITHUB_OUTPUT

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -187,6 +187,10 @@ func (rc *RunContext) startJobContainer() common.Executor {
 				Name: "workflow/paths.txt",
 				Mode: 0666,
 				Body: "",
+			}, &container.FileEntry{
+				Name: "workflow/outputs.txt",
+				Mode: 0666,
+				Body: "",
 			}),
 		)(ctx)
 	}
@@ -540,6 +544,7 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	env["CI"] = "true"
 	env["GITHUB_ENV"] = ActPath + "/workflow/envs.txt"
 	env["GITHUB_PATH"] = ActPath + "/workflow/paths.txt"
+	env["GITHUB_OUTPUT"] = ActPath + "/workflow/outputs.txt"
 	env["GITHUB_WORKFLOW"] = github.Workflow
 	env["GITHUB_RUN_ID"] = github.RunID
 	env["GITHUB_RUN_NUMBER"] = github.RunNumber

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -170,7 +170,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "issue-597", "push", "", platforms},
 		{workdir, "issue-598", "push", "", platforms},
 		{workdir, "if-env-act", "push", "", platforms},
-		{workdir, "env-and-path", "push", "", platforms},
+		{workdir, "environment-files", "push", "", platforms},
 		{workdir, "non-existent-action", "push", "Job 'nopanic' failed", platforms},
 		{workdir, "outputs", "push", "", platforms},
 		{workdir, "networking", "push", "", platforms},

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -117,6 +117,9 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 
 			logger.WithField("stepResult", rc.StepResults[rc.CurrentStep].Outcome).Errorf("  \u274C  Failure - %s %s", stage, stepString)
 		}
+
+		updateOutputsFromEnvFile(ctx, step)
+
 		return err
 	}
 }
@@ -172,6 +175,18 @@ func mergeEnv(ctx context.Context, step step) {
 	}
 
 	rc.withGithubEnv(ctx, step.getGithubContext(ctx), *env)
+}
+
+func updateOutputsFromEnvFile(ctx context.Context, step step) error {
+	rc := step.getRunContext()
+	stepResult := rc.StepResults[rc.CurrentStep]
+
+	err := rc.JobContainer.UpdateFromEnv((*step.getEnv())["GITHUB_OUTPUT"], &stepResult.Outputs)(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func isStepEnabled(ctx context.Context, expr string, step step, stage stepStage) (bool, error) {

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -184,6 +184,7 @@ func TestSetupEnv(t *testing.T) {
 		"GITHUB_GRAPHQL_URL":       "https:///api/graphql",
 		"GITHUB_HEAD_REF":          "",
 		"GITHUB_JOB":               "",
+		"GITHUB_OUTPUT":            "/var/run/act/workflow/outputs.txt",
 		"GITHUB_PATH":              "/var/run/act/workflow/paths.txt",
 		"GITHUB_RETENTION_DAYS":    "0",
 		"GITHUB_RUN_ID":            "runId",

--- a/pkg/runner/testdata/environment-files/push.yaml
+++ b/pkg/runner/testdata/environment-files/push.yaml
@@ -1,4 +1,4 @@
-name: env-and-path
+name: environment-files
 on: push
 
 jobs:
@@ -58,8 +58,8 @@ jobs:
       - name: "Write multiline env to $GITHUB_ENV"
         run: |
           echo 'KEY2<<EOF' >> $GITHUB_ENV
-                echo value2 >> $GITHUB_ENV
-                echo 'EOF' >> $GITHUB_ENV
+          echo value2 >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: "Check multiline line env"
         run: |
           if [[ "${KEY2}" != "value2" ]]; then
@@ -69,11 +69,33 @@ jobs:
       - name: "Write multiline env with UUID to $GITHUB_ENV"
         run: |
           echo 'KEY3<<ghadelimiter_b8273c6d-d535-419a-a010-b0aaac240e36' >> $GITHUB_ENV
-                echo value3 >> $GITHUB_ENV
-                echo 'ghadelimiter_b8273c6d-d535-419a-a010-b0aaac240e36' >> $GITHUB_ENV
+          echo value3 >> $GITHUB_ENV
+          echo 'ghadelimiter_b8273c6d-d535-419a-a010-b0aaac240e36' >> $GITHUB_ENV
       - name: "Check multiline env with UUID to $GITHUB_ENV"
         run: |
           if [[ "${KEY3}" != "value3" ]]; then
             echo "${KEY3} doesn't == 'value3'"
+            exit 1
+          fi
+      - name: "Whrite single line output to $GITHUB_OUTPUT"
+        id: write-single-output
+        run: |
+          echo "KEY=value" >> $GITHUB_OUTPUT
+      - name: "Check single line output"
+        run: |
+          if [[ "${{ steps.write-single-output.outputs.KEY }}" != "value" ]]; then
+            echo "${{ steps.write-single-output.outputs.KEY }} doesn't == 'value'"
+            exit 1
+          fi
+      - name: "Write multiline output to $GITHUB_OUTPUT"
+        id: write-multi-output
+        run: |
+          echo 'KEY2<<EOF' >> $GITHUB_OUTPUT
+          echo value2 >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+      - name: "Check multiline output"
+        run: |
+          if [[ "${{ steps.write-multi-output.outputs.KEY2 }}" != "value2" ]]; then
+            echo "${{ steps.write-multi-output.outputs.KEY2 }} doesn't == 'value2'"
             exit 1
           fi


### PR DESCRIPTION
As of the beginning of October, [the `::set-output` command is being deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in favor of using [Environment Files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files) to avoid exposing data by untrusted loggers.

Use of these commands will begin failing as of 31st May 2023.  

This PR attempts to enable `act` to support the `$GITHUB_OUTPUT` environment file.  I'm a new contributor, so I'm not 100% sure if this covers all of the expected edge cases, so please let me know if there's a better way to accomplish this (e.g. maybe by adding an additional exectutor wrapper or something).