### PR TITLE
ENH: enable capability from command line to bind host volumes to containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ It will save that information to `~/.actrc`, please refer to [Configuration](#co
       --use-gitignore                               Controls whether paths specified in .gitignore should be copied into container (default true)
       --userns string                               user namespace to use
   -v, --verbose                                     verbose output
+      --volume stringArray                          volume to bind to container
   -w, --watch                                       watch the contents of the local repo and run when files change
   -W, --workflows string                            path to workflow file(s) (default "./.github/workflows/")
 ```

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -17,6 +17,7 @@ type Input struct {
 	bindWorkdir                        bool
 	secrets                            []string
 	envs                               []string
+	volumes                            []string
 	platforms                          []string
 	dryrun                             bool
 	forcePull                          bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.Flags().StringVar(&input.remoteName, "remote-name", "origin", "git remote name that will be used to retrieve url of git repo")
 	rootCmd.Flags().StringArrayVarP(&input.secrets, "secret", "s", []string{}, "secret to make available to actions with optional value (e.g. -s mysecret=foo or -s mysecret)")
 	rootCmd.Flags().StringArrayVarP(&input.envs, "env", "", []string{}, "env to make available to actions with optional value (e.g. --env myenv=foo or --env myenv)")
+	rootCmd.Flags().StringArrayVarP(&input.volumes, "volume", "", []string{}, "volume to bind to container")
 	rootCmd.Flags().StringArrayVarP(&input.platforms, "platform", "P", []string{}, "custom image to use per platform (e.g. -P ubuntu-18.04=nektos/act-environments-ubuntu:18.04)")
 	rootCmd.Flags().BoolVarP(&input.reuseContainers, "reuse", "r", false, "don't remove container(s) on successfully completed workflow(s) to maintain state between runs")
 	rootCmd.Flags().BoolVarP(&input.bindWorkdir, "bind", "b", false, "bind working directory to container, rather than copy")
@@ -441,6 +442,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			GitHubInstance:                     input.githubInstance,
 			ContainerCapAdd:                    input.containerCapAdd,
 			ContainerCapDrop:                   input.containerCapDrop,
+			Volumes:                            input.volumes,
 			AutoRemove:                         input.autoRemove,
 			ArtifactServerPath:                 input.artifactServerPath,
 			ArtifactServerPort:                 input.artifactServerPort,

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -109,8 +109,6 @@ func supportsContainerImagePlatform(ctx context.Context, cli client.APIClient) b
 }
 
 func (cr *containerReference) Create(capAdd []string, capDrop []string) common.Executor {
-	// cr.input.Mounts["pkgs"] = "/home/vagrant/miniconda/pkgs:/root/miniconda3/pkgs"
-	cr.input.Binds = append(cr.input.Binds, "/home/vagrant/miniconda/pkgs:/pkgs")
 	return common.
 		NewInfoExecutor("%sdocker create image=%s platform=%s entrypoint=%+q cmd=%+q", logPrefix, cr.input.Image, cr.input.Platform, cr.input.Entrypoint, cr.input.Cmd).
 		Then(

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -109,6 +109,8 @@ func supportsContainerImagePlatform(ctx context.Context, cli client.APIClient) b
 }
 
 func (cr *containerReference) Create(capAdd []string, capDrop []string) common.Executor {
+	// cr.input.Mounts["pkgs"] = "/home/vagrant/miniconda/pkgs:/root/miniconda3/pkgs"
+	cr.input.Binds = append(cr.input.Binds, "/home/vagrant/miniconda/pkgs:/pkgs")
 	return common.
 		NewInfoExecutor("%sdocker create image=%s platform=%s entrypoint=%+q cmd=%+q", logPrefix, cr.input.Image, cr.input.Platform, cr.input.Entrypoint, cr.input.Cmd).
 		Then(

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -124,9 +124,7 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 		mounts[name] = ext.ToContainerPath(rc.Config.Workdir)
 	}
 
-	for _, vol := range rc.Config.Volumes {
-		binds = append(binds, vol)
-	}
+	binds = append(binds, rc.Config.Volumes...)
 
 	return binds, mounts
 }

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -114,6 +114,10 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 		mounts[name] = rc.Config.ContainerWorkdir()
 	}
 
+	for _, vol := range rc.Config.Volumes {
+		binds = append(binds, vol)
+	}
+
 	return binds, mounts
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -48,6 +48,7 @@ type Config struct {
 	GitHubInstance                     string            // GitHub instance to use, default "github.com"
 	ContainerCapAdd                    []string          // list of kernel capabilities to add to the containers
 	ContainerCapDrop                   []string          // list of kernel capabilities to remove from the containers
+	Volumes                            []string          // list of volumes / binds to add to containers
 	AutoRemove                         bool              // controls if the container is automatically removed upon workflow completion
 	ArtifactServerPath                 string            // the path where the artifact server stores uploads
 	ArtifactServerPort                 string            // the port the artifact server binds to


### PR DESCRIPTION
See also question I raised on SO https://stackoverflow.com/questions/74516196/nektos-act-docker-containers-how-to-mount-a-volume

There are quite significant overheads with **conda** and act.  Sharing the downloaded packages between host and containers by binding host directory of downloaded packages with **act** containers significantly improves situation.

This is the first time I've coded in **go**.  I'm not really aware of things like PEP8/**black**/**flake8** and **pytest** that are standard in **python**