### PR TITLE
feat: `--container-options`

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -30,6 +30,7 @@ type Input struct {
 	usernsMode                         string
 	containerArchitecture              string
 	containerDaemonSocket              string
+	containerOptions                   string
 	noWorkflowRecurse                  bool
 	useGitIgnore                       bool
 	githubInstance                     string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().StringVarP(&input.envfile, "env-file", "", ".env", "environment file to read and use as env in the containers")
 	rootCmd.PersistentFlags().StringVarP(&input.containerArchitecture, "container-architecture", "", "", "Architecture which should be used to run containers, e.g.: linux/amd64. If not specified, will use host default architecture. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.")
 	rootCmd.PersistentFlags().StringVarP(&input.containerDaemonSocket, "container-daemon-socket", "", "/var/run/docker.sock", "Path to Docker daemon socket which will be mounted to containers")
+	rootCmd.PersistentFlags().StringVarP(&input.containerOptions, "container-options", "", "", "Path to Docker daemon socket which will be mounted to containers")
 	rootCmd.PersistentFlags().StringVarP(&input.githubInstance, "github-instance", "", "github.com", "GitHub instance to use. Don't use this if you are not using GitHub Enterprise Server.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerPath, "artifact-server-path", "", "", "Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified the artifact server will not start.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerPort, "artifact-server-port", "", "34567", "Defines the port where the artifact server listens (will only bind to localhost).")
@@ -437,6 +438,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			UsernsMode:                         input.usernsMode,
 			ContainerArchitecture:              input.containerArchitecture,
 			ContainerDaemonSocket:              input.containerDaemonSocket,
+			ContainerOptions:                   input.containerOptions,
 			UseGitIgnore:                       input.useGitIgnore,
 			GitHubInstance:                     input.githubInstance,
 			ContainerCapAdd:                    input.containerCapAdd,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().StringVarP(&input.envfile, "env-file", "", ".env", "environment file to read and use as env in the containers")
 	rootCmd.PersistentFlags().StringVarP(&input.containerArchitecture, "container-architecture", "", "", "Architecture which should be used to run containers, e.g.: linux/amd64. If not specified, will use host default architecture. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.")
 	rootCmd.PersistentFlags().StringVarP(&input.containerDaemonSocket, "container-daemon-socket", "", "/var/run/docker.sock", "Path to Docker daemon socket which will be mounted to containers")
-	rootCmd.PersistentFlags().StringVarP(&input.containerOptions, "container-options", "", "", "Path to Docker daemon socket which will be mounted to containers")
+	rootCmd.PersistentFlags().StringVarP(&input.containerOptions, "container-options", "", "", "Custom docker container options for the job container without an options property in the job definition")
 	rootCmd.PersistentFlags().StringVarP(&input.githubInstance, "github-instance", "", "github.com", "GitHub instance to use. Don't use this if you are not using GitHub Enterprise Server.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerPath, "artifact-server-path", "", "", "Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified the artifact server will not start.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerPort, "artifact-server-port", "", "34567", "Defines the port where the artifact server listens (will only bind to localhost).")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -415,6 +415,22 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 				input.platforms = readArgsFile(cfgLocations[0], true)
 			}
 		}
+		deprecationWarning := "--%s is deprecated and will be removed soon, please switch to cli: `--container-options \"%[2]s\"` or `.actrc`: `--container-options %[2]s`."
+		if input.privileged {
+			log.Warnf(deprecationWarning, "privileged", "--privileged")
+		}
+		if len(input.usernsMode) > 0 {
+			log.Warnf(deprecationWarning, "userns", fmt.Sprintf("--userns=%s", input.usernsMode))
+		}
+		if len(input.containerArchitecture) > 0 {
+			log.Warnf(deprecationWarning, "container-architecture", fmt.Sprintf("--platform=%s", input.containerArchitecture))
+		}
+		if len(input.containerCapAdd) > 0 {
+			log.Warnf(deprecationWarning, "container-cap-add", fmt.Sprintf("--cap-add=%s", input.containerCapAdd))
+		}
+		if len(input.containerCapDrop) > 0 {
+			log.Warnf(deprecationWarning, "container-cap-drop", fmt.Sprintf("--cap-drop=%s", input.containerCapDrop))
+		}
 
 		// run the plan
 		config := &runner.Config{

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -411,8 +411,10 @@ func (cr *containerReference) mergeContainerConfigs(ctx context.Context, config 
 
 	logger.Debugf("Custom container.HostConfig from options ==> %+v", containerConfig.HostConfig)
 
-	binds := append(hostConfig.Binds, containerConfig.HostConfig.Binds...)
-	mounts := append(hostConfig.Mounts, containerConfig.HostConfig.Mounts...)
+	hostConfig.Binds = append(hostConfig.Binds, containerConfig.HostConfig.Binds...)
+	hostConfig.Mounts = append(hostConfig.Mounts, containerConfig.HostConfig.Mounts...)
+	binds := hostConfig.Binds
+	mounts := hostConfig.Mounts
 	err = mergo.Merge(hostConfig, containerConfig.HostConfig, mergo.WithOverride)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Cannot merge container.HostConfig options: '%s': '%w'", input.Options, err)

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -411,10 +411,14 @@ func (cr *containerReference) mergeContainerConfigs(ctx context.Context, config 
 
 	logger.Debugf("Custom container.HostConfig from options ==> %+v", containerConfig.HostConfig)
 
+	binds := append(hostConfig.Binds, containerConfig.HostConfig.Binds...)
+	mounts := append(hostConfig.Mounts, containerConfig.HostConfig.Mounts...)
 	err = mergo.Merge(hostConfig, containerConfig.HostConfig, mergo.WithOverride)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Cannot merge container.HostConfig options: '%s': '%w'", input.Options, err)
 	}
+	hostConfig.Binds = binds
+	hostConfig.Mounts = mounts
 	logger.Debugf("Merged container.HostConfig ==> %+v", hostConfig)
 
 	return config, hostConfig, nil

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -366,6 +366,7 @@ func newStepContainer(ctx context.Context, step step, image string, cmd []string
 		Privileged:  rc.Config.Privileged,
 		UsernsMode:  rc.Config.UsernsMode,
 		Platform:    rc.Config.ContainerArchitecture,
+		Options:     rc.Config.ContainerOptions,
 	})
 	return stepContainer
 }

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -409,7 +409,7 @@ func (rc *RunContext) options(ctx context.Context) string {
 	job := rc.Run.Job()
 	c := job.Container()
 	if c == nil {
-		return ""
+		return rc.Config.ContainerOptions
 	}
 
 	return c.Options

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -40,6 +40,7 @@ type Config struct {
 	UsernsMode                         string            // user namespace to use
 	ContainerArchitecture              string            // Desired OS/architecture platform for running containers
 	ContainerDaemonSocket              string            // Path to Docker daemon socket
+	ContainerOptions                   string            // Options for the job container
 	UseGitIgnore                       bool              // controls if paths in .gitignore should not be copied into container, default true
 	GitHubInstance                     string            // GitHub instance to use, default "github.com"
 	ContainerCapAdd                    []string          // list of kernel capabilities to add to the containers


### PR DESCRIPTION
This deprecates the following options
- `--privileged`
- `--container-cap-add`
- `--container-cap-drop`
- `--container-architecture`
- `--userns`

If we decide to get rid of the options, we might want to add a warning before removal.