### PR TITLE
refactor: move autoremove into the jobexecutor

### DIFF
--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -128,6 +128,24 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			return postExecutor(ctx)
 		}).
 		Finally(info.interpolateOutputs()).
+		Finally(func(ctx context.Context) error {
+			logger := common.Logger(ctx)
+			if rc.Config.AutoRemove {
+				var cancel context.CancelFunc
+				if ctx.Err() == context.Canceled {
+					ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+					defer cancel()
+				}
+
+				logger.Infof("Cleaning up container for job %s", rc.JobName)
+
+				if err := rc.stopJobContainer()(ctx); err != nil {
+					logger.Errorf("Error while cleaning container: %v", err)
+				}
+			}
+
+			return nil
+		}).
 		Finally(info.closeContainer()))
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -76,8 +76,6 @@ func New(runnerConfig *Config) (Runner, error) {
 }
 
 // NewPlanExecutor ...
-//
-//nolint:gocyclo
 func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 	maxJobNameLen := 0
 


### PR DESCRIPTION
breaking: docker container are removed after job exit

In github-act-runner I directly instantiate the RunContext, but I also want to make use of autoremove due to randomized job container name.