### PR TITLE
Fix shellcommand error on alpine sh shell

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -495,7 +495,7 @@ func (s *Step) ShellCommand() string {
 	case "python":
 		shellCommand = "python {0}"
 	case "sh":
-		shellCommand = "sh -e -c {0}"
+		shellCommand = "sh -e {0}"
 	case "cmd":
 		shellCommand = "%ComSpec% /D /E:ON /V:OFF /S /C \"CALL \"{0}\"\""
 	case "powershell":


### PR DESCRIPTION
When running on sh on alpine image, the following error occurs:

```text
[test.yml/test] 🚀  Start image=docker:20.10
[test.yml/test]   🐳  docker pull image=docker:20.10 platform=linux/amd64 username= forcePull=false
[test.yml/test]   🐳  docker create image=docker:20.10 platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[test.yml/test]   🐳  docker run image=docker:20.10 platform=linux/amd64 entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[test.yml/test] ⭐ Run Main ls
[test.yml/test]   🐳  docker exec cmd=[sh -e -c /var/run/act/workflow/0.sh] user= workdir=..
| 0.sh: applet not found
[test.yml/test]   ❌  Failure - Main ls
[test.yml/test] exitcode '127': command not found, please refer to https://github.com/nektos/act/issues/107 for more information
[test.yml/test] 🏁  Job failed
Error: Job 'test' failed
```

It seems to be working without any problem on debian. I suspect that it's due to the difference in interpreting a fille passed onto `-c` option by both the OS.

Since we are passing in a `.sh` file in this case, I think it's safe to drop that option