### PR TITLE
Pass `LANG=C.UTF-8` to environment

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -225,6 +225,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 		envList = append(envList, fmt.Sprintf("%s=%s", "RUNNER_OS", "Linux"))
 		envList = append(envList, fmt.Sprintf("%s=%s", "RUNNER_ARCH", container.RunnerArch(ctx)))
 		envList = append(envList, fmt.Sprintf("%s=%s", "RUNNER_TEMP", "/tmp"))
+		envList = append(envList, fmt.Sprintf("%s=%s", "LANG", "C.UTF-8")) // Use same locale as GitHub Actions
 
 		ext := container.LinuxContainerEnvironmentExtensions{}
 		binds, mounts := rc.GetBindsAndMounts()
@@ -667,7 +668,6 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	env["GITHUB_RETENTION_DAYS"] = github.RetentionDays
 	env["RUNNER_PERFLOG"] = github.RunnerPerflog
 	env["RUNNER_TRACKING_ID"] = github.RunnerTrackingID
-	env["LANG"] = "C.UTF-8" // Use same locale as GitHub Actions
 	if rc.Config.GitHubInstance != "github.com" {
 		env["GITHUB_SERVER_URL"] = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
 		env["GITHUB_API_URL"] = fmt.Sprintf("https://%s/api/v3", rc.Config.GitHubInstance)

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -667,6 +667,7 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	env["GITHUB_RETENTION_DAYS"] = github.RetentionDays
 	env["RUNNER_PERFLOG"] = github.RunnerPerflog
 	env["RUNNER_TRACKING_ID"] = github.RunnerTrackingID
+	env["LANG"] = "C.UTF-8" // Use same locale as GitHub Actions
 	if rc.Config.GitHubInstance != "github.com" {
 		env["GITHUB_SERVER_URL"] = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
 		env["GITHUB_API_URL"] = fmt.Sprintf("https://%s/api/v3", rc.Config.GitHubInstance)

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -196,7 +196,6 @@ func TestSetupEnv(t *testing.T) {
 		"RC_KEY":                   "rcvalue",
 		"RUNNER_PERFLOG":           "/dev/null",
 		"RUNNER_TRACKING_ID":       "",
-		"LANG":                     "C.UTF-8",
 	}, env)
 
 	cm.AssertExpectations(t)

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -196,6 +196,7 @@ func TestSetupEnv(t *testing.T) {
 		"RC_KEY":                   "rcvalue",
 		"RUNNER_PERFLOG":           "/dev/null",
 		"RUNNER_TRACKING_ID":       "",
+		"LANG":                     "C.UTF-8",
 	}, env)
 
 	cm.AssertExpectations(t)


### PR DESCRIPTION
In order to use `act` with workflows where any tools, like build tools, depends on the locale being `UTF-8`, one must pass via command line via the `--env` option.

However the Github Actions runner already passes `LANG=C.UTF-8` by default, which makes the need to explicitly pass this variable via command line un-intuitive.

The PR here aims to make `act` pass that environment variable by default.

Fixes: #1308
Possibly #639