### PR TITLE
Remove red color from logging messages

### DIFF
--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	// nocolor = 0
-	red     = 31
 	green   = 32
 	yellow  = 33
 	blue    = 34
@@ -33,7 +32,7 @@ var mux sync.Mutex
 func init() {
 	nextColor = 0
 	colors = []int{
-		blue, yellow, green, magenta, red, gray, cyan,
+		blue, yellow, green, magenta, gray, cyan,
 	}
 }
 


### PR DESCRIPTION
This PR removes the color `red` from logging messages as red is typically associated with error messages, and can result in confusion with lots of output from many containers. 

Avoiding red text removes the ambiguity of red text that is not an error message.