### PR TITLE
fix: tail (not absolute) as entrypoint of job container

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -240,7 +240,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 
 		rc.JobContainer = container.NewContainer(&container.NewContainerInput{
 			Cmd:         nil,
-			Entrypoint:  []string{"/usr/bin/tail", "-f", "/dev/null"},
+			Entrypoint:  []string{"tail", "-f", "/dev/null"},
 			WorkingDir:  ext.ToContainerPath(rc.Config.Workdir),
 			Image:       image,
 			Username:    username,


### PR DESCRIPTION
Reason actions/runner doesn't use /usr/bin/tail in the entrypoint, it uses tail without /usr/bin/ prefix.

Fixes https://github.com/nektos/act/issues/1449