### PR TITLE
fix: align runner.os / runner.arch to known values

### DIFF
--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -410,10 +410,32 @@ func (*HostEnvironment) JoinPathVariable(paths ...string) string {
 	return strings.Join(paths, string(filepath.ListSeparator))
 }
 
+func goArchToActionArch(arch string) string {
+	archMapper := map[string]string{
+		"x86_64":  "X64",
+		"386":     "x86",
+		"aarch64": "arm64",
+	}
+	if arch, ok := archMapper[arch]; ok {
+		return arch
+	}
+	return arch
+}
+
+func goOsToActionOs(os string) string {
+	osMapper := map[string]string{
+		"darwin":  "macOS",
+	}
+	if os, ok := osMapper[os]; ok {
+		return os
+	}
+	return os
+}
+
 func (e *HostEnvironment) GetRunnerContext(ctx context.Context) map[string]interface{} {
 	return map[string]interface{}{
-		"os":         runtime.GOOS,
-		"arch":       runtime.GOARCH,
+		"os":         goOsToActionOs(runtime.GOOS),
+		"arch":       goArchToActionArch(runtime.GOARCH),
 		"temp":       e.TmpDir,
 		"tool_cache": e.ToolCache,
 	}

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -424,7 +424,7 @@ func goArchToActionArch(arch string) string {
 
 func goOsToActionOs(os string) string {
 	osMapper := map[string]string{
-		"darwin":  "macOS",
+		"darwin": "macOS",
 	}
 	if os, ok := osMapper[os]; ok {
 		return os

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -173,7 +173,7 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 		rc.cleanUpJobContainer = rc.JobContainer.Remove()
 		for k, v := range rc.JobContainer.GetRunnerContext(ctx) {
 			if v, ok := v.(string); ok {
-				rc.Env[fmt.Sprintf("RUNNER_%s", strings.ToUpper(k)] = v
+				rc.Env[fmt.Sprintf("RUNNER_%s", strings.ToUpper(k))] = v
 			}
 		}
 		for _, env := range os.Environ() {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -171,7 +171,7 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 			StdOut: logWriter,
 		}
 		rc.cleanUpJobContainer = rc.JobContainer.Remove()
-		for k, v := rc.JobContainer.GetRunnerContext(ctx) {
+		for k, v := range rc.JobContainer.GetRunnerContext(ctx) {
 			if v, ok := v.(string); ok {
 				rc.Env[fmt.Sprintf("RUNNER_%s", strings.ToUpper(k)] = v
 			}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -171,10 +171,11 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 			StdOut: logWriter,
 		}
 		rc.cleanUpJobContainer = rc.JobContainer.Remove()
-		rc.Env["RUNNER_TOOL_CACHE"] = toolCache
-		rc.Env["RUNNER_OS"] = runtime.GOOS
-		rc.Env["RUNNER_ARCH"] = runtime.GOARCH
-		rc.Env["RUNNER_TEMP"] = runnerTmp
+		for k, v := rc.JobContainer.GetRunnerContext(ctx) {
+			if v, ok := v.(string); ok {
+				rc.Env[fmt.Sprintf("RUNNER_%s", strings.ToUpper(k)] = v
+			}
+		}
 		for _, env := range os.Environ() {
 			i := strings.Index(env, "=")
 			if i > 0 {


### PR DESCRIPTION
This change now also unifies RUNNER_OS with runner.os, I suggest to do the same thing for the github context.

_This is a breaking change for github-act-runner, but we should align to actions/runner where possible_

Fixes #1509