### PR TITLE
build(deps): chocolatey - update alpine to 3.17

### DIFF
--- a/.github/actions/choco/Dockerfile
+++ b/.github/actions/choco/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG CHOCOVERSION=1.1.0
 


### PR DESCRIPTION
I updated two PR's and the snapshot fails, because the latest mono-dev fails to find it's dependency in the old alpine base image

This package is not found in v3.16 or older
https://pkgs.alpinelinux.org/packages?name=libgdiplus-dev&branch=v3.17&repo=&arch=&maintainer=