### PR TITLE
Feature/allow worktrees

### DIFF
--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -82,10 +82,17 @@ func TestFindGitRemoteURL(t *testing.T) {
 	assert.NoError(err)
 
 	remoteURL := "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/my-repo-name"
-	err = gitCmd("config", "-f", fmt.Sprintf("%s/.git/config", basedir), "--add", "remote.origin.url", remoteURL)
+	err = gitCmd("-C", basedir, "remote", "add", "origin", remoteURL)
 	assert.NoError(err)
 
 	u, err := findGitRemoteURL(context.Background(), basedir, "origin")
+	assert.NoError(err)
+	assert.Equal(remoteURL, u)
+
+	remoteURL = "git@github.com/AwesomeOwner/MyAwesomeRepo.git"
+	err = gitCmd("-C", basedir, "remote", "add", "upstream", remoteURL)
+	assert.NoError(err)
+	u, err = findGitRemoteURL(context.Background(), basedir, "upstream")
 	assert.NoError(err)
 	assert.Equal(remoteURL, u)
 }


### PR DESCRIPTION
Handle cases where the user uses worktrees and not a regular git clone.

This PR uses some work previously done by @lvlrt and my contribution to make it work in any cases regardless of the type of worktrees.

this PR handle 2 cases:
1. when the git dir is a regular git clone: so the worktree contains a file `.git` that contains the path to the git data inside the regular git clone. usually under: `/path/to/repo/.git/worktrees/worktre_name`
2. When the git dir is a barre clone (so no actual files, only git data) and so the worktree contains a file `.git` that contains the path to the git data directly. usually under: `/path/to/repo/commondir`

This work fine, I tried it using both worktree types (actually both git clone types) and this code was pushed using a worktree and I managed to run `act` on it.

closes #657 
Uses commits from #829 