### PR TITLE
feat: add support for building docker actions with private registries

### DIFF
--- a/pkg/container/docker_auth.go
+++ b/pkg/container/docker_auth.go
@@ -38,3 +38,24 @@ func LoadDockerAuthConfig(ctx context.Context, image string) (types.AuthConfig, 
 
 	return types.AuthConfig(authConfig), nil
 }
+
+func LoadDockerAuthConfigs(ctx context.Context) map[string]types.AuthConfig {
+	logger := common.Logger(ctx)
+	config, err := config.Load(config.Dir())
+	if err != nil {
+		logger.Warnf("Could not load docker config: %v", err)
+		return nil
+	}
+
+	if !config.ContainsAuth() {
+		config.CredentialsStore = credentials.DetectDefaultStore(config.CredentialsStore)
+	}
+
+	creds, _ := config.GetAllCredentials()
+	authConfigs := make(map[string]types.AuthConfig, len(creds))
+	for k, v := range creds {
+		authConfigs[k] = types.AuthConfig(v)
+	}
+
+	return authConfigs
+}

--- a/pkg/container/docker_build.go
+++ b/pkg/container/docker_build.go
@@ -41,9 +41,10 @@ func NewDockerBuildExecutor(input NewDockerBuildExecutorInput) common.Executor {
 
 		tags := []string{input.ImageTag}
 		options := types.ImageBuildOptions{
-			Tags:     tags,
-			Remove:   true,
-			Platform: input.Platform,
+			Tags:        tags,
+			Remove:      true,
+			Platform:    input.Platform,
+			AuthConfigs: LoadDockerAuthConfigs(ctx),
 		}
 		var buildContext io.ReadCloser
 		if input.Container != nil {


### PR DESCRIPTION
This commit adds a new `LoadDockerAuthConfigs` function, which loads all registry auths that are configured on the host and sends them with the build command to the docker daemon.

This is needed in case act builds a docker action and the images referenced in that docker action are located on private registries or otherwise require authentication (e.g. to get a higher rate limit).

The code is adapted from how the docker cli works: https://github.com/docker/cli/blob/257ff41304bf121bdf1acdf00a1c7a896ed038d1/cli/command/image/build.go#L323-L332