### PR TITLE
Fixed auto-generated platform configuration with Micro size image

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -533,7 +533,7 @@ func defaultImageSurvey(actrc string) error {
 	case "Medium":
 		option = "-P ubuntu-latest=catthehacker/ubuntu:act-latest\n-P ubuntu-22.04=catthehacker/ubuntu:act-22.04\n-P ubuntu-20.04=catthehacker/ubuntu:act-20.04\n-P ubuntu-18.04=catthehacker/ubuntu:act-18.04\n"
 	case "Micro":
-		option = "-P ubuntu-latest=node:16-buster-slim\n-P -P ubuntu-22.04=node:16-bullseye-slim\n ubuntu-20.04=node:16-buster-slim\n-P ubuntu-18.04=node:16-buster-slim\n"
+		option = "-P ubuntu-latest=node:16-buster-slim\n-P ubuntu-22.04=node:16-bullseye-slim\n-P ubuntu-20.04=node:16-buster-slim\n-P ubuntu-18.04=node:16-buster-slim\n"
 	}
 
 	f, err := os.Create(actrc)


### PR DESCRIPTION
Hi, thank you for such an awesome tool 👍 

When I first execute `act` command with `Micro` size image, `~/.actrc` was generated as below. Because `-P -P` is the wrong configuration, so I fixed it.

```
-P ubuntu-latest=node:16-buster-slim
-P -P ubuntu-22.04=node:16-bullseye-slim
 ubuntu-20.04=node:16-buster-slim
-P ubuntu-18.04=node:16-buster-slim
```

I use the latest version of `act`.

```sh
$ act --version
act version 0.2.40
```

Could you review please? Thanks!