### PR TITLE
chore: add Winget installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ choco install act-cli
 scoop install act
 ```
 
+### [Winget](https://learn.microsoft.com/en-us/windows/package-manager/) (Windows)
+
+[![Winget package](https://repology.org/badge/version-for-repo/winget/act-run-github-actions.svg)](https://repology.org/project/act-run-github-actions/versions)
+
+```shell
+winget install nektos.act
+```
+
 ### [AUR](https://aur.archlinux.org/packages/act/) (Linux)
 
 [![aur-shield](https://img.shields.io/aur/version/act)](https://aur.archlinux.org/packages/act/)


### PR DESCRIPTION
- Closes #1489
- https://github.com/nektos/act/issues/1146

The Winget package is currently outdated, and there is a blocking issue for Winget Releaser: https://github.com/vedantmgoyal2009/winget-releaser/issues/82. Will PR the releaser workflow once that is resolved.