### PR TITLE
fix: don't use os.Environ to override env

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -186,9 +186,11 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 			}
 		}
 		for _, env := range os.Environ() {
-			i := strings.Index(env, "=")
-			if i > 0 {
-				rc.Env[env[0:i]] = env[i+1:]
+			if k, v, ok := strings.Cut(env, "="); ok {
+				// don't override
+				if _, ok := rc.Env[k]; !ok {
+					rc.Env[k] = v
+				}
 			}
 		}
 


### PR DESCRIPTION
If the env has been set in the yaml file, we shouldn't override it with os env.