### PR TITLE
chore: use new form of octal

### DIFF
--- a/cmd/notices.go
+++ b/cmd/notices.go
@@ -126,7 +126,7 @@ func loadNoticesEtag() string {
 
 func saveNoticesEtag(etag string) {
 	p := etagPath()
-	err := os.WriteFile(p, []byte(strings.TrimSuffix(etag, "\n")), 0600)
+	err := os.WriteFile(p, []byte(strings.TrimSuffix(etag, "\n")), 0o600)
 	if err != nil {
 		log.Debugf("Unable to save etag to %s: %e", p, err)
 	}
@@ -143,7 +143,7 @@ func etagPath() string {
 		}
 	}
 	dir := filepath.Join(xdgCache, "act")
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
 		log.Fatal(err)
 	}
 	return filepath.Join(dir, ".notices.etag")

--- a/pkg/artifacts/server.go
+++ b/pkg/artifacts/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/julienschmidt/httprouter"
+
 	"github.com/nektos/act/pkg/common"
 )
 
@@ -65,14 +66,14 @@ func (fwfs readWriteFSImpl) OpenWritable(name string) (WritableFile, error) {
 	if err := os.MkdirAll(filepath.Dir(name), os.ModePerm); err != nil {
 		return nil, err
 	}
-	return os.OpenFile(name, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+	return os.OpenFile(name, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
 }
 
 func (fwfs readWriteFSImpl) OpenAppendable(name string) (WritableFile, error) {
 	if err := os.MkdirAll(filepath.Dir(name), os.ModePerm); err != nil {
 		return nil, err
 	}
-	file, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0644)
+	file, err := os.OpenFile(name, os.O_CREATE|os.O_RDWR, 0o644)
 
 	if err != nil {
 		return nil, err

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/nektos/act/pkg/common"
-
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -20,6 +18,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/mattn/go-isatty"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/nektos/act/pkg/common"
 )
 
 var (
@@ -260,7 +260,7 @@ func CloneIfRequired(ctx context.Context, refName plumbing.ReferenceName, input 
 			return nil, err
 		}
 
-		if err = os.Chmod(input.Dir, 0755); err != nil {
+		if err = os.Chmod(input.Dir, 0o755); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/common/git/git_test.go
+++ b/pkg/common/git/git_test.go
@@ -167,7 +167,7 @@ func TestGitFindRef(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			dir := filepath.Join(basedir, name)
-			require.NoError(t, os.MkdirAll(dir, 0755))
+			require.NoError(t, os.MkdirAll(dir, 0o755))
 			require.NoError(t, gitCmd("-C", dir, "init", "--initial-branch=master"))
 			require.NoError(t, cleanGitHooks(dir))
 			tt.Prepare(t, dir)

--- a/pkg/container/file_collector.go
+++ b/pkg/container/file_collector.go
@@ -65,7 +65,7 @@ type copyCollector struct {
 
 func (cc *copyCollector) WriteFile(fpath string, fi fs.FileInfo, linkName string, f io.Reader) error {
 	fdestpath := filepath.Join(cc.DstDir, fpath)
-	if err := os.MkdirAll(filepath.Dir(fdestpath), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fdestpath), 0o777); err != nil {
 		return err
 	}
 	if f == nil {

--- a/pkg/container/file_collector_test.go
+++ b/pkg/container/file_collector_test.go
@@ -76,7 +76,7 @@ func (mfs *memoryFs) Readlink(path string) (string, error) {
 
 func TestIgnoredTrackedfile(t *testing.T) {
 	fs := memfs.New()
-	_ = fs.MkdirAll("mygitrepo/.git", 0777)
+	_ = fs.MkdirAll("mygitrepo/.git", 0o777)
 	dotgit, _ := fs.Chroot("mygitrepo/.git")
 	worktree, _ := fs.Chroot("mygitrepo")
 	repo, _ := git.Init(filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault()), worktree)

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -15,14 +16,13 @@ import (
 	"strings"
 	"time"
 
-	"errors"
-
 	"github.com/go-git/go-billy/v5/helper/polyfill"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+	"golang.org/x/term"
+
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/lookpath"
-	"golang.org/x/term"
 )
 
 type HostEnvironment struct {
@@ -50,7 +50,7 @@ func (e *HostEnvironment) Close() common.Executor {
 func (e *HostEnvironment) Copy(destPath string, files ...*FileEntry) common.Executor {
 	return func(ctx context.Context) error {
 		for _, f := range files {
-			if err := os.MkdirAll(filepath.Dir(filepath.Join(destPath, f.Name)), 0777); err != nil {
+			if err := os.MkdirAll(filepath.Dir(filepath.Join(destPath, f.Name)), 0o777); err != nil {
 				return err
 			}
 			if err := os.WriteFile(filepath.Join(destPath, f.Name), []byte(f.Body), fs.FileMode(f.Mode)); err != nil {

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/kballard/go-shellquote"
+
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
@@ -30,6 +31,7 @@ type actionStep interface {
 type readAction func(ctx context.Context, step *model.Step, actionDir string, actionPath string, readFile actionYamlReader, writeFile fileWriter) (*model.Action, error)
 
 type actionYamlReader func(filename string) (io.Reader, io.Closer, error)
+
 type fileWriter func(filename string, data []byte, perm fs.FileMode) error
 
 type runAction func(step actionStep, actionDir string, remoteAction *remoteAction) common.Executor
@@ -61,7 +63,7 @@ func readActionImpl(ctx context.Context, step *model.Step, actionDir string, act
 					if b, err = trampoline.ReadFile("res/trampoline.js"); err != nil {
 						return nil, err
 					}
-					err2 := writeFile(filepath.Join(actionDir, actionPath, "trampoline.js"), b, 0400)
+					err2 := writeFile(filepath.Join(actionDir, actionPath, "trampoline.js"), b, 0o400)
 					if err2 != nil {
 						return nil, err2
 					}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -156,15 +156,15 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 		_, _ = rand.Read(randBytes)
 		miscpath := filepath.Join(cacheDir, hex.EncodeToString(randBytes))
 		actPath := filepath.Join(miscpath, "act")
-		if err := os.MkdirAll(actPath, 0777); err != nil {
+		if err := os.MkdirAll(actPath, 0o777); err != nil {
 			return err
 		}
 		path := filepath.Join(miscpath, "hostexecutor")
-		if err := os.MkdirAll(path, 0777); err != nil {
+		if err := os.MkdirAll(path, 0o777); err != nil {
 			return err
 		}
 		runnerTmp := filepath.Join(miscpath, "tmp")
-		if err := os.MkdirAll(runnerTmp, 0777); err != nil {
+		if err := os.MkdirAll(runnerTmp, 0o777); err != nil {
 			return err
 		}
 		toolCache := filepath.Join(cacheDir, "tool_cache")
@@ -195,11 +195,11 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 		return common.NewPipelineExecutor(
 			rc.JobContainer.Copy(rc.JobContainer.GetActPath()+"/", &container.FileEntry{
 				Name: "workflow/event.json",
-				Mode: 0644,
+				Mode: 0o644,
 				Body: rc.EventJSON,
 			}, &container.FileEntry{
 				Name: "workflow/envs.txt",
-				Mode: 0666,
+				Mode: 0o666,
 				Body: "",
 			}),
 		)(ctx)
@@ -278,11 +278,11 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.JobContainer.Start(false),
 			rc.JobContainer.Copy(rc.JobContainer.GetActPath()+"/", &container.FileEntry{
 				Name: "workflow/event.json",
-				Mode: 0644,
+				Mode: 0o644,
 				Body: rc.EventJSON,
 			}, &container.FileEntry{
 				Name: "workflow/envs.txt",
-				Mode: 0666,
+				Mode: 0o666,
 				Body: "",
 			}),
 		)(ctx)

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -111,16 +111,16 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		(*step.getEnv())["GITHUB_ENV"] = path.Join(actPath, envFileCommand)
 		_ = rc.JobContainer.Copy(actPath, &container.FileEntry{
 			Name: outputFileCommand,
-			Mode: 0666,
+			Mode: 0o666,
 		}, &container.FileEntry{
 			Name: stateFileCommand,
-			Mode: 0666,
+			Mode: 0o666,
 		}, &container.FileEntry{
 			Name: pathFileCommand,
-			Mode: 0666,
+			Mode: 0o666,
 		}, &container.FileEntry{
 			Name: envFileCommand,
-			Mode: 0666,
+			Mode: 0o666,
 		})(ctx)
 
 		err = executor(ctx)

--- a/pkg/runner/step_run.go
+++ b/pkg/runner/step_run.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kballard/go-shellquote"
+
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
@@ -72,7 +73,7 @@ func (sr *stepRun) setupShellCommandExecutor() common.Executor {
 		rc := sr.getRunContext()
 		return rc.JobContainer.Copy(rc.JobContainer.GetActPath(), &container.FileEntry{
 			Name: scriptName,
-			Mode: 0755,
+			Mode: 0o755,
 			Body: script,
 		})(ctx)
 	}

--- a/pkg/runner/step_run_test.go
+++ b/pkg/runner/step_run_test.go
@@ -6,17 +6,18 @@ import (
 	"io"
 	"testing"
 
-	"github.com/nektos/act/pkg/container"
-	"github.com/nektos/act/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/nektos/act/pkg/container"
+	"github.com/nektos/act/pkg/model"
 )
 
 func TestStepRun(t *testing.T) {
 	cm := &containerMock{}
 	fileEntry := &container.FileEntry{
 		Name: "workflow/1.sh",
-		Mode: 0755,
+		Mode: 0o755,
 		Body: "\ncmd\n",
 	}
 


### PR DESCRIPTION
Go 1.13 added the `0o` form for octal numbers, like `0o644`, it's more readable than `0644`.

---

Just a suggestion, please feel free to close this PR if you think it's unnecessary.