### PR TITLE
chore: Remove obsolete Container.UpdateFromPath

### DIFF
--- a/pkg/container/container_types.go
+++ b/pkg/container/container_types.go
@@ -46,7 +46,6 @@ type Container interface {
 	Exec(command []string, env map[string]string, user, workdir string) common.Executor
 	UpdateFromEnv(srcPath string, env *map[string]string) common.Executor
 	UpdateFromImageEnv(env *map[string]string) common.Executor
-	UpdateFromPath(env *map[string]string) common.Executor
 	Remove() common.Executor
 	Close() common.Executor
 	ReplaceLogWriter(io.Writer, io.Writer) (io.Writer, io.Writer)

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -4,7 +4,6 @@ package container
 
 import (
 	"archive/tar"
-	"bufio"
 	"bytes"
 	"context"
 	"errors"

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -344,32 +344,6 @@ func (e *HostEnvironment) UpdateFromEnv(srcPath string, env *map[string]string) 
 	return parseEnvFile(e, srcPath, env)
 }
 
-func (e *HostEnvironment) UpdateFromPath(env *map[string]string) common.Executor {
-	localEnv := *env
-	return func(ctx context.Context) error {
-		pathTar, err := e.GetContainerArchive(ctx, localEnv["GITHUB_PATH"])
-		if err != nil {
-			return err
-		}
-		defer pathTar.Close()
-
-		reader := tar.NewReader(pathTar)
-		_, err = reader.Next()
-		if err != nil && err != io.EOF {
-			return err
-		}
-		s := bufio.NewScanner(reader)
-		for s.Scan() {
-			line := s.Text()
-			pathSep := string(filepath.ListSeparator)
-			localEnv[e.GetPathVariableName()] = fmt.Sprintf("%s%s%s", line, pathSep, localEnv[e.GetPathVariableName()])
-		}
-
-		env = &localEnv
-		return nil
-	}
-}
-
 func (e *HostEnvironment) Remove() common.Executor {
 	return func(ctx context.Context) error {
 		if e.CleanUp != nil {

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"archive/tar"
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"

--- a/pkg/runner/container_mock_test.go
+++ b/pkg/runner/container_mock_test.go
@@ -50,11 +50,6 @@ func (cm *containerMock) UpdateFromImageEnv(env *map[string]string) common.Execu
 	return args.Get(0).(func(context.Context) error)
 }
 
-func (cm *containerMock) UpdateFromPath(env *map[string]string) common.Executor {
-	args := cm.Called(env)
-	return args.Get(0).(func(context.Context) error)
-}
-
 func (cm *containerMock) Copy(destPath string, files ...*container.FileEntry) common.Executor {
 	args := cm.Called(destPath, files)
 	return args.Get(0).(func(context.Context) error)


### PR DESCRIPTION
I have removed any references to this function in previous PR's, this just removes the unused code.