### PR TITLE
Add example command for collecting artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ act pull_request
 # Run a specific job:
 act -j test
 
+# Collect artifacts to the /tmp/artifacts folder:
+act --artifact-server-path /tmp/artifacts
+
 # Run a job in a specific workflow (useful if you have duplicate job names)
 act -j lint -W .github/workflows/checks.yml
 


### PR DESCRIPTION
As a beginner with act, it took me some time to find this comment and figure out how to access the artifacts https://github.com/nektos/act/issues/329#issuecomment-1187246629.

I had read `--help` but it was not clear that an artifact server was included and thought I had to provide an URI to an external service.

So I suggest adding this small example -- alternatively add a note to the wiki