### PR TITLE
fix: correct ref and ref_name

### DIFF
--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -103,7 +103,7 @@ func (ghc *GithubContext) SetRef(ctx context.Context, defaultBranch string, repo
 	case "deployment", "deployment_status":
 		ghc.Ref = asString(nestedMapLookup(ghc.Event, "deployment", "ref"))
 	case "release":
-		ghc.Ref = asString(nestedMapLookup(ghc.Event, "release", "tag_name"))
+		ghc.Ref = fmt.Sprintf("refs/tags/%s", asString(nestedMapLookup(ghc.Event, "release", "tag_name")))
 	case "push", "create", "workflow_dispatch":
 		ghc.Ref = asString(ghc.Event["ref"])
 	default:
@@ -183,6 +183,9 @@ func (ghc *GithubContext) SetRefTypeAndName() {
 	} else if strings.HasPrefix(ghc.Ref, "refs/heads/") {
 		refType = "branch"
 		refName = ghc.Ref[len("refs/heads/"):]
+	} else if strings.HasPrefix(ghc.Ref, "refs/pull/") {
+		refType = ""
+		refName = ghc.Ref[len("refs/pull/"):]
 	}
 
 	if ghc.RefType == "" {

--- a/pkg/model/github_context_test.go
+++ b/pkg/model/github_context_test.go
@@ -29,18 +29,21 @@ func TestSetRef(t *testing.T) {
 		eventName string
 		event     map[string]interface{}
 		ref       string
+		refName   string
 	}{
 		{
 			eventName: "pull_request_target",
 			event:     map[string]interface{}{},
 			ref:       "refs/heads/master",
+			refName:   "master",
 		},
 		{
 			eventName: "pull_request",
 			event: map[string]interface{}{
 				"number": 1234.,
 			},
-			ref: "refs/pull/1234/merge",
+			ref:     "refs/pull/1234/merge",
+			refName: "1234/merge",
 		},
 		{
 			eventName: "deployment",
@@ -49,7 +52,8 @@ func TestSetRef(t *testing.T) {
 					"ref": "refs/heads/somebranch",
 				},
 			},
-			ref: "refs/heads/somebranch",
+			ref:     "refs/heads/somebranch",
+			refName: "somebranch",
 		},
 		{
 			eventName: "release",
@@ -58,14 +62,16 @@ func TestSetRef(t *testing.T) {
 					"tag_name": "v1.0.0",
 				},
 			},
-			ref: "v1.0.0",
+			ref:     "refs/tags/v1.0.0",
+			refName: "v1.0.0",
 		},
 		{
 			eventName: "push",
 			event: map[string]interface{}{
 				"ref": "refs/heads/somebranch",
 			},
-			ref: "refs/heads/somebranch",
+			ref:     "refs/heads/somebranch",
+			refName: "somebranch",
 		},
 		{
 			eventName: "unknown",
@@ -74,12 +80,14 @@ func TestSetRef(t *testing.T) {
 					"default_branch": "main",
 				},
 			},
-			ref: "refs/heads/main",
+			ref:     "refs/heads/main",
+			refName: "main",
 		},
 		{
 			eventName: "no-event",
 			event:     map[string]interface{}{},
 			ref:       "refs/heads/master",
+			refName:   "master",
 		},
 	}
 
@@ -92,8 +100,10 @@ func TestSetRef(t *testing.T) {
 			}
 
 			ghc.SetRef(context.Background(), "main", "/some/dir")
+			ghc.SetRefTypeAndName()
 
 			assert.Equal(t, table.ref, ghc.Ref)
+			assert.Equal(t, table.refName, ghc.RefName)
 		})
 	}
 

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -413,7 +413,7 @@ func TestGetGithubContextRef(t *testing.T) {
 		{event: "pull_request_target", json: `{"pull_request":{"base":{"ref": "main"}}}`, ref: "refs/heads/main"},
 		{event: "deployment", json: `{"deployment": {"ref": "tag-name"}}`, ref: "tag-name"},
 		{event: "deployment_status", json: `{"deployment": {"ref": "tag-name"}}`, ref: "tag-name"},
-		{event: "release", json: `{"release": {"tag_name": "tag-name"}}`, ref: "tag-name"},
+		{event: "release", json: `{"release": {"tag_name": "tag-name"}}`, ref: "refs/tags/tag-name"},
 	}
 
 	for _, data := range table {


### PR DESCRIPTION
The ref in the GitHub context is always full qualified (e.g. refs/heads/branch, refs/tags/v1).
The ref_name is the ref with the stripped prefix.

In case of pull_requests, this is the merge commit ref (e.g. refs/pull/123/merge -> 123/merge).
