### PR TITLE
Support for docker steps in host environment

### DIFF
--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -355,8 +355,6 @@ func (e *HostEnvironment) Remove() common.Executor {
 func (e *HostEnvironment) ToContainerPath(path string) string {
 	if bp, err := filepath.Rel(e.Workdir, path); err != nil {
 		return filepath.Join(e.Path, bp)
-	} else if filepath.Clean(e.Workdir) == filepath.Clean(path) {
-		return e.Path
 	}
 	return path
 }

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -355,6 +355,8 @@ func (e *HostEnvironment) Remove() common.Executor {
 func (e *HostEnvironment) ToContainerPath(path string) string {
 	if bp, err := filepath.Rel(e.Workdir, path); err != nil {
 		return filepath.Join(e.Path, bp)
+	} else if filepath.Clean(e.Workdir) == filepath.Clean(path) {
+		return e.Path
 	}
 	return path
 }

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -356,7 +356,10 @@ func newStepContainer(ctx context.Context, step step, image string, cmd []string
 	envList = append(envList, fmt.Sprintf("%s=%s", "RUNNER_TEMP", "/tmp"))
 
 	binds, mounts := rc.GetBindsAndMounts()
-
+	networkMode := fmt.Sprintf("container:%s", rc.jobContainerName())
+	if rc.IsHostEnv(ctx) {
+		networkMode = "default"
+	}
 	stepContainer := container.NewContainer(&container.NewContainerInput{
 		Cmd:         cmd,
 		Entrypoint:  entrypoint,
@@ -367,7 +370,7 @@ func newStepContainer(ctx context.Context, step step, image string, cmd []string
 		Name:        createContainerName(rc.jobContainerName(), stepModel.ID),
 		Env:         envList,
 		Mounts:      mounts,
-		NetworkMode: fmt.Sprintf("container:%s", rc.jobContainerName()),
+		NetworkMode: networkMode,
 		Binds:       binds,
 		Stdout:      logWriter,
 		Stderr:      logWriter,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -384,12 +384,16 @@ func (rc *RunContext) interpolateOutputs() common.Executor {
 
 func (rc *RunContext) startContainer() common.Executor {
 	return func(ctx context.Context) error {
-		image := rc.platformImage(ctx)
-		if strings.EqualFold(image, "-self-hosted") {
+		if rc.IsHostEnv(ctx) {
 			return rc.startHostEnvironment()(ctx)
 		}
 		return rc.startJobContainer()(ctx)
 	}
+}
+
+func (rc *RunContext) IsHostEnv(ctx context.Context) bool {
+	image := rc.platformImage(ctx)
+	return strings.EqualFold(image, "-self-hosted")
 }
 
 func (rc *RunContext) stopContainer() common.Executor {


### PR DESCRIPTION
Network mode in host environment is set to container network earlier. But the container network is not present. This PR uses default as network mode in case host environment is enabled.

Also, setting working directory for container step to same as one specified in the input params.