### PR TITLE
feat: specify matrix on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,48 @@ don't want to run locally. E.g. a step that posts a Slack message or bumps a ver
     ...
 ```
 
+# Specifying Matrix
+
+You can selectively choose a subset of matrix options to run by specifying the `--matrix` flag. It will only run those matrix configurations
+which include your specified values.
+
+Example workflow file
+
+```yaml
+name: matrix-with-user-inclusions
+on: push
+
+jobs:
+  build:
+    name: Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${NODE_VERSION}
+        env:
+          NODE_VERSION: ${{ matrix.node }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+        node: [4, 6, 8, 10]
+        exclude:
+          - os: macos-latest
+            node: 4
+        include:
+          - os: ubuntu-16.04
+            node: 10
+```
+
+In this case if we only wanted to run this workflow for node 8, then we would run `act push --matrix node:8`  
+This will trigger the workflow to use the following matrix configurations only:
+- `os: ubuntu-18.04, node 8`
+- `os: macos-latest, node 8`
+
+Similarly if we just wanted to trigger this workflow for node 10 and macos-latest then we would run `act push --matrix node:10 --matrix os:macos-latest`.  
+This will trigger the workflow to use the following matrix configurations only:
+- `os: macos-latest, node 10`
+
+Note that using the `--matrix` flag you can't add new values (for e.g. running the above workflow for node 20). It will simply ignore it. Moreover, the `exclude` field in the workflow will take precedance over the `--matrix` flag (for e.g. running the above workflow for only macos-latest and node 4 will result in no matrix configuration being used) 
+
 # Events
 
 Every [GitHub event](https://developer.github.com/v3/activity/events/types) is accompanied by a payload. You can provide these events in JSON format with the `--eventpath` to simulate specific GitHub events kicking off an action. For example:

--- a/README.md
+++ b/README.md
@@ -389,16 +389,18 @@ jobs:
             node: 10
 ```
 
-In this case if we only wanted to run this workflow for node 8, then we would run `act push --matrix node:8`  
+In this case if we only wanted to run this workflow for node 8, then we would run `act push --matrix node:8`
+
 This will trigger the workflow to use the following matrix configurations only:
 - `os: ubuntu-18.04, node 8`
 - `os: macos-latest, node 8`
 
-Similarly if we just wanted to trigger this workflow for node 10 and macos-latest then we would run `act push --matrix node:10 --matrix os:macos-latest`.  
+Similarly if we just wanted to trigger this workflow for node 10 and macos-latest then we would run `act push --matrix node:10 --matrix os:macos-latest`.
+
 This will trigger the workflow to use the following matrix configurations only:
 - `os: macos-latest, node 10`
 
-Note that using the `--matrix` flag you can't add new values (for e.g. running the above workflow for node 20). It will simply ignore it. Moreover, the `exclude` field in the workflow will take precedance over the `--matrix` flag (for e.g. running the above workflow for only macos-latest and node 4 will result in no matrix configuration being used) 
+Note that using the `--matrix` flag you can't add new values (for e.g. running the above workflow for node 20). It will simply ignore it. Moreover, the `exclude` field in the workflow will take precedance over the `--matrix` flag (for e.g. running the above workflow for only macos-latest and node 4 will result in no matrix configuration being used)
 
 # Events
 

--- a/README.md
+++ b/README.md
@@ -358,50 +358,6 @@ don't want to run locally. E.g. a step that posts a Slack message or bumps a ver
     ...
 ```
 
-# Specifying Matrix
-
-You can selectively choose a subset of matrix options to run by specifying the `--matrix` flag. It will only run those matrix configurations
-which include your specified values.
-
-Example workflow file
-
-```yaml
-name: matrix-with-user-inclusions
-on: push
-
-jobs:
-  build:
-    name: Matrix
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ${NODE_VERSION}
-        env:
-          NODE_VERSION: ${{ matrix.node }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, macos-latest]
-        node: [4, 6, 8, 10]
-        exclude:
-          - os: macos-latest
-            node: 4
-        include:
-          - os: ubuntu-16.04
-            node: 10
-```
-
-In this case if we only wanted to run this workflow for node 8, then we would run `act push --matrix node:8`
-
-This will trigger the workflow to use the following matrix configurations only:
-- `os: ubuntu-18.04, node 8`
-- `os: macos-latest, node 8`
-
-Similarly if we just wanted to trigger this workflow for node 10 and macos-latest then we would run `act push --matrix node:10 --matrix os:macos-latest`.
-
-This will trigger the workflow to use the following matrix configurations only:
-- `os: macos-latest, node 10`
-
-Note that using the `--matrix` flag you can't add new values (for e.g. running the above workflow for node 20). It will simply ignore it. Moreover, the `exclude` field in the workflow will take precedance over the `--matrix` flag (for e.g. running the above workflow for only macos-latest and node 4 will result in no matrix configuration being used)
-
 # Events
 
 Every [GitHub event](https://developer.github.com/v3/activity/events/types) is accompanied by a payload. You can provide these events in JSON format with the `--eventpath` to simulate specific GitHub events kicking off an action. For example:

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -47,6 +47,7 @@ type Input struct {
 	remoteName                         string
 	replaceGheActionWithGithubCom      []string
 	replaceGheActionTokenWithGithubCom string
+	matrix                             []string
 }
 
 func (i *Input) resolve(path string) string {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -186,6 +186,7 @@ func (j *TestJobFileInfo) runTest(ctx context.Context, t *testing.T, cfg *Config
 		Inputs:                cfg.Inputs,
 		GitHubInstance:        "github.com",
 		ContainerArchitecture: cfg.ContainerArchitecture,
+		Matrix:                cfg.Matrix,
 	}
 
 	runner, err := New(runnerConfig)
@@ -583,4 +584,31 @@ func TestRunEventPullRequest(t *testing.T) {
 	}
 
 	tjfi.runTest(context.Background(), t, &Config{EventPath: filepath.Join(workdir, workflowPath, "event.json")})
+}
+
+func TestRunMatrixWithUserDefinedInclusions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	workflowPath := "matrix-with-user-inclusions"
+
+	tjfi := TestJobFileInfo{
+		workdir:      workdir,
+		workflowPath: workflowPath,
+		eventName:    "push",
+		errorMessage: "",
+		platforms:    platforms,
+	}
+
+	matrix := map[string]map[string]bool{
+		"node": {
+			"8":   true,
+			"8.x": true,
+		},
+		"os": {
+			"ubuntu-18.04": true,
+		},
+	}
+
+	tjfi.runTest(context.Background(), t, &Config{Matrix: matrix})
 }

--- a/pkg/runner/testdata/matrix-with-user-inclusions/push.yml
+++ b/pkg/runner/testdata/matrix-with-user-inclusions/push.yml
@@ -1,0 +1,34 @@
+name: matrix-with-user-inclusions
+on: push
+
+jobs:
+  build:
+    name: PHP ${{ matrix.os }} ${{ matrix.node}}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo ${NODE_VERSION} | grep 8
+          echo ${OS_VERSION} | grep ubuntu-18.04
+        env:
+          NODE_VERSION: ${{ matrix.node }}
+          OS_VERSION: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+        node: [4, 6, 8, 10]
+        exclude:
+          - os: macos-latest
+            node: 4
+        include:
+          - os: ubuntu-16.04
+            node: 10
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [8.x, 10.x, 12.x, 13.x]
+    steps:
+      - run: echo ${NODE_VERSION} | grep 8.x
+        env:
+          NODE_VERSION: ${{ matrix.node }}


### PR DESCRIPTION
Fixes #114 

You can selectively choose a subset of matrix options to run by specifying the `--matrix` flag. It will only run those matrix configurations which include your specified values.

Example workflow file

```yaml
name: matrix-with-user-inclusions
on: push

jobs:
  build:
    name: Matrix
    runs-on: ubuntu-latest
    steps:
      - run: echo ${NODE_VERSION}
        env:
          NODE_VERSION: ${{ matrix.node }}
    strategy:
      matrix:
        os: [ubuntu-18.04, macos-latest]
        node: [4, 6, 8, 10]
        exclude:
          - os: macos-latest
            node: 4
        include:
          - os: ubuntu-16.04
            node: 10
```

In this case if we only wanted to run this workflow for node 8, then we would run `act push --matrix node:8`  
This will trigger the workflow to use the following matrix configurations only:
- `os: ubuntu-18.04, node 8`
- `os: macos-latest, node 8`

Similarly if we just wanted to trigger this workflow for node 10 and macos-latest then we would run `act push --matrix node:10 --matrix os:macos-latest`.  
This will trigger the workflow to use the following matrix configurations only:
- `os: macos-latest, node 10`

Note that using the `--matrix` flag you can't add new values (for e.g. running the above workflow for node 20). It will simply ignore it. Moreover, the `exclude` field in the workflow will take precedance over the `--matrix` flag (for e.g. running the above workflow for only macos-latest and node 4 will result in no matrix configuration being used) 