### PR TITLE
fix: add `server_url` attribute to github context

### DIFF
--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -37,6 +37,8 @@ type GithubContext struct {
 	RunnerPerflog    string                 `json:"runner_perflog"`
 	RunnerTrackingID string                 `json:"runner_tracking_id"`
 	ServerURL        string                 `json:"server_url "`
+	APIURL           string                 `json:"api_url"`
+	GraphQLURL       string                 `json:"graphql_url"`
 }
 
 func asString(v interface{}) string {

--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -36,6 +36,7 @@ type GithubContext struct {
 	RetentionDays    string                 `json:"retention_days"`
 	RunnerPerflog    string                 `json:"runner_perflog"`
 	RunnerTrackingID string                 `json:"runner_tracking_id"`
+	ServerURL        string                 `json:"server_url "`
 }
 
 func asString(v interface{}) string {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -631,9 +631,25 @@ func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext
 
 	ghc.SetRefTypeAndName()
 
+	// defaults
 	ghc.ServerURL = "https://github.com"
+	ghc.APIURL = "https://api.github.com"
+	ghc.GraphQLURL = "https://api.github.com/graphql"
+	// per GHES
 	if rc.Config.GitHubInstance != "github.com" {
 		ghc.ServerURL = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
+		ghc.APIURL = fmt.Sprintf("https://%s/api/v3", rc.Config.GitHubInstance)
+		ghc.GraphQLURL = fmt.Sprintf("https://%s/api/graphql", rc.Config.GitHubInstance)
+	}
+	// allow to be overridden by user
+	if rc.Config.Env["GITHUB_SERVER_URL"] != "" {
+		ghc.ServerURL = rc.Config.Env["GITHUB_SERVER_URL"]
+	}
+	if rc.Config.Env["GITHUB_API_URL"] != "" {
+		ghc.ServerURL = rc.Config.Env["GITHUB_API_URL"]
+	}
+	if rc.Config.Env["GITHUB_GRAPHQL_URL"] != "" {
+		ghc.ServerURL = rc.Config.Env["GITHUB_GRAPHQL_URL"]
 	}
 
 	return ghc
@@ -709,26 +725,9 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	env["RUNNER_TRACKING_ID"] = github.RunnerTrackingID
 	env["GITHUB_BASE_REF"] = github.BaseRef
 	env["GITHUB_HEAD_REF"] = github.HeadRef
-
-	if env["GITHUB_SERVER_URL"] == "" {
-		env["GITHUB_SERVER_URL"] = github.ServerURL
-	}
-
-	defaultAPIURL := "https://api.github.com"
-	defaultGraphqlURL := "https://api.github.com/graphql"
-
-	if rc.Config.GitHubInstance != "github.com" {
-		defaultAPIURL = fmt.Sprintf("https://%s/api/v3", rc.Config.GitHubInstance)
-		defaultGraphqlURL = fmt.Sprintf("https://%s/api/graphql", rc.Config.GitHubInstance)
-	}
-
-	if env["GITHUB_API_URL"] == "" {
-		env["GITHUB_API_URL"] = defaultAPIURL
-	}
-
-	if env["GITHUB_GRAPHQL_URL"] == "" {
-		env["GITHUB_GRAPHQL_URL"] = defaultGraphqlURL
-	}
+	env["GITHUB_SERVER_URL"] = github.ServerURL
+	env["GITHUB_API_URL"] = github.APIURL
+	env["GITHUB_GRAPHQL_URL"] = github.GraphQLURL
 
 	if rc.Config.ArtifactServerPath != "" {
 		setActionRuntimeVars(rc, env)

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -631,6 +631,11 @@ func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext
 
 	ghc.SetRefTypeAndName()
 
+	ghc.ServerURL = "https://github.com"
+	if rc.Config.GitHubInstance != "github.com" {
+		ghc.ServerURL = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
+	}
+
 	return ghc
 }
 
@@ -705,18 +710,16 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	env["GITHUB_BASE_REF"] = github.BaseRef
 	env["GITHUB_HEAD_REF"] = github.HeadRef
 
-	defaultServerURL := "https://github.com"
+	if env["GITHUB_SERVER_URL"] == "" {
+		env["GITHUB_SERVER_URL"] = github.ServerURL
+	}
+
 	defaultAPIURL := "https://api.github.com"
 	defaultGraphqlURL := "https://api.github.com/graphql"
 
 	if rc.Config.GitHubInstance != "github.com" {
-		defaultServerURL = fmt.Sprintf("https://%s", rc.Config.GitHubInstance)
 		defaultAPIURL = fmt.Sprintf("https://%s/api/v3", rc.Config.GitHubInstance)
 		defaultGraphqlURL = fmt.Sprintf("https://%s/api/graphql", rc.Config.GitHubInstance)
-	}
-
-	if env["GITHUB_SERVER_URL"] == "" {
-		env["GITHUB_SERVER_URL"] = defaultServerURL
 	}
 
 	if env["GITHUB_API_URL"] == "" {


### PR DESCRIPTION
The `server_urL` attribute was missing in the `github` context.
Previously it was exposed as environment variable only.

Closes #1726