### PR TITLE
fix: ensure networkmode "host" unless explicitly specified

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -348,6 +348,12 @@ func (cr *containerReference) mergeContainerConfigs(ctx context.Context, config 
 		return nil, nil, fmt.Errorf("Cannot parse container options: '%s': '%w'", input.Options, err)
 	}
 
+	if len(copts.netMode.Value()) == 0 {
+		if err = copts.netMode.Set("host"); err != nil {
+			return nil, nil, fmt.Errorf("Cannot parse networkmode=host. This is an internal error and should not happen: '%w'", err)
+		}
+	}
+
 	containerConfig, err := parse(flags, copts, "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("Cannot process container options: '%s': '%w'", input.Options, err)


### PR DESCRIPTION
act defaults network mode to "host", but when `--container-options` are passed on the CLI, it uses the docker CLI options parser, which fills empty values with defaults, in which case network mode is set to "default".
Unless the user explicitly sets `--container-options="--network=xxx"`, we should always default to "host", to keep act's behaviour.