### PR TITLE
allow command line container options to be appended to workflow specified options

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -521,11 +521,13 @@ func (rc *RunContext) platformImage(ctx context.Context) string {
 func (rc *RunContext) options(_ context.Context) string {
 	job := rc.Run.Job()
 	c := job.Container()
-	if c == nil {
-		return rc.Config.ContainerOptions
+	containerOptions := ""
+	if c != nil {
+		containerOptions = c.Options
 	}
+	containerOptions += " " + rc.Config.ContainerOptions
 
-	return c.Options
+	return containerOptions
 }
 
 func (rc *RunContext) isEnabled(ctx context.Context) (bool, error) {


### PR DESCRIPTION
This PR allows for command line options passed through `--container-options` to override any specified in the workflow file. It fixes #1696 which is needed for situations where you need to override a container option just in act and not in the GHA themselves. 

In the GIthubs section on [Container Options](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container#setting-container-resource-options) they call out they do not support the `--network` option for containers because they run containers explicitly in the bridge network and you cannot specify the `--network` flag twice in an invocation. With this change, ACT users can run both GHA and ACT runs from the same workflow file with the same network type.