### PR TITLE
fix: make sure socket path is used in bind mount

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -96,7 +96,7 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 	}
 
 	binds := []string{
-		fmt.Sprintf("%s:%s", rc.Config.ContainerDaemonSocket, "/var/run/docker.sock"),
+		fmt.Sprintf("%s:%s", strings.TrimPrefix(strings.TrimPrefix(rc.Config.ContainerDaemonSocket, "unix://"), "npipe://"), "/var/run/docker.sock"),
 	}
 
 	ext := container.LinuxContainerEnvironmentExtensions{}


### PR DESCRIPTION
Docker cannot receive socket uri parameters in a bind mount.
This change makes sure a possible uri preifx is stripped from
the path.

Fixes #1756 