### PR TITLE
chore: run act from cli on linux

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           upload-logs-name: logs-linux
       - name: Run act from cli
-        run: go run main.go -C ./pkg/runner/testdata/ -W ./basic/push.yml
+        run: go run main.go -P ubuntu-latest=node:16-buster-slim -C ./pkg/runner/testdata/ -W ./basic/push.yml
       - name: Upload Codecov report
         uses: codecov/codecov-action@v3.1.3
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -58,6 +58,8 @@ jobs:
         uses: ./.github/actions/run-tests
         with:
           upload-logs-name: logs-linux
+      - name: Run act from cli
+        run: go run main.go -C ./pkg/runner/testdata/ -W ./basic/push.yml
       - name: Upload Codecov report
         uses: codecov/codecov-action@v3.1.3
         with:


### PR DESCRIPTION
To prevent issues like #1756 in the future, we need to
run act from the cli through all the root setup code.
This ensures that the basic CLI setup can succeed.

