### PR TITLE
Avoid using `log.Fatal` in `pkg/*`

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -58,9 +58,8 @@ func (w *Workflow) On() []string {
 func (w *Workflow) OnEvent(event string) interface{} {
 	if w.RawOn.Kind == yaml.MappingNode {
 		var val map[string]interface{}
-		err := w.RawOn.Decode(&val)
-		if err != nil {
-			log.Fatal(err)
+		if !decodeNode(w.RawOn, &val) {
+			return nil
 		}
 		return val[event]
 	}
@@ -85,16 +84,14 @@ func (w *Workflow) WorkflowDispatchConfig() *WorkflowDispatch {
 	}
 
 	var val map[string]yaml.Node
-	err := w.RawOn.Decode(&val)
-	if err != nil {
-		log.Fatal(err)
+	if !decodeNode(w.RawOn, &val) {
+		return nil
 	}
 
 	var config WorkflowDispatch
 	node := val["workflow_dispatch"]
-	err = node.Decode(&config)
-	if err != nil {
-		log.Fatal(err)
+	if !decodeNode(node, &config) {
+		return nil
 	}
 
 	return &config
@@ -128,16 +125,14 @@ func (w *Workflow) WorkflowCallConfig() *WorkflowCall {
 	}
 
 	var val map[string]yaml.Node
-	err := w.RawOn.Decode(&val)
-	if err != nil {
-		log.Fatal(err)
+	if !decodeNode(w.RawOn, &val) {
+		return &WorkflowCall{}
 	}
 
 	var config WorkflowCall
 	node := val["workflow_call"]
-	err = node.Decode(&config)
-	if err != nil {
-		log.Fatal(err)
+	if !decodeNode(node, &config) {
+		return &WorkflowCall{}
 	}
 
 	return &config
@@ -220,9 +215,8 @@ func (j *Job) InheritSecrets() bool {
 	}
 
 	var val string
-	err := j.RawSecrets.Decode(&val)
-	if err != nil {
-		log.Fatal(err)
+	if !decodeNode(j.RawSecrets, &val) {
+		return false
 	}
 
 	return val == "inherit"
@@ -234,9 +228,8 @@ func (j *Job) Secrets() map[string]string {
 	}
 
 	var val map[string]string
-	err := j.RawSecrets.Decode(&val)
-	if err != nil {
-		log.Fatal(err)
+	if !decodeNode(j.RawSecrets, &val) {
+		return nil
 	}
 
 	return val


### PR DESCRIPTION
Follow up #1705 

Replace some `log.Fatal` with `decodeNode` in `pkg/model/workflow.go`.