### PR TITLE
Don't bind host docker daemon socket

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -95,9 +95,7 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 		rc.Config.ContainerDaemonSocket = "/var/run/docker.sock"
 	}
 
-	binds := []string{
-		fmt.Sprintf("%s:%s", rc.Config.ContainerDaemonSocket, "/var/run/docker.sock"),
-	}
+	binds := []string{}
 
 	ext := container.LinuxContainerEnvironmentExtensions{}
 


### PR DESCRIPTION
Binding host docker daemon socket into executor containers can be a terrible security hole. Don't do this unless explicitly specified through customized mounts.

To exploit this issue, run following test job:
```yml
on:
  pull_request:
    branches:
      - 'main'

jobs:
  test:
    runs-on: ubuntu-latest
    container: docker:git
    steps:
      - name: Bind host rootfs
        run: |
          docker run --detach --name i_am_almighty -v /:/host-rootfs ubuntu:latest /bin/tail -f /dev/null
          docker exec i_am_almighty id
          docker exec i_am_almighty ls -la /host-rootfs
```
See also #1744 , #1756, #1757.