### PR TITLE
fix: don't allow `-self-hosted` mode as container image

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -488,7 +488,7 @@ func (rc *RunContext) containerImage(ctx context.Context) string {
 
 func (rc *RunContext) runsOnImage(ctx context.Context) string {
 	job := rc.Run.Job()
-	
+
 	if job.RunsOn() == nil {
 		common.Logger(ctx).Errorf("'runs-on' key not defined in %s", rc.String())
 	}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -420,8 +420,9 @@ func (rc *RunContext) startContainer() common.Executor {
 }
 
 func (rc *RunContext) IsHostEnv(ctx context.Context) bool {
-	image := rc.runsOnImage(ctx)
-	return strings.EqualFold(image, "-self-hosted")
+	platform := rc.runsOnImage(ctx)
+	image := rc.containerImage(ctx)
+	return image == "" && strings.EqualFold(platform, "-self-hosted")
 }
 
 func (rc *RunContext) stopContainer() common.Executor {
@@ -474,6 +475,17 @@ func (rc *RunContext) Executor() common.Executor {
 	}
 }
 
+func (rc *RunContext) containerImage(ctx context.Context) string {
+	job := rc.Run.Job()
+
+	c := job.Container()
+	if c != nil {
+		return rc.ExprEval.Interpolate(ctx, c.Image)
+	}
+
+	return ""
+}
+
 func (rc *RunContext) runsOnImage(ctx context.Context) string {
 	job := rc.Run.Job()
 	
@@ -493,11 +505,8 @@ func (rc *RunContext) runsOnImage(ctx context.Context) string {
 }
 
 func (rc *RunContext) platformImage(ctx context.Context) string {
-	job := rc.Run.Job()
-
-	c := job.Container()
-	if c != nil {
-		return rc.ExprEval.Interpolate(ctx, c.Image)
+	if containerImage := rc.containerImage(ctx); containerImage != "" {
+		return containerImage
 	}
 
 	return rc.runsOnImage(ctx)

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -420,7 +420,7 @@ func (rc *RunContext) startContainer() common.Executor {
 }
 
 func (rc *RunContext) IsHostEnv(ctx context.Context) bool {
-	image := rc.platformImage(ctx)
+	image := rc.runsOnImage(ctx)
 	return strings.EqualFold(image, "-self-hosted")
 }
 
@@ -474,14 +474,9 @@ func (rc *RunContext) Executor() common.Executor {
 	}
 }
 
-func (rc *RunContext) platformImage(ctx context.Context) string {
+func (rc *RunContext) runsOnImage(ctx context.Context) string {
 	job := rc.Run.Job()
-
-	c := job.Container()
-	if c != nil {
-		return rc.ExprEval.Interpolate(ctx, c.Image)
-	}
-
+	
 	if job.RunsOn() == nil {
 		common.Logger(ctx).Errorf("'runs-on' key not defined in %s", rc.String())
 	}
@@ -495,6 +490,17 @@ func (rc *RunContext) platformImage(ctx context.Context) string {
 	}
 
 	return ""
+}
+
+func (rc *RunContext) platformImage(ctx context.Context) string {
+	job := rc.Run.Job()
+
+	c := job.Container()
+	if c != nil {
+		return rc.ExprEval.Interpolate(ctx, c.Image)
+	}
+
+	return rc.runsOnImage(ctx)
 }
 
 func (rc *RunContext) options(ctx context.Context) string {


### PR DESCRIPTION
Currently act will accept jobs like
```yaml
container: -self-hosted
```

I suggest to to block this syntax and require to write `-P freebsd=-self-hosted`.

_An empty container name will now use the platform image of the runs-on label, just like actions/runner_