### PR TITLE
fix: Update ARCH environment variable used in runners/actions

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -240,8 +240,8 @@ func RunnerArch(ctx context.Context) string {
 
 	archMapper := map[string]string{
 		"x86_64":  "X64",
-		"386":     "x86",
-		"aarch64": "arm64",
+		"386":     "X86",
+		"aarch64": "ARM64",
 	}
 	if arch, ok := archMapper[info.Architecture]; ok {
 		return arch

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -387,11 +387,13 @@ func (*HostEnvironment) JoinPathVariable(paths ...string) string {
 	return strings.Join(paths, string(filepath.ListSeparator))
 }
 
+// Reference for Arch values for runner.arch
+// https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
 func goArchToActionArch(arch string) string {
 	archMapper := map[string]string{
 		"x86_64":  "X64",
-		"386":     "x86",
-		"aarch64": "arm64",
+		"386":     "X86",
+		"aarch64": "ARM64",
 	}
 	if arch, ok := archMapper[arch]; ok {
 		return arch


### PR DESCRIPTION
## Summary of Changes
According to https://github.com/github/docs/blob/main/data/reusables/actions/runner-arch-description.md the ARCH values used in actions are uppercase. This is affecting testing actions that depend on https://github.com/sigstore/cosign-installer because they are using `ARM64` instead of `arm64`. 