### PR TITLE
 Fix bug in processing jobs on platforms without Docker

### DIFF
--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -3,6 +3,8 @@ package common
 import (
 	"context"
 	"fmt"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Warning that implements `error` but safe to ignore
@@ -93,6 +95,11 @@ func NewParallelExecutor(parallel int, executors ...Executor) Executor {
 	return func(ctx context.Context) error {
 		work := make(chan Executor, len(executors))
 		errs := make(chan error, len(executors))
+
+		if 1 > parallel {
+			log.Infof("Parallel tasks (%d) below minimum, setting to 1", parallel)
+			parallel = 1
+		}
 
 		for i := 0; i < parallel; i++ {
 			go func(work <-chan Executor, errs chan<- error) {

--- a/pkg/common/executor_test.go
+++ b/pkg/common/executor_test.go
@@ -100,6 +100,17 @@ func TestNewParallelExecutor(t *testing.T) {
 	assert.Equal(3, count, "should run all 3 executors")
 	assert.Equal(2, maxCount, "should run at most 2 executors in parallel")
 	assert.Nil(err)
+
+	// Reset to test running the executor with 0 parallelism
+	count = 0
+	activeCount = 0
+	maxCount = 0
+
+	errSingle := NewParallelExecutor(0, emptyWorkflow, emptyWorkflow, emptyWorkflow)(ctx)
+
+	assert.Equal(3, count, "should run all 3 executors")
+	assert.Equal(1, maxCount, "should run at most 1 executors in parallel")
+	assert.Nil(errSingle)
 }
 
 func TestNewParallelExecutorFailed(t *testing.T) {

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -417,6 +417,7 @@ func (j *Job) GetMatrixes() ([]map[string]interface{}, error) {
 		}
 	} else {
 		matrixes = append(matrixes, make(map[string]interface{}))
+		log.Debugf("Empty Strategy, matrixes=%v", matrixes)
 	}
 	return matrixes, nil
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -103,15 +103,45 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 	maxJobNameLen := 0
 
 	stagePipeline := make([]common.Executor, 0)
+	log.Debugf("Plan Stages: %v", plan.Stages)
+
 	for i := range plan.Stages {
 		stage := plan.Stages[i]
 		stagePipeline = append(stagePipeline, func(ctx context.Context) error {
 			pipeline := make([]common.Executor, 0)
 			for _, run := range stage.Runs {
+				log.Debugf("Stages Runs: %v", stage.Runs)
 				stageExecutor := make([]common.Executor, 0)
 				job := run.Job()
+				log.Debugf("Job.Name: %v", job.Name)
+				log.Debugf("Job.RawNeeds: %v", job.RawNeeds)
+				log.Debugf("Job.RawRunsOn: %v", job.RawRunsOn)
+				log.Debugf("Job.Env: %v", job.Env)
+				log.Debugf("Job.If: %v", job.If)
+				for step := range job.Steps {
+					if nil != job.Steps[step] {
+						log.Debugf("Job.Steps: %v", job.Steps[step].String())
+					}
+				}
+				log.Debugf("Job.TimeoutMinutes: %v", job.TimeoutMinutes)
+				log.Debugf("Job.Services: %v", job.Services)
+				log.Debugf("Job.Strategy: %v", job.Strategy)
+				log.Debugf("Job.RawContainer: %v", job.RawContainer)
+				log.Debugf("Job.Defaults.Run.Shell: %v", job.Defaults.Run.Shell)
+				log.Debugf("Job.Defaults.Run.WorkingDirectory: %v", job.Defaults.Run.WorkingDirectory)
+				log.Debugf("Job.Outputs: %v", job.Outputs)
+				log.Debugf("Job.Uses: %v", job.Uses)
+				log.Debugf("Job.With: %v", job.With)
+				//log.Debugf("Job.RawSecrets: %v", job.RawSecrets)
+				log.Debugf("Job.Result: %v", job.Result)
 
 				if job.Strategy != nil {
+					log.Debugf("Job.Strategy.FailFast: %v", job.Strategy.FailFast)
+					log.Debugf("Job.Strategy.MaxParallel: %v", job.Strategy.MaxParallel)
+					log.Debugf("Job.Strategy.FailFastString: %v", job.Strategy.FailFastString)
+					log.Debugf("Job.Strategy.MaxParallelString: %v", job.Strategy.MaxParallelString)
+					log.Debugf("Job.Strategy.RawMatrix: %v", job.Strategy.RawMatrix)
+
 					strategyRc := runner.newRunContext(ctx, run, nil)
 					if err := strategyRc.NewExpressionEvaluator(ctx).EvaluateYamlNode(ctx, &job.Strategy.RawMatrix); err != nil {
 						log.Errorf("Error while evaluating matrix: %v", err)
@@ -122,6 +152,8 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				if m, err := job.GetMatrixes(); err != nil {
 					log.Errorf("Error while get job's matrix: %v", err)
 				} else {
+					log.Debugf("Job Matrices: %v", m)
+					log.Debugf("Runner Matrices: %v", runner.config.Matrix)
 					matrixes = selectMatrixes(m, runner.config.Matrix)
 				}
 				log.Debugf("Final matrix after applying user inclusions '%v'", matrixes)


### PR DESCRIPTION
The container.GetHostInfo() struct is returned empty on hosts without docker and this results in passing zero parallelism to the parallel executor.

Use Golang's inbuilt runtime.NumCPU() instead. This should be safe on Docker too.

I've also added a fair bit of debug logging to assist with debugging the struct passed to the runner. This is leftover from my original line of inquiry, but it seemed like useful code so I kept it in the change.
