### PR TITLE
fix: spelling mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ If your workflow depends on this token, you need to create a [personal access to
 act -s GITHUB_TOKEN=[insert token or leave blank and omit equals for secure input]
 ```
 
-If [GitHub CLI](https://cli.github.com/) is installed, the [`gh auth token`](https://cli.github.com/manual/gh_auth_token) command can be used to autmatically pass the token to act
+If [GitHub CLI](https://cli.github.com/) is installed, the [`gh auth token`](https://cli.github.com/manual/gh_auth_token) command can be used to automatically pass the token to act
 
 ```bash
 act -s GITHUB_TOKEN="$(gh auth token)"


### PR DESCRIPTION
Simple spelling mistake that I couldn't find an issue for. 