### PR TITLE
Allow to override location of action cache dir

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -54,6 +54,7 @@ type Input struct {
 	replaceGheActionWithGithubCom      []string
 	replaceGheActionTokenWithGithubCom string
 	matrix                             []string
+	actionCachePath                    string
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().StringVarP(&input.cacheServerPath, "cache-server-path", "", filepath.Join(CacheHomeDir, "actcache"), "Defines the path where the cache server stores caches.")
 	rootCmd.PersistentFlags().StringVarP(&input.cacheServerAddr, "cache-server-addr", "", common.GetOutboundIP().String(), "Defines the address to which the cache server binds.")
 	rootCmd.PersistentFlags().Uint16VarP(&input.cacheServerPort, "cache-server-port", "", 0, "Defines the port where the artifact server listens. 0 means a randomly available port.")
+	rootCmd.PersistentFlags().StringVarP(&input.actionCachePath, "action-cache-path", "", filepath.Join(CacheHomeDir, "act"), "Defines the path where the actions get cached and host workspaces created.")
 	rootCmd.SetArgs(args())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -580,6 +581,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			ForceRebuild:                       input.forceRebuild,
 			ReuseContainers:                    input.reuseContainers,
 			Workdir:                            input.Workdir(),
+			ActionCacheDir:                     input.actionCachePath,
 			BindWorkdir:                        input.bindWorkdir,
 			LogOutput:                          !input.noOutput,
 			JSONLogger:                         input.jsonLogger,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -383,6 +383,9 @@ func (rc *RunContext) stopJobContainer() common.Executor {
 
 // ActionCacheDir is for rc
 func (rc *RunContext) ActionCacheDir() string {
+	if rc.Config.ActionCacheDir != "" {
+		return rc.Config.ActionCacheDir
+	}
 	var xdgCache string
 	var ok bool
 	if xdgCache, ok = os.LookupEnv("XDG_CACHE_HOME"); !ok || xdgCache == "" {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -22,6 +22,7 @@ type Runner interface {
 type Config struct {
 	Actor                              string                     // the user that triggered the event
 	Workdir                            string                     // path to working directory
+	ActionCacheDir                     string                     // path used for caching action contents
 	BindWorkdir                        bool                       // bind the workdir to the job container
 	EventName                          string                     // name of event to run
 	EventPath                          string                     // path to JSON file to use for event.json in containers


### PR DESCRIPTION
Adds an option to specify the directory below which actions and host workspaces will be stored. If left empty the previous location at `$XDG_CACHE_HOME/act` or `$HOME/.cache/act` will be used respectively.

Closes #1862.