### PR TITLE
Drop disappeared `wei/curl@v1`

### DIFF
--- a/pkg/artifacts/server_test.go
+++ b/pkg/artifacts/server_test.go
@@ -14,10 +14,11 @@ import (
 	"testing/fstest"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/nektos/act/pkg/model"
-	"github.com/nektos/act/pkg/runner"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/nektos/act/pkg/model"
+	"github.com/nektos/act/pkg/runner"
 )
 
 type writableMapFile struct {
@@ -239,7 +240,9 @@ type TestJobFileInfo struct {
 }
 
 var artifactsPath = path.Join(os.TempDir(), "test-artifacts")
+
 var artifactsAddr = "127.0.0.1"
+
 var artifactsPort = "12345"
 
 func TestArtifactFlow(t *testing.T) {
@@ -253,7 +256,7 @@ func TestArtifactFlow(t *testing.T) {
 	defer cancel()
 
 	platforms := map[string]string{
-		"ubuntu-latest": "node:16-buster-slim",
+		"ubuntu-latest": "node:16-buster", // Don't use node:16-buster-slim because it doesn't have curl command, which is used in the tests
 	}
 
 	tables := []TestJobFileInfo{

--- a/pkg/artifacts/server_test.go
+++ b/pkg/artifacts/server_test.go
@@ -239,11 +239,11 @@ type TestJobFileInfo struct {
 	containerArchitecture string
 }
 
-var artifactsPath = path.Join(os.TempDir(), "test-artifacts")
-
-var artifactsAddr = "127.0.0.1"
-
-var artifactsPort = "12345"
+var (
+	artifactsPath = path.Join(os.TempDir(), "test-artifacts")
+	artifactsAddr = "127.0.0.1"
+	artifactsPort = "12345"
+)
 
 func TestArtifactFlow(t *testing.T) {
 	if testing.Short() {

--- a/pkg/artifacts/testdata/GHSL-2023-004/artifacts.yml
+++ b/pkg/artifacts/testdata/GHSL-2023-004/artifacts.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - run: echo "hello world" > test.txt
       - name: curl upload
-        run: curl --silent --show-error --fail --fail-with-body ${ACTIONS_RUNTIME_URL}upload/1?itemPath=../../my-artifact/secret.txt --upload-file test.txt
+        run: curl --silent --show-error --fail ${ACTIONS_RUNTIME_URL}upload/1?itemPath=../../my-artifact/secret.txt --upload-file test.txt
       - uses: actions/download-artifact@v2
         with:
           name: my-artifact
@@ -25,7 +25,7 @@ jobs:
             exit 1
           fi
       - name: Verify download should work by clean extra dots
-        run: curl --silent --show-error --fail --fail-with-body --path-as-is -o out.txt ${ACTIONS_RUNTIME_URL}artifact/1/../../../1/my-artifact/secret.txt
+        run: curl --silent --show-error --fail --path-as-is -o out.txt ${ACTIONS_RUNTIME_URL}artifact/1/../../../1/my-artifact/secret.txt
       - name: 'Verify download content'
         run: |
           file="out.txt"

--- a/pkg/artifacts/testdata/GHSL-2023-004/artifacts.yml
+++ b/pkg/artifacts/testdata/GHSL-2023-004/artifacts.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - run: echo "hello world" > test.txt
       - name: curl upload
+        # FIXME: wei/curl@v1 is gone
         uses: wei/curl@v1
         with:
           args: -s --fail ${ACTIONS_RUNTIME_URL}upload/1?itemPath=../../my-artifact/secret.txt --upload-file test.txt

--- a/pkg/artifacts/testdata/GHSL-2023-004/artifacts.yml
+++ b/pkg/artifacts/testdata/GHSL-2023-004/artifacts.yml
@@ -8,10 +8,7 @@ jobs:
     steps:
       - run: echo "hello world" > test.txt
       - name: curl upload
-        # FIXME: wei/curl@v1 is gone
-        uses: wei/curl@v1
-        with:
-          args: -s --fail ${ACTIONS_RUNTIME_URL}upload/1?itemPath=../../my-artifact/secret.txt --upload-file test.txt
+        run: curl --silent --show-error --fail --fail-with-body ${ACTIONS_RUNTIME_URL}upload/1?itemPath=../../my-artifact/secret.txt --upload-file test.txt
       - uses: actions/download-artifact@v2
         with:
           name: my-artifact
@@ -28,9 +25,7 @@ jobs:
             exit 1
           fi
       - name: Verify download should work by clean extra dots
-        uses: wei/curl@v1
-        with:
-          args: --path-as-is -s -o out.txt --fail ${ACTIONS_RUNTIME_URL}artifact/1/../../../1/my-artifact/secret.txt
+        run: curl --silent --show-error --fail --fail-with-body --path-as-is -o out.txt ${ACTIONS_RUNTIME_URL}artifact/1/../../../1/my-artifact/secret.txt
       - name: 'Verify download content'
         run: |
           file="out.txt"


### PR DESCRIPTION
Reported by https://github.com/nektos/act/pull/1863#issuecomment-1588555812

`wei/curl@v1` is gone. See https://github.com/wei/curl

Fortunately, I found a fork of the repo, and I'm sure it's just [a wrapper of curl command](https://github.com/thinkdolabs/curl/blob/master/entrypoint.sh). So we can use curl command directly.