### PR TITLE
refactor: open boltdb only while using it

### DIFF
--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -146,7 +146,7 @@ func (h *Handler) openDB() (*bolthold.Store, error) {
 		Encoder: json.Marshal,
 		Decoder: json.Unmarshal,
 		Options: &bbolt.Options{
-			Timeout:      5 * time.Second,
+			Timeout:      50 * time.Second,
 			NoGrowSync:   bbolt.DefaultOptions.NoGrowSync,
 			FreelistType: bbolt.DefaultOptions.FreelistType,
 		},

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -321,6 +321,7 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, params httprout
 		h.responseJSON(w, r, 500, err)
 		return
 	}
+	defer db.Close()
 
 	cache.Complete = true
 	if err := db.Update(cache.ID, cache); err != nil {

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -27,7 +27,7 @@ const (
 )
 
 type Handler struct {
-	dir	     string
+	dir      string
 	storage  *Storage
 	router   *httprouter.Router
 	listener net.Listener

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -146,7 +146,7 @@ func (h *Handler) openDB() (*bolthold.Store, error) {
 		Encoder: json.Marshal,
 		Decoder: json.Unmarshal,
 		Options: &bbolt.Options{
-			Timeout:      50 * time.Second,
+			Timeout:      5 * time.Second,
 			NoGrowSync:   bbolt.DefaultOptions.NoGrowSync,
 			FreelistType: bbolt.DefaultOptions.FreelistType,
 		},
@@ -309,7 +309,15 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, params httprout
 		return
 	}
 
+	db.Close()
+
 	if err := h.storage.Commit(cache.ID, cache.Size); err != nil {
+		h.responseJSON(w, r, 500, err)
+		return
+	}
+
+	db, err = h.openDB()
+	if err != nil {
 		h.responseJSON(w, r, 500, err)
 		return
 	}

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -27,6 +27,7 @@ func TestHandler(t *testing.T) {
 		t.Run("inpect db", func(t *testing.T) {
                         db, err := handler.openDB()
                         require.NoError(t, err)
+                        defer db.Close()
 			require.NoError(t, db.Bolt().View(func(tx *bbolt.Tx) error {
 				return tx.Bucket([]byte("Cache")).ForEach(func(k, v []byte) error {
 					t.Logf("%s: %s", k, v)

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -25,9 +25,9 @@ func TestHandler(t *testing.T) {
 
 	defer func() {
 		t.Run("inpect db", func(t *testing.T) {
-                        db, err := handler.openDB()
-                        require.NoError(t, err)
-                        defer db.Close()
+			db, err := handler.openDB()
+			require.NoError(t, err)
+			defer db.Close()
 			require.NoError(t, db.Bolt().View(func(tx *bbolt.Tx) error {
 				return tx.Bucket([]byte("Cache")).ForEach(func(k, v []byte) error {
 					t.Logf("%s: %s", k, v)

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -25,7 +25,9 @@ func TestHandler(t *testing.T) {
 
 	defer func() {
 		t.Run("inpect db", func(t *testing.T) {
-			require.NoError(t, handler.db.Bolt().View(func(tx *bbolt.Tx) error {
+                        db, err := handler.openDB()
+                        require.NoError(t, err)
+			require.NoError(t, db.Bolt().View(func(tx *bbolt.Tx) error {
 				return tx.Bucket([]byte("Cache")).ForEach(func(k, v []byte) error {
 					t.Logf("%s: %s", k, v)
 					return nil
@@ -36,7 +38,6 @@ func TestHandler(t *testing.T) {
 			require.NoError(t, handler.Close())
 			assert.Nil(t, handler.server)
 			assert.Nil(t, handler.listener)
-			assert.Nil(t, handler.db)
 			_, err := http.Post(fmt.Sprintf("%s/caches/%d", base, 1), "", nil)
 			assert.Error(t, err)
 		})


### PR DESCRIPTION
I don't know anything about boltdb, but running two act instances with the same bolt database returns after 5s with error timeout.

My proposal is open the db on demand. Additionally close the db during download, upload and commit to reduce hitting a 5s timeout due to large caches.

Do you know any other solution?
This might have a negative impact for a single act instance, due to additional open and close calls.

Does boltdb have any problem when calling Close() twice? If so we need to disable the defered Close() after calling it.

~~Timeout is now 50s to allow using cache in parallel on slower devices, since database locks might take longer.~~

Closes #1825