### PR TITLE
Remove `archives.replacements` in `goreleaser.yaml`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,7 +108,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --snapshot --rm-dist
+          args: release --snapshot --clean
       - name: Capture x86_64 (64-bit) Linux binary
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
       - name: Chocolatey

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-      {{ if .Arm }}v{{ .Arm }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,13 +22,12 @@ builds:
 checksum:
   name_template: 'checksums.txt'
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+      {{ if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ endif
 .PHONY: snapshot
 snapshot:
 	goreleaser build \
-		--rm-dist \
+		--clean \
 		--single-target \
 		--snapshot
 


### PR DESCRIPTION
Fix #1894 and other CI failures.

`archives.replacements` has been removed since goreleaser v1.19.0. See https://goreleaser.com/deprecations/#archivesreplacements

Use an equivalent replacement to handle it.

To ensure that it is indeed equivalent, there's the archives of `v0.2.46`:

<img width="246" alt="image" src="https://github.com/nektos/act/assets/9418365/3f8a4d78-bc66-4192-b1c7-44647f4d7fc0">

And the CI outputs of this PR:

<img width="281" alt="image" src="https://github.com/nektos/act/assets/9418365/5a016264-2a8e-4ab6-8dee-a22001768926">