### PR TITLE
Add new CLI flag to log just the job id and not the entire job name

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -54,7 +54,7 @@ runs:
               }
             }
           };
-          var args = ['test', '-v', '-cover', '-coverprofile=coverage.txt', '-covermode=atomic', '-timeout', '15m'];
+          var args = ['test', '-v', '-cover', '-coverprofile=coverage.txt', '-covermode=atomic', '-timeout', '20m'];
           var filter = process.env.FILTER;
           if(filter) {
             args.push('-run');

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -55,6 +55,7 @@ type Input struct {
 	replaceGheActionTokenWithGithubCom string
 	matrix                             []string
 	actionCachePath                    string
+	logPrefixJobID                     bool
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().StringVarP(&input.workdir, "directory", "C", ".", "working directory")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&input.jsonLogger, "json", false, "Output logs in json format")
+	rootCmd.PersistentFlags().BoolVar(&input.logPrefixJobID, "log-prefix-job-id", false, "Output the job id within non-json logs instead of the entire name")
 	rootCmd.PersistentFlags().BoolVarP(&input.noOutput, "quiet", "q", false, "disable logging of output from steps")
 	rootCmd.PersistentFlags().BoolVarP(&input.dryrun, "dryrun", "n", false, "dryrun mode")
 	rootCmd.PersistentFlags().StringVarP(&input.secretfile, "secret-file", "", ".secrets", "file with list of secrets to read from (e.g. --secret-file .secrets)")
@@ -584,6 +585,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			BindWorkdir:                        input.bindWorkdir,
 			LogOutput:                          !input.noOutput,
 			JSONLogger:                         input.jsonLogger,
+			LogPrefixJobID:                     input.logPrefixJobID,
 			Env:                                envs,
 			Secrets:                            secrets,
 			Vars:                               vars,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -32,6 +32,7 @@ type Config struct {
 	ForceRebuild                       bool                       // force rebuilding local docker image action
 	LogOutput                          bool                       // log the output from docker run
 	JSONLogger                         bool                       // use json or text logger
+	LogPrefixJobID                     bool                       // switches from the full job name to the job id
 	Env                                map[string]string          // env for containers
 	Inputs                             map[string]string          // manually passed action inputs
 	Secrets                            map[string]string          // list of secrets


### PR DESCRIPTION
Log messages can already be fairly long which is exacerbated by the prefix, however the prefix is useful when running multiple jobs within a single act pipeline. The compromise in this PR is to allow for a shorter prefix using just the job ID, which is user configurable.

The flag chosen is intentionally verbose.

```bash
--log-prefix-job-id
```

Sample output without the flag
```bash
[call-workflow/Run In Container/run-in-container] [DEBUG] evaluating expression 'success()'
[call-workflow/Run In Container/run-in-container] [DEBUG] expression 'success()' evaluated to 'true'
[call-workflow/Run In Container/run-in-container] [DEBUG] Loading revision from git directory
```

Sample output with the flag
```bash
[run-in-container] [DEBUG] evaluating expression 'success()'
[run-in-container] [DEBUG] expression 'success()' evaluated to 'true'
[run-in-container] [DEBUG] Loading revision from git directory
```

Closes https://github.com/nektos/act/issues/1821