### PR TITLE
feat: only print container logs with `--focus`

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -24,6 +24,7 @@ type Input struct {
 	forcePull                          bool
 	forceRebuild                       bool
 	noOutput                           bool
+	focusOutput                        bool
 	envfile                            string
 	inputfile                          string
 	secretfile                         string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,7 @@ func Execute(ctx context.Context, version string) {
 	rootCmd.PersistentFlags().BoolVar(&input.jsonLogger, "json", false, "Output logs in json format")
 	rootCmd.PersistentFlags().BoolVar(&input.logPrefixJobID, "log-prefix-job-id", false, "Output the job id within non-json logs instead of the entire name")
 	rootCmd.PersistentFlags().BoolVarP(&input.noOutput, "quiet", "q", false, "disable logging of output from steps")
+	rootCmd.PersistentFlags().BoolVarP(&input.focusOutput, "focus", "f", false, "disable logging of non-step messages")
 	rootCmd.PersistentFlags().BoolVarP(&input.dryrun, "dryrun", "n", false, "dryrun mode")
 	rootCmd.PersistentFlags().StringVarP(&input.secretfile, "secret-file", "", ".secrets", "file with list of secrets to read from (e.g. --secret-file .secrets)")
 	rootCmd.PersistentFlags().StringVarP(&input.varfile, "var-file", "", ".vars", "file with list of vars to read from (e.g. --var-file .vars)")
@@ -280,6 +281,11 @@ func setup(_ *Input) func(*cobra.Command, []string) {
 		if verbose {
 			log.SetLevel(log.DebugLevel)
 		}
+		focus, _ := cmd.Flags().GetBool("focus")
+		if focus {
+			log.SetLevel(log.WarnLevel)
+		}
+
 		loadVersionNotices(cmd.Version)
 	}
 }
@@ -584,6 +590,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			ActionCacheDir:                     input.actionCachePath,
 			BindWorkdir:                        input.bindWorkdir,
 			LogOutput:                          !input.noOutput,
+			LogFocus:                           input.focusOutput,
 			JSONLogger:                         input.jsonLogger,
 			LogPrefixJobID:                     input.logPrefixJobID,
 			Env:                                envs,

--- a/pkg/common/logger.go
+++ b/pkg/common/logger.go
@@ -6,8 +6,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type outputLoggerContextKey string
 type loggerContextKey string
 
+const outputLoggerContextKeyVal = outputLoggerContextKey("logrus.FieldLogger")
 const loggerContextKeyVal = loggerContextKey("logrus.FieldLogger")
 
 // Logger returns the appropriate logger for current context
@@ -21,7 +23,23 @@ func Logger(ctx context.Context) logrus.FieldLogger {
 	return logrus.StandardLogger()
 }
 
+// Logger returns the appropriate logger for current context
+func OutputLogger(ctx context.Context) logrus.FieldLogger {
+	val := ctx.Value(outputLoggerContextKeyVal)
+	if val != nil {
+		if logger, ok := val.(logrus.FieldLogger); ok {
+			return logger
+		}
+	}
+	return logrus.StandardLogger()
+}
+
 // WithLogger adds a value to the context for the logger
 func WithLogger(ctx context.Context, logger logrus.FieldLogger) context.Context {
 	return context.WithValue(ctx, loggerContextKeyVal, logger)
+}
+
+// WithOutputLogger adds a value to the context for the logger
+func WithOutputLogger(ctx context.Context, logger logrus.FieldLogger) context.Context {
+	return context.WithValue(ctx, outputLoggerContextKeyVal, logger)
 }

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -336,7 +336,10 @@ func evalDockerArgs(ctx context.Context, step step, action *model.Action, cmd *[
 func newStepContainer(ctx context.Context, step step, image string, cmd []string, entrypoint []string) container.Container {
 	rc := step.getRunContext()
 	stepModel := step.getStepModel()
-	rawLogger := common.Logger(ctx).WithField("raw_output", true)
+	rawLogger := common.OutputLogger(ctx)
+	if !rc.Config.LogFocus {
+		rawLogger = rawLogger.WithField("raw_output", true)
+	}
 	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -198,7 +198,10 @@ func (rc *RunContext) newCompositeCommandExecutor(executor common.Executor) comm
 		// handler into the current running job container
 		// We need this, to support scoping commands to the composite action
 		// executing.
-		rawLogger := common.Logger(ctx).WithField("raw_output", true)
+		rawLogger := common.OutputLogger(ctx)
+		if !rc.Config.LogFocus {
+			rawLogger = rawLogger.WithField("raw_output", true)
+		}
 		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
 			if rc.Config.LogOutput {
 				rawLogger.Infof("%s", s)

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -32,7 +32,7 @@ func tryParseRawActionCommand(line string) (command string, kvPairs map[string]s
 }
 
 func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
-	logger := common.Logger(ctx)
+	logger := common.OutputLogger(ctx)
 	resumeCommand := ""
 	return func(line string) bool {
 		command, kvPairs, arg, ok := tryParseRawActionCommand(line)

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -175,7 +175,10 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 	return func(ctx context.Context) error {
 		ctx = withStepLogger(ctx, stepModel.ID, rc.ExprEval.Interpolate(ctx, stepModel.String()), stage.String())
 
-		rawLogger := common.Logger(ctx).WithField("raw_output", true)
+		rawLogger := common.OutputLogger(ctx)
+		if !rc.Config.LogFocus {
+			rawLogger = rawLogger.WithField("raw_output", true)
+		}
 		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
 			if rc.Config.LogOutput {
 				rawLogger.Infof("%s", s)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -31,6 +31,7 @@ type Config struct {
 	ForcePull                          bool                       // force pulling of the image, even if already present
 	ForceRebuild                       bool                       // force rebuilding local docker image action
 	LogOutput                          bool                       // log the output from docker run
+	LogFocus                           bool                       // hide everything but the output from docker run
 	JSONLogger                         bool                       // use json or text logger
 	LogPrefixJobID                     bool                       // switches from the full job name to the job id
 	Env                                map[string]string          // env for containers

--- a/pkg/runner/step_docker.go
+++ b/pkg/runner/step_docker.go
@@ -93,7 +93,10 @@ func (sd *stepDocker) newStepContainer(ctx context.Context, image string, cmd []
 	rc := sd.RunContext
 	step := sd.Step
 
-	rawLogger := common.Logger(ctx).WithField("raw_output", true)
+	rawLogger := common.OutputLogger(ctx)
+	if !rc.Config.LogFocus {
+		rawLogger = rawLogger.WithField("raw_output", true)
+	}
 	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)


### PR DESCRIPTION
This PR introduces a new `--focus` (`-f`) flag, which, when enabled, will suppress all logs _except_ those emitted by the processes inside the running container.

Doing so, reduces this:

```
act --job json
[Linting/json] 🚀  Start image=catthehacker/ubuntu:act-latest
[Linting/json]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[Linting/json]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Linting/json]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Linting/json] ⭐ Run Main actions/checkout@v3
[Linting/json]   🐳  docker cp src=... dst=...
[Linting/json]   ✅  Success - Main actions/checkout@v3
[Linting/json] ⭐ Run Main ./.github/actions/linters/json
[Linting/json]   ☁  git clone 'https://github.com/actionsx/prettier' # ref=v3
[Linting/json] ⭐ Run Main actionsx/prettier@v3
[Linting/json]   🐳  docker cp src=/Users/jean/.cache/act/actionsx-prettier@v3/ dst=/var/run/act/actions/actionsx-prettier@v3/
[Linting/json]   🐳  docker exec cmd=[node /var/run/act/actions/actionsx-prettier@v3/dist/index.js] user= workdir=
| Checking formatting...
| All matched files use Prettier code style!
[Linting/json]   ✅  Success - Main actionsx/prettier@v3
[Linting/json]   ✅  Success - Main ./.github/actions/linters/json
[Linting/json] ⭐ Run Post ./.github/actions/linters/json
[Linting/json]   ✅  Success - Post ./.github/actions/linters/json
[Linting/json] 🏁  Job succeeded
```

To this:

```
act --job json --focus
[Linting/json] Checking formatting...
[Linting/json] All matched files use Prettier code style!
```

The two differences are:

- Non-process logs are only emitted if they are `WARN` or above.
- Process logs have their workflow/job names prefixed, to distinguish multiple runners from each other.

For those who really _only_ want the process logs without any annotations, you can add `--json` and then format the output using `jq` etc, e.g.:

```
act --job json --focus --json | jq -r '.msg | gsub("\\n"; "")'
Checking formatting...
All matched files use Prettier code style!
```


The implementation itself works, but isn't as elegant as I would like because I didn't want to introduce any backward breaking changes.

I think, ideally, with two separate loggers (one for the process messages, the other for messages from act itself), there would be flags to control the log level of each individual logger, and do away with `--quiet`, `--focus`, and `--verbose`.

But, the current implementation works for me and doesn't introduce any backward breaking changes, so I figured I'd push this up, either for you to modify, or take as is.

---

One other alternative that I only thought of as I was writing this PR description, is to introduce a new field on the JSON-based log output, to distinguish between process and act logs. That way, we could again use `jq` to filter out the logs we don't want. The downside is we'd lose the pretty printing niceties, so it's a trade-off of supporting this in the utility itself, or giving people the hooks to do it themselves outside the process.

Edit: one more thing I forgot to mention — I didn't add any tests yet. I'm uncertain if/where logging output is tested, so feel free to either add it yourself, or give me some pointers, so I can see if I can find some additional time to add them.