### PR TITLE
refactor: remove unnecessary nil check in RunContext

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -789,17 +789,15 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	}
 
 	job := rc.Run.Job()
-	if job.RunsOn() != nil {
-		for _, runnerLabel := range job.RunsOn() {
-			platformName := rc.ExprEval.Interpolate(ctx, runnerLabel)
-			if platformName != "" {
-				if platformName == "ubuntu-latest" {
-					// hardcode current ubuntu-latest since we have no way to check that 'on the fly'
-					env["ImageOS"] = "ubuntu20"
-				} else {
-					platformName = strings.SplitN(strings.Replace(platformName, `-`, ``, 1), `.`, 2)[0]
-					env["ImageOS"] = platformName
-				}
+	for _, runnerLabel := range job.RunsOn() {
+		platformName := rc.ExprEval.Interpolate(ctx, runnerLabel)
+		if platformName != "" {
+			if platformName == "ubuntu-latest" {
+				// hardcode current ubuntu-latest since we have no way to check that 'on the fly'
+				env["ImageOS"] = "ubuntu20"
+			} else {
+				platformName = strings.SplitN(strings.Replace(platformName, `-`, ``, 1), `.`, 2)[0]
+				env["ImageOS"] = platformName
 			}
 		}
 	}


### PR DESCRIPTION
From the Go docs:

> "For a nil slice, the number of iterations is 0" https://go.dev/ref/spec#For_range

Therefore, an additional nil check for `job.RunsOn()` before the loop is unnecessary because `job.RunsOn()` returns a `[]string`. Example: https://go.dev/play/p/cmcRrMJ6Mb4