### PR TITLE
Fix "Unknown server OS" for Docker container `--device` option

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -351,7 +351,7 @@ func (cr *containerReference) mergeContainerConfigs(ctx context.Context, config 
 		}
 	}
 
-	containerConfig, err := parse(flags, copts, "")
+	containerConfig, err := parse(flags, copts, runtime.GOOS)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Cannot process container options: '%s': '%w'", input.Options, err)
 	}


### PR DESCRIPTION
The `--device` option would do platform-dependent validation, but the OS was not passed as an argument. When a user added the `--device` option to the container, it would result in a "Unknown server OS" error.

Fixes #1910.

Sample YAML to reproduce it:

```yml
jobs:
  build:
    name: Foo
    container:
      image: bar:latest
      options: -uroot --device=/dev/bus/usb/001/002
```

I would prefer to write a test for this fix, but I'm not very familiar with the project or the programming language.