### PR TITLE
feat: support interpolation in `<job>.container.options`

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -518,14 +518,14 @@ func (rc *RunContext) platformImage(ctx context.Context) string {
 	return rc.runsOnImage(ctx)
 }
 
-func (rc *RunContext) options(_ context.Context) string {
+func (rc *RunContext) options(ctx context.Context) string {
 	job := rc.Run.Job()
 	c := job.Container()
-	if c == nil {
-		return rc.Config.ContainerOptions
+	if c != nil {
+		return rc.ExprEval.Interpolate(ctx, c.Options)
 	}
 
-	return c.Options
+	return rc.Config.ContainerOptions
 }
 
 func (rc *RunContext) isEnabled(ctx context.Context) (bool, error) {


### PR DESCRIPTION
### Desired functionality

Seems that act does not support variable interpolation in the `--device` option:

```yaml
jobs:
  build:
    container:
      options: -uroot --device=${{ inputs.device }}
```

Results in:

```
Error: Cannot process container options: '-uroot --device=${{ inputs.device }}': '${{ is not an absolute path'
```

Seems that variable interpolation is not enabled anywhere in the options field, since it's doing the same for the `-u` flag:

```
-u${{inputs.user }}
```

Results in:

```
Error: failed to start container: Error response from daemon: unable to find user ${{inputs.user}}: no matching entries in passwd file
```

These are supported in the live GitHub Actions runner.

### Approach

Adapted `options` method in `run_context.go` to be in the same style as `containerImage` which already has support for variable interpolation:

```go
func (rc *RunContext) containerImage(ctx context.Context) string {
	job := rc.Run.Job()

	c := job.Container()
	if c != nil {
		return rc.ExprEval.Interpolate(ctx, c.Image)
	}

	return ""
}
```