### PR TITLE
Update install instructions on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ winget install nektos.act
 yay -Syu act
 ```
 
-### [COPR](https://copr.fedorainfracloud.org/coprs/rubemlrm/act-cli/) (Linux)
+### [COPR](https://copr.fedorainfracloud.org/coprs/goncalossilva/act/) (Linux)
 
 ```shell
-dnf copr enable rubemlrm/act-cli
+dnf copr enable goncalossilva/act
 dnf install act-cli
 ```
 


### PR DESCRIPTION
Disclaimer: I'm the author of this copr repo.

goncalossilva/cli has been up and running for much longer than the official recommendation, and over the years, it's been more reliable with its builds. See:
- https://github.com/goncalossilva/rpm-act/actions
- https://copr.fedorainfracloud.org/coprs/goncalossilva/act/monitor/

It's also fully automated. This means stable versions of Fedora get new builds quickly (even if builds on rawhide/preview versions tend to fail while the dust settles).

I think this is a better default choice for `act` users, but other than this PR, it's up to the reviewer. Regardless of it being merged or not, goncalossilva/act will continue to be built. :)