### PR TITLE
fix: fail if no stages were found

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -527,9 +527,15 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		if jobID != "" {
 			log.Debugf("Planning job: %s", jobID)
 			plan, plannerErr = planner.PlanJob(jobID)
+			if len(plan.Stages) == 0 {
+				log.Warnf("Could not find any stages to run with the job ID %s. View the valid job IDs with `act --list`", jobID)
+			}
 		} else {
 			log.Debugf("Planning jobs for event: %s", eventName)
 			plan, plannerErr = planner.PlanEvent(eventName)
+			if len(plan.Stages) == 0 {
+				log.Warnf("Could not find any stages to run with the event name %s. View the valid event names with `act --list`", eventName)
+			}
 		}
 		if plan == nil && plannerErr != nil {
 			return plannerErr


### PR DESCRIPTION
Adds a warning message if act is cannot find any stages to run with the filters provided.

Reproduction:
- run `act -j gibberish`

Desired behavior: some indication I did something silly
Actual behavior: no output, just exit with success.

As a human who often makes spelling mistakes,
it would be nice if act warned me what I was doing that was silly rather than exiting apparently doing
nothing with no obvious indication
I did something wrong.

Alternative solutions:
- Do nothing, it's the user's fault: True it is, would be nice to give them a hint where to resolve their issue
- Exit with error rather than warn: Reasonable behavior as well, not knowledgeable enough with the code base to know for sure this is enough justification to exit