### PR TITLE
Mention act user guide in act

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ New issues can be created with in our [GitHub repo](https://github.com/nektos/ac
 
 ### <a id="pr"></a>Pull Requests
 
-Pull requests should target the `master` branch. Please also reference the issue from the description of the pull request using [special keyword syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) to auto close the issue when the PR is merged. For example, include the phrase `fixes #14` in the PR description to have issue #14 auto close.
+Pull requests should target the `master` branch. Please also reference the issue from the description of the pull request using [special keyword syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) to auto close the issue when the PR is merged. For example, include the phrase `fixes #14` in the PR description to have issue #14 auto close. Please send documentation updates for the [act user guide](https://nektosact.com) to [nektos/act-docs](https://github.com/nektos/act-docs).
 
 ### <a id="style"></a> Styleguide
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Let's see it in action with a [sample repo](https://github.com/cplee/github-acti
 
 ![Demo](https://github.com/nektos/act/wiki/quickstart/act-quickstart-2.gif)
 
+# Act User Guide
+
+Please look at the [act user guide](https://nektosact.com) for more documentation.
+
 # Installation
 
 ## Necessary prerequisites for running `act`


### PR DESCRIPTION
We should mention where to find the act user guide and that documentation updates should target https://github.com/nektos/act-docs.

Please help me to improve the wording.

_Maintainer see also https://github.com/nektos/act-maintainers/discussions/16_