### PR TITLE
Fix float formatting

### DIFF
--- a/pkg/exprparser/functions_test.go
+++ b/pkg/exprparser/functions_test.go
@@ -230,6 +230,7 @@ func TestFunctionFormat(t *testing.T) {
 		{"format('{0', '{1}', 'World')", nil, "Unclosed brackets. The following format string is invalid: '{0'", "format-invalid-format-string"},
 		{"format('{2}', '{1}', 'World')", "", "The following format string references more arguments than were supplied: '{2}'", "format-invalid-replacement-reference"},
 		{"format('{2147483648}')", "", "The following format string is invalid: '{2147483648}'", "format-invalid-replacement-reference"},
+		{"format('{0} {1} {2} {3}', 1.0, 1.1, 1234567890.0, 12345678901234567890.0)", "1 1.1 1234567890 1.23456789012346E+19", nil, "format-floats"},
 	}
 
 	env := &EvaluationEnvironment{

--- a/pkg/exprparser/interpreter.go
+++ b/pkg/exprparser/interpreter.go
@@ -447,7 +447,7 @@ func (impl *interperterImpl) coerceToString(value reflect.Value) reflect.Value {
 		} else if math.IsInf(value.Float(), -1) {
 			return reflect.ValueOf("-Infinity")
 		}
-		return reflect.ValueOf(fmt.Sprint(value))
+		return reflect.ValueOf(fmt.Sprintf("%.15G", value.Float()))
 
 	case reflect.Slice:
 		return reflect.ValueOf("Array")


### PR DESCRIPTION
Format floats the same way as actions/runner (precision 15, remove trailing zeroes)

See: https://github.com/actions/runner/blob/67d70803a95fca2fc86d89231acbc319f9a9be2a/src/Sdk/DTObjectTemplating/ObjectTemplating/Tokens/NumberToken.cs#L34

Fixes #2017