### PR TITLE
fix: network-scoped alias is supported only for containers in user defined networks

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -450,7 +450,9 @@ func (cr *containerReference) create(capAdd []string, capDrop []string) common.E
 
 		var networkingConfig *network.NetworkingConfig
 		logger.Debugf("input.NetworkAliases ==> %v", input.NetworkAliases)
-		if hostConfig.NetworkMode.IsUserDefined() && len(input.NetworkAliases) > 0 {
+		n := hostConfig.NetworkMode
+		// TODO: use IsUserDefined() once it's windows implementation matches the unix one
+		if !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer() && len(input.NetworkAliases) > 0 {
 			endpointConfig := &network.EndpointSettings{
 				Aliases: input.NetworkAliases,
 			}


### PR DESCRIPTION
This Windows only issue is caused by the missing `!n.IsHost()` in the `n.IsUserDefined()` function for windows. Act sends the network alias for the host network on windows, linux sees that and calls the same `IsUserDefined` (but uses the unix definition on the server side), which detects the `host` network as non user defined network.

On linux and macOS it is impossible to reproduce at the time of creating this change. I don't get why windows has it's own definition, but bad maintained.

The actual code uses `IsUserDefined` to detect if network aliases are supported, which didn't work on windows due to the mess in the docker client go library.

Thank you docker client.

go\pkg\mod\github.com\docker\docker@v24.0.7+incompatible\api\types\container\hostconfig_unix.go
```
// IsUserDefined indicates user-created network
func (n NetworkMode) IsUserDefined() bool {
	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer()
}
```

go\pkg\mod\github.com\docker\docker@v24.0.7+incompatible\api\types\container\hostconfig_windows.go
```
// IsUserDefined indicates user-created network
func (n NetworkMode) IsUserDefined() bool {
	return !n.IsDefault() && !n.IsNone() && !n.IsBridge() && !n.IsContainer()
}
```

Why did docker this?

Seems like we have to replace the convenience function with it's unix definition

**Important bug fix, I don't have the power**