### PR TITLE
Evaluate if condition when calling a reusable workflow

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -673,13 +673,15 @@ func (rc *RunContext) isEnabled(ctx context.Context) (bool, error) {
 
 	if jobType == model.JobTypeInvalid {
 		return false, jobTypeErr
-	} else if jobType != model.JobTypeDefault {
-		return true, nil
 	}
 
 	if !runJob {
 		l.WithField("jobResult", "skipped").Debugf("Skipping job '%s' due to '%s'", job.Name, job.If.Value)
 		return false, nil
+	}
+
+	if jobType != model.JobTypeDefault {
+		return true, nil
 	}
 
 	img := rc.platformImage(ctx)

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -572,6 +572,17 @@ if: always()`, ""),
 	})
 	rc.Run.JobID = "job2"
 	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `uses: ./.github/workflows/reusable.yml`, ""),
+	})
+	assertObject.True(rc.isEnabled(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `uses: ./.github/workflows/reusable.yml
+if: false`, ""),
+	})
+	assertObject.False(rc.isEnabled(context.Background()))
 }
 
 func TestRunContextGetEnv(t *testing.T) {


### PR DESCRIPTION
Ensure we evaluate the `if` condition if the job calls a reusable workflow, rather than always assuming it should run.

Fixes #2085