### PR TITLE
Support array expressions in runs-on

### DIFF
--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -15,7 +15,7 @@ func (i *Input) newPlatforms() map[string]string {
 	for _, p := range i.platforms {
 		pParts := strings.Split(p, "=")
 		if len(pParts) == 2 {
-			platforms[pParts[0]] = pParts[1]
+			platforms[strings.ToLower(pParts[0])] = pParts[1]
 		}
 	}
 	return platforms

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -272,20 +272,23 @@ func (j *Job) Needs() []string {
 	return nil
 }
 
-// RunsOn string or list for Job
-func (j *Job) RunsOn() (runsOnString string, runsOnList []string, err error) {
+// RunsOn list for Job
+func (j *Job) RunsOn() []string {
 	switch j.RawRunsOn.Kind {
 	case yaml.ScalarNode:
-		if decodeNode(j.RawRunsOn, &runsOnString) && runsOnString != "" {
-			return
+		var val string
+		if !decodeNode(j.RawRunsOn, &val) {
+			return nil
 		}
+		return []string{val}
 	case yaml.SequenceNode:
-		if decodeNode(j.RawRunsOn, &runsOnList) && len(runsOnList) > 0 {
-			return
+		var val []string
+		if !decodeNode(j.RawRunsOn, &val) {
+			return nil
 		}
+		return val
 	}
-	err = fmt.Errorf("'runs-on' key not defined or invalid")
-	return
+	return nil
 }
 
 func environment(yml yaml.Node) map[string]string {

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -272,23 +272,20 @@ func (j *Job) Needs() []string {
 	return nil
 }
 
-// RunsOn list for Job
-func (j *Job) RunsOn() []string {
+// RunsOn string or list for Job
+func (j *Job) RunsOn() (runsOnString string, runsOnList []string, err error) {
 	switch j.RawRunsOn.Kind {
 	case yaml.ScalarNode:
-		var val string
-		if !decodeNode(j.RawRunsOn, &val) {
-			return nil
+		if decodeNode(j.RawRunsOn, &runsOnString) && runsOnString != "" {
+			return
 		}
-		return []string{val}
 	case yaml.SequenceNode:
-		var val []string
-		if !decodeNode(j.RawRunsOn, &val) {
-			return nil
+		if decodeNode(j.RawRunsOn, &runsOnList) && len(runsOnList) > 0 {
+			return
 		}
-		return val
 	}
-	return nil
+	err = fmt.Errorf("'runs-on' key not defined or invalid")
+	return
 }
 
 func environment(yml yaml.Node) map[string]string {

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -470,6 +470,36 @@ func createJob(t *testing.T, input string, result string) *model.Job {
 	return job
 }
 
+func TestRunContextRunsOnPlatformNames(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	assertObject := assert.New(t)
+
+	rc := createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ubuntu-latest`, ""),
+	})
+	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"ubuntu-latest"})
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ${{ 'ubuntu-latest' }}`, ""),
+	})
+	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"ubuntu-latest"})
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: [self-hosted, my-runner]`, ""),
+	})
+	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"self-hosted", "my-runner"})
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: [self-hosted, "${{ 'my-runner' }}"]`, ""),
+	})
+	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"self-hosted", "my-runner"})
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ${{ fromJSON('["ubuntu-latest"]') }}`, ""),
+	})
+	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"ubuntu-latest"})
+}
+
 func TestRunContextIsEnabled(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	assertObject := assert.New(t)

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -477,27 +477,44 @@ func TestRunContextRunsOnPlatformNames(t *testing.T) {
 	rc := createIfTestRunContext(map[string]*model.Job{
 		"job1": createJob(t, `runs-on: ubuntu-latest`, ""),
 	})
-	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"ubuntu-latest"})
+	assertObject.Equal([]string{"ubuntu-latest"}, rc.runsOnPlatformNames(context.Background()))
 
 	rc = createIfTestRunContext(map[string]*model.Job{
 		"job1": createJob(t, `runs-on: ${{ 'ubuntu-latest' }}`, ""),
 	})
-	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"ubuntu-latest"})
+	assertObject.Equal([]string{"ubuntu-latest"}, rc.runsOnPlatformNames(context.Background()))
 
 	rc = createIfTestRunContext(map[string]*model.Job{
 		"job1": createJob(t, `runs-on: [self-hosted, my-runner]`, ""),
 	})
-	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"self-hosted", "my-runner"})
+	assertObject.Equal([]string{"self-hosted", "my-runner"}, rc.runsOnPlatformNames(context.Background()))
 
 	rc = createIfTestRunContext(map[string]*model.Job{
 		"job1": createJob(t, `runs-on: [self-hosted, "${{ 'my-runner' }}"]`, ""),
 	})
-	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"self-hosted", "my-runner"})
+	assertObject.Equal([]string{"self-hosted", "my-runner"}, rc.runsOnPlatformNames(context.Background()))
 
 	rc = createIfTestRunContext(map[string]*model.Job{
 		"job1": createJob(t, `runs-on: ${{ fromJSON('["ubuntu-latest"]') }}`, ""),
 	})
-	assertObject.Equal(rc.runsOnPlatformNames(context.Background()), []string{"ubuntu-latest"})
+	assertObject.Equal([]string{"ubuntu-latest"}, rc.runsOnPlatformNames(context.Background()))
+
+	// test missing / invalid runs-on
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `name: something`, ""),
+	})
+	assertObject.Equal([]string{}, rc.runsOnPlatformNames(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on:
+  mapping: value`, ""),
+	})
+	assertObject.Equal([]string{}, rc.runsOnPlatformNames(context.Background()))
+
+	rc = createIfTestRunContext(map[string]*model.Job{
+		"job1": createJob(t, `runs-on: ${{ invalid expression }}`, ""),
+	})
+	assertObject.Equal([]string{}, rc.runsOnPlatformNames(context.Background()))
 }
 
 func TestRunContextIsEnabled(t *testing.T) {


### PR DESCRIPTION
Ensure array expressions in `runs-on` are handled correctly. Also fix `-P` to work case-insensitively, since labels are not case sensitive.

There is still one outstanding issue with `runs-on` and expressions, but that is not new to this PR: a matrix with a templated runs-on (e.g. `runs-on: ${{ matrix.label }}`). That feels like a bigger fix/refactor, so I was thinking of filing a new issue issue/PR for that, but if you'd prefer I can incorporate it into this one.

Fixes #2080