### PR TITLE
Don't set `GITHUB_TOKEN` env variable

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -907,7 +907,6 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	env["GITHUB_REF"] = github.Ref
 	env["GITHUB_REF_NAME"] = github.RefName
 	env["GITHUB_REF_TYPE"] = github.RefType
-	env["GITHUB_TOKEN"] = github.Token
 	env["GITHUB_JOB"] = github.Job
 	env["GITHUB_REPOSITORY_OWNER"] = github.RepositoryOwner
 	env["GITHUB_RETENTION_DAYS"] = github.RetentionDays

--- a/pkg/runner/step_test.go
+++ b/pkg/runner/step_test.go
@@ -182,7 +182,6 @@ func TestSetupEnv(t *testing.T) {
 		"GITHUB_RUN_ID":            "runId",
 		"GITHUB_RUN_NUMBER":        "1",
 		"GITHUB_SERVER_URL":        "https://",
-		"GITHUB_TOKEN":             "",
 		"GITHUB_WORKFLOW":          "",
 		"INPUT_STEP_WITH":          "with-value",
 		"RC_KEY":                   "rcvalue",


### PR DESCRIPTION
This needs to be explicitly set in the job/step/etc `env` to be consistent with GitHub.

Fixes #2081