### PR TITLE
WorkflowDispatchConfig supports multiple yaml node kinds

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"reflect"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -94,8 +93,10 @@ func (w *Workflow) WorkflowDispatchConfig() *WorkflowDispatch {
 		if !decodeNode(w.RawOn, &val) {
 			return nil
 		}
-		if slices.Contains(val, "workflow_dispatch") {
-			return &WorkflowDispatch{}
+		for _, v := range val {
+			if v == "workflow_dispatch" {
+				return &WorkflowDispatch{}
+			}
 		}
 	case yaml.MappingNode:
 		var val map[string]yaml.Node

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -83,9 +83,7 @@ func (w *Workflow) WorkflowDispatchConfig() *WorkflowDispatch {
 	switch w.RawOn.Kind {
 	case yaml.ScalarNode:
 		var val string
-		err := w.RawOn.Decode(&val)
-		if err != nil {
-			log.Fatal(err)
+		if !decodeNode(w.RawOn, &val) {
 			return nil
 		}
 		if val == "workflow_dispatch" {
@@ -93,9 +91,7 @@ func (w *Workflow) WorkflowDispatchConfig() *WorkflowDispatch {
 		}
 	case yaml.SequenceNode:
 		var val []string
-		err := w.RawOn.Decode(&val)
-		if err != nil {
-			log.Fatal(err)
+		if !decodeNode(w.RawOn, &val) {
 			return nil
 		}
 		if slices.Contains(val, "workflow_dispatch") {


### PR DESCRIPTION
I was working on PR https://github.com/go-gitea/gitea/pull/28163 . and found that the `workflow.WorkflowDispatchConfig()` method cannot be parsed correctly when the yaml node is not a mapping type

```
on: workflow_dispatch

on: [push, workflow_dispatch]

on:
    - push
    - workflow_dispatch

on:
    push:
    pull_request:
    workflow_dispatch:
        inputs:
            logLevel:
                description: 'Log level'
                required: true
                default: 'warning'
                type: choice
                options:
                - info
                - warning
                - debug
```
