### PR TITLE
fix: match cache `restore-keys` in creation reverse order

### DIFF
--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -386,7 +387,12 @@ func (h *Handler) findCache(db *bolthold.Store, keys []string, version string) (
 
 	for _, prefix := range keys[1:] {
 		found := false
-		if err := db.ForEach(bolthold.Where("Key").Ge(prefix).And("Version").Eq(version).SortBy("CreatedAt").Reverse(), func(v *Cache) error {
+		prefixPattern := fmt.Sprintf("^%s", regexp.QuoteMeta(prefix))
+		re, err := regexp.Compile(prefixPattern)
+		if err != nil {
+			continue
+		}
+		if err := db.ForEach(bolthold.Where("Key").RegExp(re).And("Version").Eq(version).SortBy("CreatedAt").Reverse(), func(v *Cache) error {
 			if !strings.HasPrefix(v.Key, prefix) {
 				return stop
 			}

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -386,7 +386,7 @@ func (h *Handler) findCache(db *bolthold.Store, keys []string, version string) (
 
 	for _, prefix := range keys[1:] {
 		found := false
-		if err := db.ForEach(bolthold.Where("Key").Ge(prefix).And("Version").Eq(version).SortBy("Key"), func(v *Cache) error {
+		if err := db.ForEach(bolthold.Where("Key").Ge(prefix).And("Version").Eq(version).SortBy("CreatedAt").Reverse(), func(v *Cache) error {
 			if !strings.HasPrefix(v.Key, prefix) {
 				return stop
 			}


### PR DESCRIPTION
Fixes https://github.com/nektos/act/issues/1823

Will now return from cache in the order mentioned in GitHub Actions cache [docs](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key):

> When a key doesn't match directly, the action searches for keys prefixed with the restore key. If there are multiple partial matches for a restore key, the action returns the most recently created cache.