### PR TITLE
refactor(cmd/root): simplify `parseEnvs`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -296,19 +296,17 @@ func cleanup(inputs *Input) func(*cobra.Command, []string) {
 	}
 }
 
-func parseEnvs(env []string, envs map[string]string) bool {
-	if env != nil {
-		for _, envVar := range env {
-			e := strings.SplitN(envVar, `=`, 2)
-			if len(e) == 2 {
-				envs[e[0]] = e[1]
-			} else {
-				envs[e[0]] = ""
-			}
+func parseEnvs(env []string) map[string]string {
+	envs := make(map[string]string, len(env))
+	for _, envVar := range env {
+		e := strings.SplitN(envVar, `=`, 2)
+		if len(e) == 2 {
+			envs[e[0]] = e[1]
+		} else {
+			envs[e[0]] = ""
 		}
-		return true
 	}
-	return false
+	return envs
 }
 
 func readYamlFile(file string) (map[string]string, error) {
@@ -414,13 +412,11 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		}
 
 		log.Debugf("Loading environment from %s", input.Envfile())
-		envs := make(map[string]string)
-		_ = parseEnvs(input.envs, envs)
+		envs := parseEnvs(input.envs)
 		_ = readEnvs(input.Envfile(), envs)
 
 		log.Debugf("Loading action inputs from %s", input.Inputfile())
-		inputs := make(map[string]string)
-		_ = parseEnvs(input.inputs, inputs)
+		inputs := parseEnvs(input.inputs)
 		_ = readEnvs(input.Inputfile(), inputs)
 
 		log.Debugf("Loading secrets from %s", input.Secretfile())


### PR DESCRIPTION
Currently `parseEnvs` accept two parameters:

1. `env []string`
2. `envs map[string]string`

`parseEnvs` then do a safety `nil` check for `env`. 

https://github.com/nektos/act/blob/15bb54f14e96734963b78310f0cb8ed0c67e25bb/cmd/root.go#L299-L312

However, we never pass a `nil` `env` to `parseEnvs` in `newRunCommand`.

https://github.com/nektos/act/blob/15bb54f14e96734963b78310f0cb8ed0c67e25bb/cmd/root.go#L417-L418

https://github.com/nektos/act/blob/15bb54f14e96734963b78310f0cb8ed0c67e25bb/cmd/root.go#L422-L423

This commit simplify the `parseEnvs` function to accept just one `env []string` parameter and return the result as `map[string]string` instead.