### PR TITLE
Add containerd's normalized architectures to archMapper

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -238,8 +238,10 @@ func RunnerArch(ctx context.Context) string {
 
 	archMapper := map[string]string{
 		"x86_64":  "X64",
+		"amd64":   "X64",
 		"386":     "X86",
 		"aarch64": "ARM64",
+		"arm64":   "ARM64",
 	}
 	if arch, ok := archMapper[info.Architecture]; ok {
 		return arch


### PR DESCRIPTION
While Docker gets its architecture property from `utsname.machine`, Podman uses `containerd`'s `normalizeArch` function which returns an architecture not in act's `archMapper` map, leading to the architecture to be passed through to the runner. This causes some runners to fail if they expect the architecture to only be in GitHub's format.

I added the two missing entries from [`normalizearch`](https://github.com/containerd/containerd/blob/be9336fed1a2e5570061da2998a201b111cf22c5/platforms/database.go#L79-L106), `amd64` and `arm64`, to `archMapper`.