### PR TITLE
fix: subpath actions via new artifact cache

### DIFF
--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -113,20 +113,6 @@ func maybeCopyToActionDir(ctx context.Context, step actionStep, actionDir string
 		return nil
 	}
 
-	if rc.Config != nil && rc.Config.ActionCache != nil {
-		raction := step.(*stepActionRemote)
-		ta, err := rc.Config.ActionCache.GetTarArchive(ctx, raction.cacheDir, raction.resolvedSha, "")
-		if err != nil {
-			return err
-		}
-		defer ta.Close()
-		return rc.JobContainer.CopyTarStream(ctx, containerActionDir, ta)
-	}
-
-	if err := removeGitIgnore(ctx, actionDir); err != nil {
-		return err
-	}
-
 	var containerActionDirCopy string
 	containerActionDirCopy = strings.TrimSuffix(containerActionDir, actionPath)
 	logger.Debug(containerActionDirCopy)
@@ -134,6 +120,21 @@ func maybeCopyToActionDir(ctx context.Context, step actionStep, actionDir string
 	if !strings.HasSuffix(containerActionDirCopy, `/`) {
 		containerActionDirCopy += `/`
 	}
+
+	if rc.Config != nil && rc.Config.ActionCache != nil {
+		raction := step.(*stepActionRemote)
+		ta, err := rc.Config.ActionCache.GetTarArchive(ctx, raction.cacheDir, raction.resolvedSha, "")
+		if err != nil {
+			return err
+		}
+		defer ta.Close()
+		return rc.JobContainer.CopyTarStream(ctx, containerActionDirCopy, ta)
+	}
+
+	if err := removeGitIgnore(ctx, actionDir); err != nil {
+		return err
+	}
+
 	return rc.JobContainer.CopyDir(containerActionDirCopy, actionDir+"/", rc.Config.UseGitIgnore)(ctx)
 }
 

--- a/pkg/runner/step_action_remote.go
+++ b/pkg/runner/step_action_remote.go
@@ -75,7 +75,7 @@ func (sar *stepActionRemote) prepareActionExecutor() common.Executor {
 
 			remoteReader := func(ctx context.Context) actionYamlReader {
 				return func(filename string) (io.Reader, io.Closer, error) {
-					spath := filename
+					spath := path.Join(sar.remoteAction.Path, filename)
 					for i := 0; i < maxSymlinkDepth; i++ {
 						tars, err := cache.GetTarArchive(ctx, sar.cacheDir, sar.resolvedSha, spath)
 						if err != nil {


### PR DESCRIPTION
This bug is behind a feature flag, which is good so no impact for regular users of act.

readfile have always read from `action.yml` and didn't passed the absolute path inside the action repo. This is fixed now, so readfile applies the subpath as prefix

Additionally the repo content has been copied into the subpath, so I applied a fix to use the trimmed actionContainer path as the code used without the feature toggle

To verify
```yaml
on: push
jobs:
  _:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/cache/save@v4
```

using vscode debug config

```json
        {
            "name": "Launch Package",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "${workspaceFolder}",
            "args": [
                "-W",
                "w.yml",
                "-P",
                "ubuntu-latest=-self-hosted",
                "--use-new-action-cache"
            ]
        }
```

After this fix we get
```
[w.yml/_] ⭐ Run Main actions/cache/save@v4
[w.yml/_]   | [warning]Key is not specified.
[w.yml/_]   ✅  Success - Main actions/cache/save@v4
[w.yml/_] Cleaning up container for job _
[w.yml/_] 🏁  Job succeeded
```