### PR TITLE
fix: improve new-action-cache fetch failure error

### DIFF
--- a/pkg/runner/action_cache.go
+++ b/pkg/runner/action_cache.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"path"
@@ -86,6 +87,9 @@ func (c GoGitActionCache) Fetch(ctx context.Context, cacheDir, url, ref, token s
 		Auth:  auth,
 		Force: true,
 	}); err != nil {
+		if tagOrSha && errors.Is(err, git.NoErrAlreadyUpToDate) {
+			return "", fmt.Errorf("couldn't find remote ref \"%s\"", ref)
+		}
 		return "", err
 	}
 	if tagOrSha {

--- a/pkg/runner/step_action_remote.go
+++ b/pkg/runner/step_action_remote.go
@@ -68,9 +68,11 @@ func (sar *stepActionRemote) prepareActionExecutor() common.Executor {
 
 			var err error
 			sar.cacheDir = fmt.Sprintf("%s/%s", sar.remoteAction.Org, sar.remoteAction.Repo)
-			sar.resolvedSha, err = cache.Fetch(ctx, sar.cacheDir, sar.remoteAction.URL+"/"+sar.cacheDir, sar.remoteAction.Ref, github.Token)
+			repoURL := sar.remoteAction.URL + "/" + sar.cacheDir
+			repoRef := sar.remoteAction.Ref
+			sar.resolvedSha, err = cache.Fetch(ctx, sar.cacheDir, repoURL, repoRef, github.Token)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to fetch \"%s\" version \"%s\": %w", repoURL, repoRef, err)
 			}
 
 			remoteReader := func(ctx context.Context) actionYamlReader {


### PR DESCRIPTION
- include repoURL and repoRef in error
- map NoErrAlreadyUptodate to `couldn't find remote ref` for branchOrtag
  fetch request

test workflow
```
on: push
jobs:
  _:
    runs-on: ubuntu-latest
    steps:
    - uses: ChristopherHX/ChristopherHX/test@main-2
```

`main-2` doesn't exist, but uses the wildcard query so it returns already uptodate as error due to to ref needing to be fetched

The random tmp branch would never exist so there is no problem mapping it