### PR TITLE
fix: sync DOCKER_HOST with cli parameter

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -384,7 +384,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		// Prefer DOCKER_HOST, don't override it
 		socketPath, hasDockerHost := os.LookupEnv("DOCKER_HOST")
 		if hasDockerHost {
-			// Try to mount tge socket in DOCKER_HOST, remote uris have a fallback deeper in the codebase
+			// Try to mount the socket in DOCKER_HOST, remote uris have a fallback deeper in the codebase
 			if input.containerDaemonSocket == "" {
 				input.containerDaemonSocket = socketPath
 			}


### PR DESCRIPTION
- **new** mount unix socket from `DOCKER_HOST` if it uses that protocol to `/var/run/docker.sock`
  - **old** behavior was mount `/var/run/docker.sock` if no cli arg changed it
- **new** mount the auto detected unix socket if it uses the unix socket protocol to `/var/run/docker.sock` (grey list of known non default sockets)
  - **old** behavior was mount `/var/run/docker.sock` if no cli arg changed it

