### PR TITLE
feat: correctly use the xdg library, which has the side effect to fix the config survey

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,19 +111,18 @@ func Execute(ctx context.Context, version string) {
 func configLocations() []string {
 	configFileName := ".actrc"
 
+	homePath := filepath.Join(UserHomeDir, configFileName)
+	invocationPath := filepath.Join(".", configFileName)
+
 	// Though named xdg, adrg's lib support macOS and Windows config paths as well
 	// It also takes cares of creating the parent folder so we don't need to bother later
-	configPath, err := xdg.ConfigFile("act/actrc")
+	specPath, err := xdg.ConfigFile("act/actrc")
 	if err != nil {
-		log.Fatal("Could not create config file")
+		specPath = homePath
 	}
 
 	// This order should be enforced since the survey part relies on it
-	return []string{
-		configPath,
-		filepath.Join(UserHomeDir, configFileName),
-		filepath.Join(".", configFileName),
-	}
+	return []string{specPath, homePath, invocationPath}
 }
 
 var commonSocketPaths = []string{


### PR DESCRIPTION
Fixes: #2193

It worked before my PR merge commit, and does not after... I guess it's my fault 😄.

# Fix

The `os.Create` call in `defaultImageSurvey` errors in case we could not create the file, like in the situation the parent folder wasn't created.

Also `configLocations` would set `actrcXdg` only if a file was actually found. So the path would be empty on first launch.

Instead of manually creating the parent folder, I went the way of modifying `configLocations` to include the correct xdg lib calls that takes cares of creating the folder and returning the right path.

Thanks and sorry again
