### PR TITLE
Dynamic artifact server port

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -43,7 +43,7 @@ type Input struct {
 	autoRemove                         bool
 	artifactServerPath                 string
 	artifactServerAddr                 string
-	artifactServerPort                 string
+	artifactServerPort                 uint16
 	noCacheServer                      bool
 	cacheServerPath                    string
 	cacheServerAddr                    string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -640,9 +640,15 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		}
 
 		const actionsRuntimeURLKey = "ACTIONS_RUNTIME_URL"
-		if envs[actionsRuntimeURLKey] == "" {
+		if !input.noCacheServer && envs[actionsRuntimeURLKey] == "" && artifactServer != nil {
 			envs[actionsRuntimeURLKey] = fmt.Sprintf("http://%s/", artifactServer.Addr)
 		}
+		const actionsRuntimeTokenKey = "ACTIONS_RUNTIME_TOKEN"
+		actionsRuntimeToken := os.Getenv(actionsRuntimeTokenKey)
+		if !input.noCacheServer && actionsRuntimeToken == "" && artifactServer != nil {
+			actionsRuntimeToken = "token"
+		}
+		envs[actionsRuntimeTokenKey] = actionsRuntimeToken
 
 		ctx = common.WithDryrun(ctx, input.dryrun)
 		if watch, err := cmd.Flags().GetBool("watch"); err != nil {

--- a/pkg/artifacts/server_test.go
+++ b/pkg/artifacts/server_test.go
@@ -240,9 +240,9 @@ type TestJobFileInfo struct {
 }
 
 var (
-	artifactsPath = path.Join(os.TempDir(), "test-artifacts")
-	artifactsAddr = "127.0.0.1"
-	artifactsPort = "12345"
+	artifactsPath        = path.Join(os.TempDir(), "test-artifacts")
+	artifactsAddr        = "127.0.0.1"
+	artifactsPort uint16 = 12345
 )
 
 func TestArtifactFlow(t *testing.T) {
@@ -252,7 +252,7 @@ func TestArtifactFlow(t *testing.T) {
 
 	ctx := context.Background()
 
-	cancel := Serve(ctx, artifactsPath, artifactsAddr, artifactsPort)
+	cancel, _ := Serve(ctx, artifactsPath, artifactsAddr, artifactsPort)
 	defer cancel()
 
 	platforms := map[string]string{

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -958,7 +958,7 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 func setActionRuntimeVars(rc *RunContext, env map[string]string) {
 	actionsRuntimeURL := os.Getenv("ACTIONS_RUNTIME_URL")
 	if actionsRuntimeURL == "" {
-		actionsRuntimeURL = fmt.Sprintf("http://%s:%s/", rc.Config.ArtifactServerAddr, rc.Config.ArtifactServerPort)
+		actionsRuntimeURL = fmt.Sprintf("http://%s:%d/", rc.Config.ArtifactServerAddr, rc.Config.ArtifactServerPort)
 	}
 	env["ACTIONS_RUNTIME_URL"] = actionsRuntimeURL
 

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -936,10 +936,6 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	env["GITHUB_API_URL"] = github.APIURL
 	env["GITHUB_GRAPHQL_URL"] = github.GraphQLURL
 
-	if rc.Config.ArtifactServerPath != "" {
-		setActionRuntimeVars(rc, env)
-	}
-
 	for _, platformName := range rc.runsOnPlatformNames(ctx) {
 		if platformName != "" {
 			if platformName == "ubuntu-latest" {
@@ -953,20 +949,6 @@ func (rc *RunContext) withGithubEnv(ctx context.Context, github *model.GithubCon
 	}
 
 	return env
-}
-
-func setActionRuntimeVars(rc *RunContext, env map[string]string) {
-	actionsRuntimeURL := os.Getenv("ACTIONS_RUNTIME_URL")
-	if actionsRuntimeURL == "" {
-		actionsRuntimeURL = fmt.Sprintf("http://%s:%d/", rc.Config.ArtifactServerAddr, rc.Config.ArtifactServerPort)
-	}
-	env["ACTIONS_RUNTIME_URL"] = actionsRuntimeURL
-
-	actionsRuntimeToken := os.Getenv("ACTIONS_RUNTIME_TOKEN")
-	if actionsRuntimeToken == "" {
-		actionsRuntimeToken = "token"
-	}
-	env["ACTIONS_RUNTIME_TOKEN"] = actionsRuntimeToken
 }
 
 func (rc *RunContext) handleCredentials(ctx context.Context) (string, string, error) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -53,7 +53,7 @@ type Config struct {
 	AutoRemove                         bool                         // controls if the container is automatically removed upon workflow completion
 	ArtifactServerPath                 string                       // the path where the artifact server stores uploads
 	ArtifactServerAddr                 string                       // the address the artifact server binds to
-	ArtifactServerPort                 string                       // the port the artifact server binds to
+	ArtifactServerPort                 uint16                       // the port the artifact server binds to
 	NoSkipCheckout                     bool                         // do not skip actions/checkout
 	RemoteName                         string                       // remote name in local git repo config
 	ReplaceGheActionWithGithubCom      []string                     // Use actions from GitHub Enterprise instance to GitHub


### PR DESCRIPTION
This makes `--artifact-server-port` consistent with  `--cache-server-port` and resolves my own feature request #2192 