### PR TITLE
fix: docker buildx cache restore not working

### DIFF
--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -385,7 +385,7 @@ func (h *Handler) findCache(db *bolthold.Store, keys []string, version string) (
 	}
 	stop := fmt.Errorf("stop")
 
-	for _, prefix := range keys[1:] {
+	for _, prefix := range keys {
 		found := false
 		prefixPattern := fmt.Sprintf("^%s", regexp.QuoteMeta(prefix))
 		re, err := regexp.Compile(prefixPattern)


### PR DESCRIPTION
* To take effect artifacts v4 pr is needed with adjusted claims


See https://github.com/go-gitea/gitea/pull/29584

For initial jwt ACTIONS_RUNTIME_TOKEN see

https://github.com/nektos/act/pull/2224

However we would need to start providing ACTIONS_RUNTIME_TOKEN even when artifacs server is disabled.