### PR TITLE
Trivial: reduce log spam.

### DIFF
--- a/pkg/common/executor.go
+++ b/pkg/common/executor.go
@@ -97,7 +97,7 @@ func NewParallelExecutor(parallel int, executors ...Executor) Executor {
 		errs := make(chan error, len(executors))
 
 		if 1 > parallel {
-			log.Infof("Parallel tasks (%d) below minimum, setting to 1", parallel)
+			log.Debugf("Parallel tasks (%d) below minimum, setting to 1", parallel)
 			parallel = 1
 		}
 


### PR DESCRIPTION
When verbose logging is false, this log line is still output, but it seems inconsequential to the end user, so I've dropped it to Debug.