### PR TITLE
docs: use HTTPS for cloning instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Want to contribute to act? Awesome! Check out the [contributing guidelines](CONT
 ## Manually building from source
 
 - Install Go tools 1.20+ - (<https://golang.org/doc/install>)
-- Clone this repo `git clone git@github.com:nektos/act.git`
+- Clone this repo `git clone https://github.com/nektos/act`
 - Run unit tests with `make test`
 - Build and install: `make install`


### PR DESCRIPTION
Cloning is a read-only command, and using SSH is a bit of an overkill, and gives me an error when I am inside a server, with unconfigured git (which I imagine a lot of people do). 