### PR TITLE
Support overwriting caches

### DIFF
--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -367,9 +367,10 @@ func (h *Handler) findCache(db *bolthold.Store, keys []string, version string) (
 				And("Version").Eq(version).
 				And("Complete").Eq(true).
 				SortBy("CreatedAt").Reverse()); err != nil {
-			if !errors.Is(err, bolthold.ErrNotFound) {
+			if errors.Is(err, bolthold.ErrNotFound) {
 				continue
 			}
+			return nil, fmt.Errorf("find cache: %w", err)
 		}
 		return cache, nil
 	}

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -395,7 +395,7 @@ func (h *Handler) gcCache() {
 	if h.gcing.Load() {
 		return
 	}
-	if h.gcing.CompareAndSwap(false, true) {
+	if !h.gcing.CompareAndSwap(false, true) {
 		return
 	}
 	defer h.gcing.Store(false)

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -170,7 +170,7 @@ func (h *Handler) find(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 	}
 	defer db.Close()
 
-	cache, err := h.findCache(db, keys, version)
+	cache, err := findCache(db, keys, version)
 	if err != nil {
 		h.responseJSON(w, r, 500, err)
 		return
@@ -216,7 +216,7 @@ func (h *Handler) reserve(w http.ResponseWriter, r *http.Request, _ httprouter.P
 	now := time.Now().Unix()
 	cache.CreatedAt = now
 	cache.UsedAt = now
-	if err := h.insertCache(db, cache); err != nil {
+	if err := insertCache(db, cache); err != nil {
 		h.responseJSON(w, r, 500, err)
 		return
 	}
@@ -349,7 +349,7 @@ func (h *Handler) middleware(handler httprouter.Handle) httprouter.Handle {
 }
 
 // if not found, return (nil, nil) instead of an error.
-func (_ *Handler) findCache(db *bolthold.Store, keys []string, version string) (*Cache, error) {
+func findCache(db *bolthold.Store, keys []string, version string) (*Cache, error) {
 	cache := &Cache{}
 	for _, prefix := range keys {
 		prefixPattern := fmt.Sprintf("^%s", regexp.QuoteMeta(prefix))
@@ -372,7 +372,7 @@ func (_ *Handler) findCache(db *bolthold.Store, keys []string, version string) (
 	return nil, nil
 }
 
-func (_ *Handler) insertCache(db *bolthold.Store, cache *Cache) error {
+func insertCache(db *bolthold.Store, cache *Cache) error {
 	if err := db.Insert(bolthold.NextSequence(), cache); err != nil {
 		return fmt.Errorf("insert cache: %w", err)
 	}

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -379,7 +379,7 @@ func TestHandler(t *testing.T) {
 			}{}
 			require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
 			assert.Equal(t, "hit", got.Result)
-			assert.Equal(t, keys[1], got.CacheKey)
+			assert.Equal(t, keys[2], got.CacheKey) // expect key + "_a_b_c"
 			archiveLocation = got.ArchiveLocation
 		}
 		{
@@ -388,7 +388,7 @@ func TestHandler(t *testing.T) {
 			require.Equal(t, 200, resp.StatusCode)
 			got, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			assert.Equal(t, contents[1], got)
+			assert.Equal(t, contents[2], got) // expect key + "_a_b_c"
 		}
 	})
 

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -590,5 +590,4 @@ func TestHandler_gcCache(t *testing.T) {
 		})
 	}
 	require.NoError(t, db.Close())
-
 }

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -569,7 +569,7 @@ func TestHandler_gcCache(t *testing.T) {
 	db, err := handler.openDB()
 	require.NoError(t, err)
 	for _, c := range cases {
-		require.NoError(t, handler.insertCache(db, c.Cache))
+		require.NoError(t, insertCache(db, c.Cache))
 	}
 	require.NoError(t, db.Close())
 

--- a/pkg/artifactcache/model.go
+++ b/pkg/artifactcache/model.go
@@ -1,10 +1,5 @@
 package artifactcache
 
-import (
-	"crypto/sha256"
-	"fmt"
-)
-
 type Request struct {
 	Key     string `json:"key" `
 	Version string `json:"version"`
@@ -29,16 +24,11 @@ func (c *Request) ToCache() *Cache {
 }
 
 type Cache struct {
-	ID             uint64 `json:"id" boltholdKey:"ID"`
-	Key            string `json:"key" boltholdIndex:"Key"`
-	Version        string `json:"version" boltholdIndex:"Version"`
-	KeyVersionHash string `json:"keyVersionHash" boltholdUnique:"KeyVersionHash"`
-	Size           int64  `json:"cacheSize"`
-	Complete       bool   `json:"complete"`
-	UsedAt         int64  `json:"usedAt" boltholdIndex:"UsedAt"`
-	CreatedAt      int64  `json:"createdAt" boltholdIndex:"CreatedAt"`
-}
-
-func (c *Cache) FillKeyVersionHash() {
-	c.KeyVersionHash = fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%s", c.Key, c.Version))))
+	ID        uint64 `json:"id" boltholdKey:"ID"`
+	Key       string `json:"key" boltholdIndex:"Key"`
+	Version   string `json:"version" boltholdIndex:"Version"`
+	Size      int64  `json:"cacheSize"`
+	Complete  bool   `json:"complete" boltholdIndex:"Complete"`
+	UsedAt    int64  `json:"usedAt" boltholdIndex:"UsedAt"`
+	CreatedAt int64  `json:"createdAt" boltholdIndex:"CreatedAt"`
 }

--- a/pkg/runner/testdata/networking/push.yml
+++ b/pkg/runner/testdata/networking/push.yml
@@ -7,8 +7,8 @@ jobs:
       - name: Install tools
         run: |
           apt update
-          apt install -y bind9-host
+          apt install -y iputils-ping
       - name: Run hostname test
         run: |
           hostname -f
-          host $(hostname -f)
+          ping -c 4 $(hostname -f)


### PR DESCRIPTION
In the old implementation, it assumes that there will be no duplicate uploads of caches with the same key.

But in fact, some actions like `actions/setup-go` will do something like:

1. Download the cache with the generated key.
2. Add more contents to the cache dir by downloading and building.
3. Upload the cache dir with the same key to replace the old cache.

It will result in a failure (though it will actually be ignored) with the following log:
```
/root/go/pkg/mod
/root/.cache/go-build
[command]/bin/tar --posix -cf cache.tgz --exclude cache.tgz -P -C /workspace/gitea/act_runner --files-from manifest.txt -z
::warning::Failed to save: {"error":"already exist"}
```

To support it, this PR introduces some changes.

- Uploading caches with same key (and the version which indicates the env) will be allowed.
- Return the latest completed one when retrieving a cache with a key.
- The old caches with the same key will be deleted regularly, keep the latest only.

I have tested the code with a custom act_runner. It works well and is compatible with old data.