### PR TITLE
Use ping to improve network test

### DIFF
--- a/pkg/runner/testdata/networking/push.yml
+++ b/pkg/runner/testdata/networking/push.yml
@@ -7,8 +7,8 @@ jobs:
       - name: Install tools
         run: |
           apt update
-          apt install -y bind9-host
+          apt install -y iputils-ping
       - name: Run hostname test
         run: |
           hostname -f
-          host $(hostname -f)
+          ping -c 4 $(hostname -f)


### PR DESCRIPTION
The `ping` command works well with mDNS, while the `host` command does not.

To avoid failed tests like:

```
2024-03-28T07:30:14.5399002Z [test network setup/test] [DEBUG] Working directory '/home/runner/work/act/act/pkg/runner/testdata'
2024-03-28T07:30:14.5399461Z [test network setup/test]   | fv-az1040-512.0dilqmdz4mhurinb4xzj4l1lvc.bx.internal.cloudapp.net
2024-03-28T07:30:14.5400024Z [test network setup/test]   | fv-az1040-512.0dilqmdz4mhurinb4xzj4l1lvc.bx.internal.cloudapp.net has address 10.1.0.90
2024-03-28T07:30:14.5400617Z [test network setup/test]   | Host fv-az1040-512.0dilqmdz4mhurinb4xzj4l1lvc.bx.internal.cloudapp.net not found: 3(NXDOMAIN)
2024-03-28T07:30:14.5400892Z [test network setup/test]   ❌  Failure - Main Run hostname test
2024-03-28T07:30:14.5401089Z [test network setup/test] exitcode '1': failure
2024-03-28T07:30:14.5401260Z [test network setup/test] 🏁  Job failed
```


