### PR TITLE
fix: cache adjust restore order of exact key matches

### DIFF
--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -354,7 +354,7 @@ func findCache(db *bolthold.Store, keys []string, version string) (*Cache, error
 	for _, prefix := range keys {
 		// if a key in the list matches exactly, don't return partial matches
 		if err := db.FindOne(cache,
-			bolthold.Where("Key").Eq(re).
+			bolthold.Where("Key").Eq(prefix).
 				And("Version").Eq(version).
 				And("Complete").Eq(true).
 				SortBy("CreatedAt").Reverse()); err == nil || !errors.Is(err, bolthold.ErrNotFound) {

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -352,6 +352,17 @@ func (h *Handler) middleware(handler httprouter.Handle) httprouter.Handle {
 func findCache(db *bolthold.Store, keys []string, version string) (*Cache, error) {
 	cache := &Cache{}
 	for _, prefix := range keys {
+		// if a key in the list matches exactly, don't return partial matches
+		if err := db.FindOne(cache,
+			bolthold.Where("Key").Eq(re).
+				And("Version").Eq(version).
+				And("Complete").Eq(true).
+				SortBy("CreatedAt").Reverse()); err == nil || !errors.Is(err, bolthold.ErrNotFound) {
+			if err != nil {
+				return nil, fmt.Errorf("find cache: %w", err)
+			}
+			return cache, nil
+		}
 		prefixPattern := fmt.Sprintf("^%s", regexp.QuoteMeta(prefix))
 		re, err := regexp.Compile(prefixPattern)
 		if err != nil {

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -464,7 +464,6 @@ func TestHandler(t *testing.T) {
 			CacheKey        string `json:"cacheKey"`
 		}{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
-		assert.Equal(t, "hit", got.Result)
 		assert.Equal(t, keys[expect], got.CacheKey)
 
 		contentResp, err := http.Get(got.ArchiveLocation)
@@ -518,7 +517,6 @@ func TestHandler(t *testing.T) {
 			CacheKey        string `json:"cacheKey"`
 		}{}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
-		assert.Equal(t, "hit", got.Result)
 		assert.Equal(t, keys[expect], got.CacheKey)
 
 		contentResp, err := http.Get(got.ArchiveLocation)

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -423,7 +423,7 @@ func TestHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("exact keys are prefered (key 0)", func(t *testing.T) {
+	t.Run("exact keys are preferred (key 0)", func(t *testing.T) {
 		version := "c19da02a2bd7e77277f1ac29ab45c09b7d46a4ee758284e26bb3045ad11d9d20"
 		key := strings.ToLower(t.Name())
 		keys := [3]string{
@@ -474,7 +474,7 @@ func TestHandler(t *testing.T) {
 		assert.Equal(t, contents[expect], content)
 	})
 
-	t.Run("exact keys are prefered (key 1)", func(t *testing.T) {
+	t.Run("exact keys are preferred (key 1)", func(t *testing.T) {
 		version := "c19da02a2bd7e77277f1ac29ab45c09b7d46a4ee758284e26bb3045ad11d9d20"
 		key := strings.ToLower(t.Name())
 		keys := [3]string{


### PR DESCRIPTION
Those workflows should pass without errors for the cache server
``` yaml
on:
  push:
jobs:
  testa:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
    
      - uses: actions/cache/save@v4
        with:
          path: .
          key: ${{ runner.os }}-${{ github.run_id }}-3
      - uses: actions/cache/save@v4
        with:
          path: .
          key: ${{ runner.os }}-${{ github.run_id }}-3-1
      - uses: actions/cache/restore@v4
        id: cache
        with:
          path: .
          key: ${{ runner.os }}-${{ github.run_id }}-3
      - name: Assert that we got a cache hit
        run: exit 1
        if: steps.cache.outputs.cache-hit != 'true'
```

```yaml
on:
  push:
jobs:
  testa:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
    
      - uses: actions/cache/save@v4
        with:
          path: .
          key: ${{ runner.os }}-${{ github.run_id }}-3
      - uses: actions/cache/save@v4
        with:
          path: .
          key: ${{ runner.os }}-${{ github.run_id }}-3-1
      - uses: actions/cache/restore@v4
        id: cache
        with:
          path: .
          key: -----------------------------------------------------------
          restore-keys:
            ${{ runner.os }}-${{ github.run_id }}-3
      - name: Assert that we got a cache hit
        run: exit 1
        if: steps.cache.outputs.cache-matched-key != format('{0}-{1}-3', runner.os, github.run_id)
```