### PR TITLE
feat: worklow: add `permissions` field

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -15,12 +15,13 @@ import (
 
 // Workflow is the structure of the files in .github/workflows
 type Workflow struct {
-	File     string
-	Name     string            `yaml:"name"`
-	RawOn    yaml.Node         `yaml:"on"`
-	Env      map[string]string `yaml:"env"`
-	Jobs     map[string]*Job   `yaml:"jobs"`
-	Defaults Defaults          `yaml:"defaults"`
+	File        string
+	Name        string            `yaml:"name"`
+	RawOn       yaml.Node         `yaml:"on"`
+	Env         map[string]string `yaml:"env"`
+	Jobs        map[string]*Job   `yaml:"jobs"`
+	Defaults    Defaults          `yaml:"defaults"`
+	Permissions map[string]string `yaml:"permissions"`
 }
 
 // On events for the workflow
@@ -172,6 +173,7 @@ type Job struct {
 	Outputs        map[string]string         `yaml:"outputs"`
 	Uses           string                    `yaml:"uses"`
 	With           map[string]interface{}    `yaml:"with"`
+	Permissions    map[string]string         `yaml:"permissions"`
 	RawSecrets     yaml.Node                 `yaml:"secrets"`
 	Result         string
 }


### PR DESCRIPTION
The `permissions` field can either be a top level key, or a per-job one. It supports a map of scope<>permission relations.
For example, to allow the jobs to write to the the packages registry, the following must be set:
```yaml
permissions:
  packages: write
```

this fixes that.
Right now, this field is not used/useful when running the actions locally, but can be used to handle permissions on forges that implement the same action format, such as Forgejo/Gitea.