### PR TITLE
add test for listartifacts v4 filter

### DIFF
--- a/pkg/artifacts/arifacts_v4.go
+++ b/pkg/artifacts/arifacts_v4.go
@@ -376,7 +376,7 @@ func (r *artifactV4Routes) listArtifacts(ctx *ArtifactContext) {
 
 	for _, entry := range entries {
 		id := artifactNameToID(entry.Name())
-		if (req.NameFilter == nil || req.NameFilter.Value == entry.Name()) || (req.IdFilter == nil || req.IdFilter.Value == id) {
+		if (req.NameFilter == nil || req.NameFilter.Value == entry.Name()) && (req.IdFilter == nil || req.IdFilter.Value == id) {
 			data := &ListArtifactsResponse_MonolithArtifact{
 				Name:                    entry.Name(),
 				CreatedAt:               timestamppb.Now(),

--- a/pkg/artifacts/arifacts_v4.go
+++ b/pkg/artifacts/arifacts_v4.go
@@ -121,9 +121,9 @@ type ArtifactContext struct {
 }
 
 func artifactNameToID(s string) int64 {
-	h := fnv.New64a()
+	h := fnv.New32a()
 	h.Write([]byte(s))
-	return int64(h.Sum64())
+	return int64(h.Sum32())
 }
 
 func (c ArtifactContext) Error(status int, _ ...interface{}) {

--- a/pkg/artifacts/testdata/v4/artifacts.yml
+++ b/pkg/artifacts/testdata/v4/artifacts.yml
@@ -73,7 +73,7 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: "test*"
+        pattern: "test*"
         path: out4
         merge-multiple: true
 

--- a/pkg/artifacts/testdata/v4/artifacts.yml
+++ b/pkg/artifacts/testdata/v4/artifacts.yml
@@ -59,3 +59,29 @@ jobs:
       run: |
         [[ "$(cat context.txt)" = "$(cat out2/context.txt)" ]] || exit 1
       shell: bash
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: test2
+        path: out3
+    - run: cat out3/data.txt
+
+    - name: assert 3
+      run: |
+        [[ "$(cat data.txt)" = "$(cat out3/data.txt)" ]] || exit 1
+      shell: bash
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: "test*"
+        path: out4
+        merge-multiple: true
+
+    - run: cat out4/data.txt
+    - run: cat out4/context.txt
+
+    - name: assert 4
+      run: |
+        [[ "$(cat context.txt)" = "$(cat out4/context.txt)" ]] || exit 1
+        [[ "$(cat data.txt)" = "$(cat out4/data.txt)" ]] || exit 1
+      shell: bash

--- a/pkg/artifacts/testdata/v4/artifacts.yml
+++ b/pkg/artifacts/testdata/v4/artifacts.yml
@@ -17,16 +17,29 @@ jobs:
         strategy:
         ${{ tojson(strategy) }}            
       shell: cp {0} context.txt
+    - run: echo Artifact2 > data.txt
+
     - uses: actions/upload-artifact@v4
       with:
         name: test
         path: context.txt
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: test2
+        path: data.txt
 
     - uses: actions/download-artifact@v4
       with:
         name: test
         path: out
     - run: cat out/context.txt
+
+    - name: assert
+      run: |
+        [[ "$(cat context.txt)" = "$(cat out/context.txt)" ]] || exit 1
+      shell: bash
+
     - run: |
         No content        
       shell: cp {0} context.txt
@@ -41,3 +54,8 @@ jobs:
         name: test
         path: out2
     - run: cat out2/context.txt
+
+    - name: assert 2
+      run: |
+        [[ "$(cat context.txt)" = "$(cat out2/context.txt)" ]] || exit 1
+      shell: bash


### PR DESCRIPTION
* fixes a defect of last change

I reviewed my own code today and saw `||` instead of `&&` resulting in broken artifact matching.

After fixing this I noticed that nodejs truncates the int64 ids so switch to 32bit that fitd in double.

Additionally added an actual test what this change should fix