### PR TITLE
fix: Only collect .yml or .yaml files as workflow much earlier

### DIFF
--- a/pkg/model/planner.go
+++ b/pkg/model/planner.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
GitHub Actions doesn't process non yaml files, since strict validation this doesn't make sense.