### PR TITLE
ci(run-tests): update actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -70,7 +70,7 @@ runs:
       env:
         FILTER: ${{ inputs.filter }}
         UPLOAD_LOGS: ${{ inputs.upload-logs }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always() && inputs.upload-logs == 'true' && !env.ACT
       with:
         name: ${{ inputs.upload-logs-name }}


### PR DESCRIPTION
For some reasons, Dependabot did not detect the `upload-artifact@v3` in PR #2133.

v3 of `actions/upload-artifact` and `actions/download-artifact` will be fully deprecated by **30 January 2025**. Jobs that are scheduled to run during the brownout periods will also fail. See:

1. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
2. https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/
3. https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#artifacts-v3-brownouts