### PR TITLE
Add NoProfile flag to PowerShell/Pwsh Call

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -625,7 +625,7 @@ func (s *Step) ShellCommand() string {
 			shellCommand = "bash --noprofile --norc -e -o pipefail {0}"
 		}
 	case "pwsh":
-		shellCommand = "pwsh -command . '{0}'"
+		shellCommand = "pwsh -NoProfile -command . '{0}'"
 	case "python":
 		shellCommand = "python {0}"
 	case "sh":
@@ -633,7 +633,7 @@ func (s *Step) ShellCommand() string {
 	case "cmd":
 		shellCommand = "cmd /D /E:ON /V:OFF /S /C \"CALL \"{0}\"\""
 	case "powershell":
-		shellCommand = "powershell -command . '{0}'"
+		shellCommand = "powershell -NoProfile -command . '{0}'"
 	default:
 		shellCommand = s.Shell
 	}


### PR DESCRIPTION
This is a known best practice when launching build commands. While this is not necessary for a container, it does issues when the platform is `-self-hosted`.

Fixes #2545