### PR TITLE
fix: install into `usr/local/bin`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ usage() {
 $this: download go binaries for nektos/act
 
 Usage: $this [-b bindir] [-d] [-f] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to /usr/local/bin
   -d turns on debug logging
   -f forces installation, bypassing version checks
    [tag] is a tag from
@@ -21,10 +21,10 @@ EOF
 }
 
 parse_args() {
-  #BINDIR is ./bin unless set be ENV
+  # BINDIR is /usr/local/bin unless set by ENV
   # over-ridden by flag below
 
-  BINDIR=${BINDIR:-./bin}
+  BINDIR=${BINDIR:-/usr/local/bin}
   while getopts "b:dfh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;


### PR DESCRIPTION
Fixes https://github.com/nektos/act/issues/2519

act install script by default installs binaries to `./bin` and doesn't explain this in the docs, this change was made in https://github.com/nektos/act/pull/937 with a some other changes and has been referenced [here](https://github.com/nektos/act/issues/1368) with no explanation for why this was made so I'd like to assume it wasn't intentional and was overlooked