### PR TITLE
When debug is enabled, all loggers set report caller to true

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -352,6 +352,9 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		if input.jsonLogger {
 			log.SetFormatter(&log.JSONFormatter{})
 		}
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.SetReportCaller(true)
+		}
 
 		if ok, _ := cmd.Flags().GetBool("bug-report"); ok {
 			return bugReport(ctx, cmd.Version)

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -96,6 +96,8 @@ func WithJobLogger(ctx context.Context, jobID string, jobName string, config *Co
 		logger.SetFormatter(formatter)
 	}
 
+	// If the main logger is reporting caller, this inner one should too
+	logger.SetReportCaller(logrus.StandardLogger().ReportCaller)
 	logger.SetFormatter(&maskedFormatter{
 		Formatter: logger.Formatter,
 		masker:    valueMasker(config.InsecureSecrets, config.Secrets),


### PR DESCRIPTION
This change is only to improve debugging visibility by enabling logrus `SetReportCaller` when the logger is set to debug level (verbose) - Bear in mind that because there's a specific formatter when in text mode, the report caller fields will only be visible in all loggers when the JSON logger is enabled too.

## Why this change

This change is a side effect of https://github.com/nektos/act/issues/2609 in which @ChristopherHX challenged that the error of not showing why this is happening belongs to Gitea Act runner and not Nektos Act.  I think he's right, but because of how thin the logging is it is tough to understand where the error is being reported, hence I introduced this change (disabled by default in normal operations) to simplify the work of debugging by dumping which line is the one called when something is being logged.

Logs look like this when this is enabled:

```json
{"file":"/home/pcarranza/go/src/github.com/pcarranza/act/pkg/container/docker_socket.go:63","func":"github.com/nektos/act/pkg/container.GetSocketAndHost","level":"debug","msg":"Handling container host and socket","time":"2025-01-26T12:31:33+01:00"}
{"file":"/home/pcarranza/go/src/github.com/pcarranza/act/pkg/container/docker_socket.go:99","func":"github.com/nektos/act/pkg/container.GetSocketAndHost","level":"debug","msg":"Defaulting container socket to DOCKER_HOST","time":"2025-01-26T12:31:33+01:00"}
```

Then

```json
{"dryrun":false,"file":"/home/pcarranza/go/src/github.com/pcarranza/act/pkg/common/executor.go:38","func":"github.com/nektos/act/pkg/container.(*containerReference).Exec.NewInfoExecutor.func1","job":"testing/monolith","jobID":"monolith","level":"info","matrix":{},"msg":"  🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/docker-login-action@v3/dist/index.js] user= workdir=","stage":"Main","step":"Login to GitLab Registry","stepID":["0"],"time":"2025-01-26T12:31:38+01:00"}
```

Greatly simplifying following what is being called when from where.