### PR TITLE
Use gh auth token for default GITHUB_TOKEN secret

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nektos/act/pkg/artifacts"
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
+	"github.com/nektos/act/pkg/gh"
 	"github.com/nektos/act/pkg/model"
 	"github.com/nektos/act/pkg/runner"
 )
@@ -412,6 +413,15 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		log.Debugf("Loading secrets from %s", input.Secretfile())
 		secrets := newSecrets(input.secrets)
 		_ = readEnvs(input.Secretfile(), secrets)
+		hasGitHubToken := false
+		for k := range secrets {
+			if strings.EqualFold(k, "GITHUB_TOKEN") {
+				hasGitHubToken = true
+			}
+		}
+		if !hasGitHubToken {
+			secrets["GITHUB_TOKEN"], _ = gh.GetToken(ctx, "")
+		}
 
 		log.Debugf("Loading vars from %s", input.Varfile())
 		vars := newSecrets(input.vars)

--- a/pkg/gh/gh.go
+++ b/pkg/gh/gh.go
@@ -1,0 +1,40 @@
+package gh
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"os/exec"
+)
+
+func GetToken(ctx context.Context, workingDirectory string) (string, error) {
+	var token string
+
+	// Locate the 'gh' executable
+	path, err := exec.LookPath("gh")
+	if err != nil {
+		return "", err
+	}
+
+	// Command setup
+	cmd := exec.CommandContext(ctx, path, "auth", "token")
+	cmd.Dir = workingDirectory
+
+	// Capture the output
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	// Run the command
+	err = cmd.Run()
+	if err != nil {
+		return "", err
+	}
+
+	// Read the first line of the output
+	scanner := bufio.NewScanner(&out)
+	if scanner.Scan() {
+		token = scanner.Text()
+	}
+
+	return token, nil
+}

--- a/pkg/gh/gh_test.go
+++ b/pkg/gh/gh_test.go
@@ -1,0 +1,11 @@
+package gh
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetToken(t *testing.T) {
+	token, _ := GetToken(context.TODO(), "")
+	t.Log(token)
+}


### PR DESCRIPTION
* initial version

Closes https://github.com/nektos/gh-act/issues/8

The readEnvs function should be rewritten to apply ToUpper for the secrets keys (not for env variables) like for newSecrets so the following can get refactored to just check for `GITHUB_TOKEN`
```go
		hasGitHubToken := false
		for k := range secrets {
			if strings.EqualFold(k, "GITHUB_TOKEN") {
				hasGitHubToken = true
			}
		}
```

I considered to not make this conditionally and skipped the ghes auto detection. Now act will always have a `${{ github.token }}` value if `gh` is installed and authenticated.