### PR TITLE
chore: move to environment secrets

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          check-latest: true
       - uses: golangci/golangci-lint-action@v6.2.0
         with:
           version: v1.62
@@ -45,18 +44,13 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          check-latest: true
-      - uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Install gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
       - name: Run Tests
-        run: go test -json -v -cover -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -timeout 20m ./... | gotestfmt -hide successful-packages,empty-packages 2>&1
+        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname -- -v -cover -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -timeout 20m ./...
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "unit-tests.xml"
+        if: always()
       - name: Run act from cli
         run: go run main.go -P ubuntu-latest=node:16-buster-slim -C ./pkg/runner/testdata/ -W ./basic/push.yml
       - name: Run act from cli without docker support
@@ -83,12 +77,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          check-latest: true
-      - name: Install gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
       - name: Run Tests
-        run: go test -v -cover -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -timeout 20m -run ^TestRunEventHostEnvironment$ ./...
+        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname -- -v -cover -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -timeout 20m -run ^TestRunEventHostEnvironment$ ./...
         shell: bash
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "unit-tests.xml"
+        if: always()
 
 
   snapshot:
@@ -99,14 +95,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          check-latest: true
-      - uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -8,6 +8,7 @@ jobs:
   release:
     name: promote
     runs-on: ubuntu-latest
+    environment: promote
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,12 +19,4 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          check-latest: true
-      - uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - run: make promote

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,10 +4,6 @@ on:
     - cron: '0 2 1 * *'
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-  actions: write
-
 jobs:
   release:
     name: promote
@@ -17,6 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
+          token: ${{ secrets.RELEASE_TOKEN }}
       - uses: fregante/setup-git-user@v2
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.PROMOTE_TOKEN }}
       - uses: fregante/setup-git-user@v2
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,6 +4,10 @@ on:
     - cron: '0 2 1 * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
   release:
     name: promote
@@ -13,7 +17,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
-          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
       - uses: fregante/setup-git-user@v2
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          check-latest: true
-      - uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,7 +30,7 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Winget
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
@@ -45,7 +46,7 @@ jobs:
       - name: GitHub CLI extension
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_ACT_TOKEN }}
           script: |
             const mainRef = (await github.rest.git.getRef({
               owner: 'nektos',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
   release:
     name: release

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pkg/runner/act/
 dist/local/act
 
 coverage.txt
+unit-tests.xml
 
 .env
 .secrets


### PR DESCRIPTION
* Remove `GORELEASER_GITHUB_TOKEN` secret. Instead, use the `GITHUB_TOKEN` to manage releases by adding permissions to the token
* Use new `GH_ACT_TOKEN` secret defined in the `release` environment. This is a fine grained token with access to the nektos/gh-act repo only
