### PR TITLE
Index entries in action cache directory by SHA

### DIFF
--- a/pkg/runner/reusable_workflow.go
+++ b/pkg/runner/reusable_workflow.go
@@ -31,7 +31,13 @@ func newRemoteReusableWorkflowExecutor(rc *RunContext) common.Executor {
 	// uses with safe filename makes the target directory look something like this {owner}-{repo}-.github-workflows-{filename}@{ref}
 	// instead we will just use {owner}-{repo}@{ref} as our target directory. This should also improve performance when we are using
 	// multiple reusable workflows from the same repository and ref since for each workflow we won't have to clone it again
-	filename := fmt.Sprintf("%s/%s@%s", remoteReusableWorkflow.Org, remoteReusableWorkflow.Repo, remoteReusableWorkflow.Ref)
+	sha, err := git.GetShaForRefInRemote(remoteReusableWorkflow.Ref, fmt.Sprintf("%s.git", remoteReusableWorkflow.CloneURL()))
+
+	if err != nil {
+		return common.NewErrorExecutor(fmt.Errorf("%s", err))
+	}
+
+	filename := fmt.Sprintf("%s/%s@%s", remoteReusableWorkflow.Org, remoteReusableWorkflow.Repo, sha)
 	workflowDir := fmt.Sprintf("%s/%s", rc.ActionCacheDir(), safeFilename(filename))
 
 	if rc.Config.ActionCache != nil {

--- a/pkg/runner/reusable_workflow.go
+++ b/pkg/runner/reusable_workflow.go
@@ -31,7 +31,7 @@ func newRemoteReusableWorkflowExecutor(rc *RunContext) common.Executor {
 	// uses with safe filename makes the target directory look something like this {owner}-{repo}-.github-workflows-{filename}@{ref}
 	// instead we will just use {owner}-{repo}@{ref} as our target directory. This should also improve performance when we are using
 	// multiple reusable workflows from the same repository and ref since for each workflow we won't have to clone it again
-	sha, err := git.GetShaForRefInRemote(remoteReusableWorkflow.Ref, fmt.Sprintf("%s.git", remoteReusableWorkflow.CloneURL()))
+	sha, err := git.GetShaForRefInRemote(&git.GetShaForRefInRemoteInput{Ref: remoteReusableWorkflow.Ref, URL: fmt.Sprintf("%s.git", remoteReusableWorkflow.CloneURL()), Token: rc.Config.Token})
 
 	if err != nil {
 		return common.NewErrorExecutor(fmt.Errorf("%s", err))


### PR DESCRIPTION
Previously they were indexed by ref name, which could be a SHA or a tag/branch name, but if a branch name was used and that branch was updated, the new reusable workflow action wouldn't be pulled.

This meant the user would have to delete the associated cache entry to be able to use the new version of the reusable workflow. If the user really wants stability, they should specify the reusable workflow by
SHA instead of by branch name/tag.

Ready to merge on my side.
