### PR TITLE
chore: Group DependableBot Updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,23 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+    groups:
+      dependencies:
+        patterns:
+        - '*'
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+    groups:
+      dependencies:
+        patterns:
+        - '*'


### PR DESCRIPTION
* run only 12 times per year (the cron job for releases might need adjustments)
* group as much as possible
* reduce merge conflicts by running less often

I am going to evaluate this change in my fork, what do you think?

This should free my inbox a lot.