### PR TITLE
Update .gitleaksignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,2 @@
 b910a42edfab7a02b08a52ecef203fd419725642:pkg/container/testdata/docker-pull-options/config.json:generic-api-key:4
+710a3ac94c3dc0eaf680d417c87f37f92b4887f4:pkg/container/docker_pull_test.go:generic-api-key:45


### PR DESCRIPTION
* megalinter update makes REDACTED fail gitleaks

Resolves CI failure of https://github.com/nektos/act/pull/2674