### PR TITLE
feat: GoGitActionCache shallow fetch

### DIFF
--- a/pkg/runner/action_cache.go
+++ b/pkg/runner/action_cache.go
@@ -77,6 +77,7 @@ func (c GoGitActionCache) Fetch(ctx context.Context, cacheDir, url, ref, token s
 		},
 		Auth:  auth,
 		Force: true,
+		Depth: 1,
 	}); err != nil {
 		return "", fmt.Errorf("GoGitActionCache failed to fetch %s with ref %s at %s: %w", url, ref, gitPath, err)
 	}


### PR DESCRIPTION
* speed up cloning iff feature flag is on, should not have any negative impact

Related to <https://github.com/nektos/act/issues/2672>, but not fixing this as this code here is disabled