### PR TITLE
docs: Remove Gitter

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,12 +3,6 @@ contact_links:
   - name: Start a discussion
     url: https://github.com/nektos/act/discussions/new
     about: You can ask for help here!
-  - name: Ask on Gitter
-    url: https://gitter.im/nektos/act
-    about: You can ask for help here!
-  - name: Ask on Gitter (via Matrix)
-    url: https://matrix.to/#/#nektos_act:gitter.im?via=gitter.im&via=matrix.org
-    about: If you prefer Matrix over Gitter
   - name: Want to contribute to act?
     url: https://github.com/nektos/act/blob/master/CONTRIBUTING.md
     about: Be sure to read contributing guidelines!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Help wanted! We'd love your contributions to Act. Please review the following gu
 
 ## <a id="questions"></a> Have a Question?
 
-Please don't open a GitHub issue for questions about how to use `act`, as the goal is to use issues for managing bugs and feature requests. Issues that are related to general support will be closed and redirected to our gitter room.
+Please don't open a GitHub issue for questions about how to use `act`, as the goal is to use issues for managing bugs and feature requests. Issues that are related to general support will be closed and redirected to [discussions](https://github.com/nektos/act/discussions).
 
-For all support related questions, please ask the question in our gitter room: [nektos/act](https://gitter.im/nektos/act).
+For all support related questions, please [open a discussion post](https://github.com/nektos/act/discussions/new/choose).
 
 ## <a id="bugs"></a> Found a Bug?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![act-logo](https://raw.githubusercontent.com/wiki/nektos/act/img/logo-150.png)
 
-# Overview [![push](https://github.com/nektos/act/workflows/push/badge.svg?branch=master&event=push)](https://github.com/nektos/act/actions) [![Join the chat at https://gitter.im/nektos/act](https://badges.gitter.im/nektos/act.svg)](https://gitter.im/nektos/act?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Go Report Card](https://goreportcard.com/badge/github.com/nektos/act)](https://goreportcard.com/report/github.com/nektos/act) [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
+# Overview [![push](https://github.com/nektos/act/workflows/push/badge.svg?branch=master&event=push)](https://github.com/nektos/act/actions) [![Go Report Card](https://goreportcard.com/badge/github.com/nektos/act)](https://goreportcard.com/report/github.com/nektos/act) [![awesome-runners](https://img.shields.io/badge/listed%20on-awesome--runners-blue.svg)](https://github.com/jonico/awesome-runners)
 
 > "Think globally, `act` locally"
 
@@ -27,7 +27,7 @@ Please look at the [act user guide](https://nektosact.com) for more documentatio
 
 # Support
 
-Need help? Ask on [Gitter](https://gitter.im/nektos/act)!
+Need help? Ask in [discussions](https://github.com/nektos/act/discussions)!
 
 # Contributing
 


### PR DESCRIPTION
Remove Gitter (which is now hosted on Matrix) since it's been abandoned for way too long