### PR TITLE
removes arbitrary whites before unicode char/emojis

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -413,7 +413,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 				DisableQuote:     true,
 				DisableTimestamp: true,
 			})
-			l.Warnf(" \U000026A0 You are using Apple M-series chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'. \U000026A0 \n")
+			l.Warnf("\U000026a0 You are using Apple M-series chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'.\U000026a0 \n")
 		}
 
 		log.Debugf("Loading environment from %s", input.Envfile())

--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -300,7 +300,7 @@ func gitOptions(token string) (fetchOptions git.FetchOptions, pullOptions git.Pu
 func NewGitCloneExecutor(input NewGitCloneExecutorInput) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
-		logger.Infof("  \u2601  git clone '%s' # ref=%s", input.URL, input.Ref)
+		logger.Infof("\U00002601  git clone '%s' # ref=%s", input.URL, input.Ref)
 		logger.Debugf("  cloning %s to %s", input.URL, input.Dir)
 
 		cloneLock.Lock()

--- a/pkg/container/docker_logger.go
+++ b/pkg/container/docker_logger.go
@@ -22,7 +22,7 @@ type dockerMessage struct {
 	Progress string `json:"progress"`
 }
 
-const logPrefix = "  \U0001F433  "
+const logPrefix = "\U0001F433 "
 
 func logDockerResponse(logger logrus.FieldLogger, dockerResponse io.ReadCloser, isError bool) error {
 	if dockerResponse == nil {

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -41,7 +41,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		}
 
 		if resumeCommand != "" && command != resumeCommand {
-			logger.Infof("  \U00002699  %s", line)
+			logger.Infof("\U00002699  %s", line)
 			return false
 		}
 		arg = unescapeCommandData(arg)
@@ -54,27 +54,27 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		case "add-path":
 			rc.addPath(ctx, arg)
 		case "debug":
-			logger.Debugf("  \U0001F4AC  %s", line)
+			logger.Debugf("\U0001f4ac  %s", line)
 		case "warning":
-			logger.Warnf("  \U0001F6A7  %s", line)
+			logger.Warnf("\U0001f6a7  %s", line)
 		case "error":
-			logger.Errorf("  \U00002757  %s", line)
+			logger.Errorf("\U00002757  %s", line)
 		case "add-mask":
 			rc.AddMask(arg)
-			logger.Infof("  \U00002699  %s", "***")
+			logger.Infof("\U00002699  %s", "***")
 		case "stop-commands":
 			resumeCommand = arg
-			logger.Infof("  \U00002699  %s", line)
+			logger.Infof("\U00002699  %s", line)
 		case resumeCommand:
 			resumeCommand = ""
-			logger.Infof("  \U00002699  %s", line)
+			logger.Infof("\U00002699  %s", line)
 		case "save-state":
-			logger.Infof("  \U0001f4be  %s", line)
+			logger.Infof("\U0001f4be  %s", line)
 			rc.saveState(ctx, kvPairs, arg)
 		case "add-matcher":
-			logger.Infof("  \U00002753 add-matcher %s", arg)
+			logger.Infof("\U00002753 add-matcher %s", arg)
 		default:
-			logger.Infof("  \U00002753  %s", line)
+			logger.Infof("\U00002753  %s", line)
 		}
 
 		return false
@@ -83,7 +83,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 
 func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg string) {
 	name := kvPairs["name"]
-	common.Logger(ctx).Infof("  \U00002699  ::set-env:: %s=%s", name, arg)
+	common.Logger(ctx).Infof("\U00002699  ::set-env:: %s=%s", name, arg)
 	if rc.Env == nil {
 		rc.Env = make(map[string]string)
 	}
@@ -111,15 +111,15 @@ func (rc *RunContext) setOutput(ctx context.Context, kvPairs map[string]string, 
 
 	result, ok := rc.StepResults[stepID]
 	if !ok {
-		logger.Infof("  \U00002757  no outputs used step '%s'", stepID)
+		logger.Infof("\U00002757  no outputs used step '%s'", stepID)
 		return
 	}
 
-	logger.Infof("  \U00002699  ::set-output:: %s=%s", outputName, arg)
+	logger.Infof("\U00002699  ::set-output:: %s=%s", outputName, arg)
 	result.Outputs[outputName] = arg
 }
 func (rc *RunContext) addPath(ctx context.Context, arg string) {
-	common.Logger(ctx).Infof("  \U00002699  ::add-path:: %s", arg)
+	common.Logger(ctx).Infof("\U00002699  ::add-path:: %s", arg)
 	extraPath := []string{arg}
 	for _, v := range rc.ExtraPath {
 		if v != arg {

--- a/pkg/runner/command_test.go
+++ b/pkg/runner/command_test.go
@@ -89,7 +89,7 @@ func TestStopCommands(t *testing.T) {
 		messages = append(messages, entry.Message)
 	}
 
-	a.Contains(messages, "  \U00002699  ::set-env name=x::abcd\n")
+	a.Contains(messages, "\U00002699  ::set-env name=x::abcd\n")
 }
 
 func TestAddpathADO(t *testing.T) {
@@ -116,8 +116,8 @@ func TestAddmask(t *testing.T) {
 	handler := rc.commandHandler(loggerCtx)
 	handler("::add-mask::my-secret-value\n")
 
-	a.Equal("  \U00002699  ***", hook.LastEntry().Message)
-	a.NotEqual("  \U00002699  *my-secret-value", hook.LastEntry().Message)
+	a.Equal("\U00002699  ***", hook.LastEntry().Message)
+	a.NotEqual("\U00002699  *my-secret-value", hook.LastEntry().Message)
 }
 
 // based on https://stackoverflow.com/a/10476304
@@ -171,7 +171,7 @@ func TestAddmaskUsemask(t *testing.T) {
 		handler("::set-output:: token=secret\n")
 	})
 
-	a.Equal("[testjob]   \U00002699  ***\n[testjob]   \U00002699  ::set-output:: = token=***\n", re)
+	a.Equal("[testjob]\U00002699  ***\n[testjob]\U00002699  ::set-output:: = token=***\n", re)
 }
 
 func TestSaveState(t *testing.T) {

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -103,7 +103,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			defer cancel()
 
 			logger := common.Logger(ctx)
-			logger.Infof("Cleaning up container for job %s", rc.JobName)
+			logger.Infof("\U0001f9f9 Cleaning up container for job %s", rc.JobName)
 			if err = info.stopContainer()(ctx); err != nil {
 				logger.Errorf("Error while stop job container: %v", err)
 			}
@@ -129,9 +129,9 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 
 	return common.NewPipelineExecutor(
 		common.NewFieldExecutor("step", "Set up job", common.NewFieldExecutor("stepid", []string{"--setup-job"},
-			common.NewPipelineExecutor(common.NewInfoExecutor("\u2B50 Run Set up job"), info.startContainer(), rc.InitializeNodeTool()).
-				Then(common.NewFieldExecutor("stepResult", model.StepStatusSuccess, common.NewInfoExecutor("  \u2705  Success - Set up job"))).
-				OnError(common.NewFieldExecutor("stepResult", model.StepStatusFailure, common.NewInfoExecutor("  \u274C  Failure - Set up job")).ThenError(setJobError)))),
+			common.NewPipelineExecutor(common.NewInfoExecutor("\U00002B50 Run Set up job"), info.startContainer(), rc.InitializeNodeTool()).
+				Then(common.NewFieldExecutor("stepResult", model.StepStatusSuccess, common.NewInfoExecutor("\U00002705 Success - Set up job"))).
+				OnError(common.NewFieldExecutor("stepResult", model.StepStatusFailure, common.NewInfoExecutor("\U0000274C Failure - Set up job")).ThenError(setJobError)))),
 		common.NewPipelineExecutor(pipeline...).
 			Finally(func(ctx context.Context) error { //nolint:contextcheck
 				var cancel context.CancelFunc
@@ -144,11 +144,11 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 				return postExecutor(ctx)
 			}).
 			Finally(common.NewFieldExecutor("step", "Complete job", common.NewFieldExecutor("stepid", []string{"--complete-job"},
-				common.NewInfoExecutor("\u2B50 Run Complete job").
+				common.NewInfoExecutor("\U00002B50 Run Complete job").
 					Finally(stopContainerExecutor).
 					Finally(
-						info.interpolateOutputs().Finally(info.closeContainer()).Then(common.NewFieldExecutor("stepResult", model.StepStatusSuccess, common.NewInfoExecutor("  \u2705  Success - Complete job"))).
-							OnError(common.NewFieldExecutor("stepResult", model.StepStatusFailure, common.NewInfoExecutor("  \u274C  Failure - Complete job"))),
+						info.interpolateOutputs().Finally(info.closeContainer()).Then(common.NewFieldExecutor("stepResult", model.StepStatusSuccess, common.NewInfoExecutor("\U00002705 Success - Complete job"))).
+							OnError(common.NewFieldExecutor("stepResult", model.StepStatusFailure, common.NewInfoExecutor("\U0000274C Failure - Complete job"))),
 					)))).Finally(setJobResultExecutor))
 }
 
@@ -177,7 +177,7 @@ func setJobResult(ctx context.Context, info jobInfo, rc *RunContext, success boo
 		jobResultMessage = "failed"
 	}
 
-	logger.WithField("jobResult", jobResult).Infof("\U0001F3C1  Job %s", jobResultMessage)
+	logger.WithField("jobResult", jobResult).Infof("\U0001F3C1 Job %s", jobResultMessage)
 }
 
 func setJobOutputs(ctx context.Context, rc *RunContext) {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -262,7 +262,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			return fmt.Errorf("failed to handle credentials: %s", err)
 		}
 
-		logger.Infof("\U0001f680  Start image=%s", image)
+		logger.Infof("\U0001f680 Start image=%s", image)
 		name := rc.jobContainerName()
 
 		envList := make([]string, 0)
@@ -353,7 +353,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 					Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName()+"-env", false)).IfNot(reuseJobContainer).
 					Then(func(ctx context.Context) error {
 						if len(rc.ServiceContainers) > 0 {
-							logger.Infof("Cleaning up services for job %s", rc.JobName)
+							logger.Infof("\U0001f9f9 Cleaning up services for job %s", rc.JobName)
 							if err := rc.stopServiceContainers()(ctx); err != nil {
 								logger.Errorf("Error while cleaning services: %v", err)
 							}
@@ -362,7 +362,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 								// if using service containers
 								// it means that the network to which containers are connecting is created by `act_runner`,
 								// so, we should remove the network at last.
-								logger.Infof("Cleaning up network for job %s, and network name is: %s", rc.JobName, networkName)
+								logger.Infof("\U0001f9f9 Cleaning up network for job %s, and network name is: %s", rc.JobName, networkName)
 								if err := container.NewDockerNetworkRemoveExecutor(networkName)(ctx); err != nil {
 									logger.Errorf("Error while cleaning network: %v", err)
 								}
@@ -783,7 +783,7 @@ func (rc *RunContext) isEnabled(ctx context.Context) (bool, error) {
 	jobType, jobTypeErr := job.Type()
 
 	if runJobErr != nil {
-		return false, fmt.Errorf("  \u274C  Error in if-expression: \"if: %s\" (%s)", job.If.Value, runJobErr)
+		return false, fmt.Errorf("\U0000274C  Error in if-expression: \"if: %s\" (%s)", job.If.Value, runJobErr)
 	}
 
 	if jobType == model.JobTypeInvalid {

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -102,7 +102,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		if strings.Contains(stepString, "::add-mask::") {
 			stepString = "add-mask command"
 		}
-		logger.Infof("\u2B50 Run %s %s", stage, stepString)
+		logger.Infof("\U00002B50 Run %s %s", stage, stepString)
 
 		// Prepare and clean Runner File Commands
 		actPath := rc.JobContainer.GetActPath()
@@ -144,7 +144,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		err = executor(timeoutctx)
 
 		if err == nil {
-			logger.WithField("stepResult", stepResult.Outcome).Infof("  \u2705  Success - %s %s", stage, stepString)
+			logger.WithField("stepResult", stepResult.Outcome).Infof("\U00002705 Success - %s %s", stage, stepString)
 		} else {
 			stepResult.Outcome = model.StepStatusFailure
 
@@ -162,7 +162,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 				stepResult.Conclusion = model.StepStatusFailure
 			}
 
-			logger.WithField("stepResult", stepResult.Outcome).Errorf("  \u274C  Failure - %s %s", stage, stepString)
+			logger.WithField("stepResult", stepResult.Outcome).Errorf("\U0000274C Failure - %s %s", stage, stepString)
 		}
 		// Process Runner File Commands
 		orgerr := err
@@ -263,7 +263,7 @@ func isStepEnabled(ctx context.Context, expr string, step step, stage stepStage)
 
 	runStep, err := EvalBool(ctx, rc.NewStepExpressionEvaluatorExt(ctx, step, stage == stepStageMain), expr, defaultStatusCheck)
 	if err != nil {
-		return false, fmt.Errorf("  \u274C  Error in if-expression: \"if: %s\" (%s)", expr, err)
+		return false, fmt.Errorf("\U0000274C  Error in if-expression: \"if: %s\" (%s)", expr, err)
 	}
 
 	return runStep, nil
@@ -279,7 +279,7 @@ func isContinueOnError(ctx context.Context, expr string, step step, _ stepStage)
 
 	continueOnError, err := EvalBool(ctx, rc.NewStepExpressionEvaluator(ctx, step), expr, exprparser.DefaultStatusCheckNone)
 	if err != nil {
-		return false, fmt.Errorf("  \u274C  Error in continue-on-error-expression: \"continue-on-error: %s\" (%s)", expr, err)
+		return false, fmt.Errorf("\U0000274C  Error in continue-on-error-expression: \"continue-on-error: %s\" (%s)", expr, err)
 	}
 
 	return continueOnError, nil


### PR DESCRIPTION
there's inconsistent usage of whitespace before and after emoji usage in log messages making the output excessively messy and messages misaligned.

this a bandaid fix as I could prob refactor the logger to use a standard convention so whitespace isn't hardcoded but for the time being this would be a welcome partial fix

Before fix output example:
![act-whitespace-example-before](https://github.com/user-attachments/assets/49321bdf-798d-4905-b0df-8c017a7bad0c)


After fix output example:
![act-whitespace-example-after](https://github.com/user-attachments/assets/e1dd0e05-ed6c-4662-b2a7-2e9f2ff213ba)
