### PR TITLE
chore: mergify and codeowners do not request review

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,22 +43,6 @@ pull_request_rules:
       label:
         remove:
           - needs-work
-  - name: Automatic maintainer assignment
-    conditions:
-      - '-approved-reviews-by=@nektos/act-maintainers'
-      - -draft
-      - -merged
-      - -closed
-      - -conflict
-      - check-success=lint
-      - check-success=test-linux
-      - check-success=codecov/patch
-      - check-success=codecov/project
-      - check-success=snapshot
-    actions:
-      request_reviews:
-        teams:
-          - '@nektos/act-maintainers'
   - name: Automatic merge on approval
     conditions: []
     actions:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @nektos/act-maintainers


### PR DESCRIPTION
* this makes it hard to notice manual mentioning
* CODEOWNERS file is another cause, removing it (workaround need admin rights)

See internal discussions