### PR TITLE
feat: add --completion flag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,11 @@ linters-settings:
             desc: Please keep tests unified using only github.com/stretchr/testify
           - pkg: log
             desc: Please keep logging unified using only github.com/sirupsen/logrus
+  revive:
+    rules:
+      - name: unused-parameter
+        arguments:
+          - allowRegex: "^_"
 linters:
   enable:
     - gosimple

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,14 @@ func createRootCommand(ctx context.Context, input *Input, version string) *cobra
 		SilenceUsage:      true,
 	}
 
+	rootCmd.Flags().StringP("completion", "", "", "Generate shell completion script for [bash|zsh|fish|powershell]")
+	err := rootCmd.RegisterFlagCompletionFunc("completion", func(_cmd *cobra.Command, _args []string, _toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"bash", "zsh", "fish", "powershell"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	rootCmd.Flags().BoolP("watch", "w", false, "watch the contents of the local repo and run when files change")
 	rootCmd.Flags().BoolP("list", "l", false, "list workflows")
 	rootCmd.Flags().BoolP("graph", "g", false, "draw workflows")
@@ -262,6 +270,24 @@ func generateManPage(cmd *cobra.Command) error {
 	return nil
 }
 
+func generateCompletion(cmd *cobra.Command, shell string) error {
+	if shell == "" {
+		return fmt.Errorf("shell is required (bash|zsh|fish|powershell)")
+	}
+	switch shell {
+	case "bash":
+		return cmd.Root().GenBashCompletion(os.Stdout)
+	case "zsh":
+		return cmd.Root().GenZshCompletion(os.Stdout)
+	case "fish":
+		return cmd.Root().GenFishCompletion(os.Stdout, true)
+	case "powershell":
+		return cmd.Root().GenPowerShellCompletion(os.Stdout)
+	default:
+		return fmt.Errorf("unsupported shell: %s, supported shells are: bash, zsh, fish, powershell", shell)
+	}
+}
+
 func listOptions(cmd *cobra.Command) error {
 	flags := []Flag{}
 	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
@@ -395,6 +421,10 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		}
 		if ok, _ := cmd.Flags().GetBool("man-page"); ok {
 			return generateManPage(cmd)
+		}
+		shell, err := cmd.Flags().GetString("completion")
+		if err == nil {
+			return generateCompletion(cmd, shell)
 		}
 		if input.listOptions {
 			return listOptions(cmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,9 @@ func createRootCommand(ctx context.Context, input *Input, version string) *cobra
 		PersistentPostRun: cleanup(input),
 		Version:           version,
 		SilenceUsage:      true,
+		ValidArgsFunction: func(_cmd *cobra.Command, _args []string, _toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 
 	rootCmd.Flags().StringP("completion", "", "", "Generate shell completion script for [bash|zsh|fish|powershell]")


### PR DESCRIPTION
adds a --completion flag to generate shell completion scripts builtin to
cobra. this includes completion for the --completion flag itself.

also allows for unused variables to be prefixed with an underscore instead of _only_ allowed to be `_` and disallows files as completion
