### PR TITLE
Report the elapsed time for each workflow step

### DIFF
--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
+	"github.com/sirupsen/logrus"
 )
 
 type step interface {
@@ -141,10 +142,12 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 
 		timeoutctx, cancelTimeOut := evaluateStepTimeout(ctx, rc.ExprEval, stepModel)
 		defer cancelTimeOut()
+		startTime := time.Now()
 		err = executor(timeoutctx)
+		executionTime := time.Since(startTime)
 
 		if err == nil {
-			logger.WithField("stepResult", stepResult.Outcome).Infof("  \u2705  Success - %s %s", stage, stepString)
+			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u2705  Success - %s %s [%s]", stage, stepString, executionTime)
 		} else {
 			stepResult.Outcome = model.StepStatusFailure
 

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -165,7 +165,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 				stepResult.Conclusion = model.StepStatusFailure
 			}
 
-			logger.WithField("stepResult", stepResult.Outcome).Errorf("  \u274C  Failure - %s %s", stage, stepString)
+			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u274C  Failure - %s %s [%s]", stage, stepString, executionTime)
 		}
 		// Process Runner File Commands
 		orgerr := err


### PR DESCRIPTION
The `runStepExecutor` was extended to track and report the **execution time** of the step.

This applies both to the standard and JSON log formats.

Please, note that:
- on the **standard log** the time format depends on the value (e.g. `3.038334954s` or `2m0.054014069s`)
- on the **JSON** log the time format is **nanoseconds**

**Standard log** example:

```log
[ci/job1]   ✅  Success - Main Step 1 [1.039520012s]
...
[ci/job2]   ❌  Failure - Main Step B [33.150896ms]
```

**JSON log** example:

```json
{"dryrun":false,"executionTime":1039563535,"job":"ci/job1","jobID":"job1","level":"info","matrix":{},"msg":"  ✅  Success - Main Step 1 [1.039563535s]","stage":"Main","step":"Step 1","stepID":["0"],"stepResult":"success","time":"2025-03-17T10:17:21+01:00"}
...
{"dryrun":false,"executionTime":33176679,"job":"ci/job2","jobID":"job2","level":"info","matrix":{},"msg":"  ❌  Failure - Main Step B [33.176679ms]","stage":"Main","step":"Step B","stepID":["1"],"stepResult":"failure","time":"2025-03-18T07:28:01+01:00"}
```

Related to #2660.