### PR TITLE
chore(deps): bump to go1.24 due to deps updates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,7 +23,7 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.62
+          version: v1.64.8
       - uses: megalinter/megalinter/flavors/go@v8.4.2
         env:
           DEFAULT_BRANCH: master

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nektos/act
 
-go 1.23
+go 1.24
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
* update linter to allow go 1.24

_depends on manual merge, one linter rejects merges without resolving all CVEs_


Hmm only my mirror had these alerts, I wonder how.