### PR TITLE
fix: reporting fetch failure as job error and log the error

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,8 +1,10 @@
 package runner
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	assert "github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
@@ -355,6 +358,136 @@ func TestRunEvent(t *testing.T) {
 			}
 
 			table.runTest(ctx, t, config)
+		})
+	}
+}
+
+type captureJobLoggerFactory struct {
+	buffer bytes.Buffer
+}
+
+func (factory *captureJobLoggerFactory) WithJobLogger() *logrus.Logger {
+	logger := logrus.New()
+	logger.SetOutput(&factory.buffer)
+	logger.SetLevel(log.TraceLevel)
+	logger.SetFormatter(&log.JSONFormatter{})
+	return logger
+}
+
+func TestPullFailureIsJobFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tables := []TestJobFileInfo{
+		{workdir, "checkout", "push", "pull failure", map[string]string{"ubuntu-latest": "localhost:0000/missing:latest"}, secrets},
+	}
+
+	for _, table := range tables {
+		t.Run(table.workflowPath, func(t *testing.T) {
+			factory := &captureJobLoggerFactory{}
+
+			config := &Config{
+				Secrets: table.secrets,
+			}
+
+			eventFile := filepath.Join(workdir, table.workflowPath, "event.json")
+			if _, err := os.Stat(eventFile); err == nil {
+				config.EventPath = eventFile
+			}
+			config.ActionCache = &GoGitActionCache{
+				path.Clean(path.Join(workdir, "cache")),
+			}
+
+			logger := logrus.New()
+			logger.SetOutput(&factory.buffer)
+			logger.SetLevel(log.TraceLevel)
+			logger.SetFormatter(&log.JSONFormatter{})
+
+			table.runTest(common.WithLogger(WithJobLoggerFactory(t.Context(), factory), logger), t, config)
+			scan := bufio.NewScanner(&factory.buffer)
+			var hasJobResult, hasStepResult bool
+			for scan.Scan() {
+				t.Log(scan.Text())
+				entry := map[string]interface{}{}
+				if json.Unmarshal(scan.Bytes(), &entry) == nil {
+					if val, ok := entry["jobResult"]; ok {
+						assert.Equal(t, "failure", val)
+						hasJobResult = true
+					}
+					if val, ok := entry["stepResult"]; ok && !hasStepResult {
+						assert.Equal(t, "failure", val)
+						hasStepResult = true
+					}
+				}
+			}
+			assert.True(t, hasStepResult, "stepResult not found")
+			assert.True(t, hasJobResult, "jobResult not found")
+		})
+	}
+}
+
+type mockCache struct {
+}
+
+func (c mockCache) Fetch(ctx context.Context, cacheDir string, url string, ref string, token string) (string, error) {
+	_ = ctx
+	_ = cacheDir
+	_ = url
+	_ = ref
+	_ = token
+	return "", fmt.Errorf("fetch failure")
+}
+func (c mockCache) GetTarArchive(ctx context.Context, cacheDir string, sha string, includePrefix string) (io.ReadCloser, error) {
+	_ = ctx
+	_ = cacheDir
+	_ = sha
+	_ = includePrefix
+	return nil, fmt.Errorf("fetch failure")
+}
+
+func TestFetchFailureIsJobFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tables := []TestJobFileInfo{
+		{workdir, "action-cache-v2-fetch-failure-is-job-error", "push", "fetch failure", map[string]string{"ubuntu-latest": "-self-hosted"}, secrets},
+	}
+
+	for _, table := range tables {
+		t.Run(table.workflowPath, func(t *testing.T) {
+			factory := &captureJobLoggerFactory{}
+
+			config := &Config{
+				Secrets: table.secrets,
+			}
+
+			eventFile := filepath.Join(workdir, table.workflowPath, "event.json")
+			if _, err := os.Stat(eventFile); err == nil {
+				config.EventPath = eventFile
+			}
+			config.ActionCache = &mockCache{}
+
+			logger := logrus.New()
+			logger.SetOutput(&factory.buffer)
+			logger.SetLevel(log.TraceLevel)
+			logger.SetFormatter(&log.JSONFormatter{})
+
+			table.runTest(common.WithLogger(WithJobLoggerFactory(t.Context(), factory), logger), t, config)
+			scan := bufio.NewScanner(&factory.buffer)
+			var hasJobResult bool
+			for scan.Scan() {
+				t.Log(scan.Text())
+				entry := map[string]interface{}{}
+				if json.Unmarshal(scan.Bytes(), &entry) == nil {
+					if val, ok := entry["jobResult"]; ok {
+						assert.Equal(t, "failure", val)
+						hasJobResult = true
+					}
+				}
+			}
+			assert.True(t, hasJobResult, "jobResult not found")
 		})
 	}
 }

--- a/pkg/runner/testdata/action-cache-v2-fetch-failure-is-job-error/push.yml
+++ b/pkg/runner/testdata/action-cache-v2-fetch-failure-is-job-error/push.yml
@@ -1,0 +1,8 @@
+name: basic
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nektos/test-override@a


### PR DESCRIPTION
E.g. if GoGitAction Cache had a fetch failure this error did not trigger report jobResult Failure.

Also the error has been not printed until the last message before exit of act.

* adds tests for both corner cases

We need more tests like this to ensure consistent logging