### PR TITLE
Enable passing of proxy variables to Docker build

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -62,6 +62,7 @@ type Input struct {
 	useNewActionCache                  bool
 	localRepository                    []string
 	listOptions                        bool
+	passProxyVarsToDockerBuild         bool
 }
 
 func (i *Input) resolve(path string) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,6 +127,7 @@ func createRootCommand(ctx context.Context, input *Input, version string) *cobra
 	rootCmd.PersistentFlags().BoolVarP(&input.useNewActionCache, "use-new-action-cache", "", false, "Enable using the new Action Cache for storing Actions locally")
 	rootCmd.PersistentFlags().StringArrayVarP(&input.localRepository, "local-repository", "", []string{}, "Replaces the specified repository and ref with a local folder (e.g. https://github.com/test/test@v0=/home/act/test or test/test@v0=/home/act/test, the latter matches any hosts or protocols)")
 	rootCmd.PersistentFlags().BoolVar(&input.listOptions, "list-options", false, "Print a json structure of compatible options")
+	rootCmd.PersistentFlags().BoolVar(&input.passProxyVarsToDockerBuild, "pass-proxy-vars-to-docker-build", false, "Pass HTTP(S)_PROXY + NO_PROXY env variables and lowercased versions as build args to build of Docker actions")
 	rootCmd.SetArgs(args())
 	return rootCmd
 }

--- a/pkg/container/container_types.go
+++ b/pkg/container/container_types.go
@@ -64,6 +64,7 @@ type NewDockerBuildExecutorInput struct {
 	BuildContext io.Reader
 	ImageTag     string
 	Platform     string
+	BuildArgs    map[string]string
 }
 
 // NewDockerPullExecutorInput the input for the NewDockerPullExecutor function

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -299,12 +299,24 @@ func execAsDocker(ctx context.Context, step actionStep, actionName, basedir, sub
 				}
 				defer buildContext.Close()
 			}
+
+			buildArgs := map[string]string{}
+			if rc.Config.PassProxyVarsToDockerBuild {
+				buildArgs["HTTP_PROXY"] = os.Getenv("HTTP_PROXY")
+				buildArgs["HTTPS_PROXY"] = os.Getenv("HTTPS_PROXY")
+				buildArgs["NO_PROXY"] = os.Getenv("NO_PROXY")
+				buildArgs["http_proxy"] = os.Getenv("http_proxy")
+				buildArgs["https_proxy"] = os.Getenv("https_proxy")
+				buildArgs["no_proxy"] = os.Getenv("no_proxy")
+			}
+
 			prepImage = container.NewDockerBuildExecutor(container.NewDockerBuildExecutorInput{
 				ContextDir:   filepath.Join(basedir, contextDir),
 				Dockerfile:   fileName,
 				ImageTag:     image,
 				BuildContext: buildContext,
 				Platform:     rc.Config.ContainerArchitecture,
+				BuildArgs:    buildArgs,
 			})
 		} else {
 			logger.Debugf("image '%s' for architecture '%s' already exists", image, rc.Config.ContainerArchitecture)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -61,6 +61,7 @@ type Config struct {
 	Matrix                             map[string]map[string]bool   // Matrix config to run
 	ContainerNetworkMode               docker_container.NetworkMode // the network mode of job containers (the value of --network)
 	ActionCache                        ActionCache                  // Use a custom ActionCache Implementation
+	PassProxyVarsToDockerBuild         bool                         // Pass HTTP_PROXY, HTTPS_PROXY & NO_PROXY (and lowercased too) to build of Docker actions
 }
 
 type caller struct {


### PR DESCRIPTION
Implements #2722.

This PR adds a flag called `--pass-proxy-vars-to-docker-build` which allows the user to pass proxy variables through to the build of Docker-based actions. These variables are HTTP_PROXY, HTTPS_PROXY and NO_PROXY, plus the lowercase versions too because not all applications respect all cases.

The variables that are set are taken from the environment of Act itself. If the URL includes a password then this is redacted when logging the command passed to Docker.

This PR allows Act to be used within an enterprise environment where access to the internet is via an authenticating proxy, otherwise Docker-based actions are not able to be used if they need to access the internet as part of their build process.