### PR TITLE
Use complete go version number

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nektos/act
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Doesn't work on my version of ubuntu without this.