### PR TITLE
fix: add missing punctuation to error report (#2752)

### DIFF
--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -45,7 +45,7 @@ func readActionImpl(ctx context.Context, step *model.Step, actionDir string, act
 	allErrors := []error{}
 	addError := func(fileName string, err error) {
 		if err != nil {
-			allErrors = append(allErrors, fmt.Errorf("failed to read '%s' from action '%s' with path '%s' of step %w", fileName, step.String(), actionPath, err))
+			allErrors = append(allErrors, fmt.Errorf("failed to read '%s' from action '%s' with path '%s' of step: %w", fileName, step.String(), actionPath, err))
 		} else {
 			// One successful read, clear error state
 			allErrors = nil


### PR DESCRIPTION
- fixes #2752

### before

```
[Check Spelling/Check Spelling] failed to read 'action.yml' from action 'checkout' with path '' of step file does not exist
failed to read 'action.yaml' from action 'checkout' with path '' of step file does not exist
failed to read 'Dockerfile' from action 'checkout' with path '' of step file does not exist
```

### after

```
[Check Spelling/Check Spelling] failed to read 'action.yml' from action 'checkout' with path '' of step: file does not exist
failed to read 'action.yaml' from action 'checkout' with path '' of step: file does not exist
failed to read 'Dockerfile' from action 'checkout' with path '' of step: file does not exist
```