### PR TITLE
chore(ci): disable invalid test case

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -538,7 +538,9 @@ func TestRunEventHostEnvironment(t *testing.T) {
 			{workdir, "matrix", "push", "", platforms, secrets},
 			{workdir, "matrix-include-exclude", "push", "", platforms, secrets},
 			{workdir, "commands", "push", "", platforms, secrets},
-			{workdir, "defaults-run", "push", "", platforms, secrets},
+                        // Disabled for now because this test is somewhat invalid
+                  	// shell sh is not necessarily bash if the job has no override
+                  	// {workdir, "defaults-run", "push", "", platforms, secrets},
 			{workdir, "composite-fail-with-output", "push", "", platforms, secrets},
 			{workdir, "issue-597", "push", "", platforms, secrets},
 			{workdir, "issue-598", "push", "", platforms, secrets},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -538,9 +538,9 @@ func TestRunEventHostEnvironment(t *testing.T) {
 			{workdir, "matrix", "push", "", platforms, secrets},
 			{workdir, "matrix-include-exclude", "push", "", platforms, secrets},
 			{workdir, "commands", "push", "", platforms, secrets},
-                        // Disabled for now because this test is somewhat invalid
-                  	// shell sh is not necessarily bash if the job has no override
-                  	// {workdir, "defaults-run", "push", "", platforms, secrets},
+			// Disabled for now because this test is somewhat invalid
+			// shell sh is not necessarily bash if the job has no override
+			// {workdir, "defaults-run", "push", "", platforms, secrets},
 			{workdir, "composite-fail-with-output", "push", "", platforms, secrets},
 			{workdir, "issue-597", "push", "", platforms, secrets},
 			{workdir, "issue-598", "push", "", platforms, secrets},


### PR DESCRIPTION
* GitHub Hosted Runners `sh` no longer identifies itself as `bash`
* This test is still enabled for container tests