### PR TITLE
fix: GITHUB_ENV and GITHUB_OUTPUT allow larger lines

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -286,6 +286,7 @@ func readArgsFile(file string, split bool) []string {
 		}
 	}()
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(nil, 1024*1024*1024) // increase buffer to 1GB to avoid scanner buffer overflow
 	for scanner.Scan() {
 		arg := os.ExpandEnv(strings.TrimSpace(scanner.Text()))
 

--- a/pkg/container/parse_env_file.go
+++ b/pkg/container/parse_env_file.go
@@ -25,6 +25,7 @@ func parseEnvFile(e Container, srcPath string, env *map[string]string) common.Ex
 			return err
 		}
 		s := bufio.NewScanner(reader)
+		s.Buffer(nil, 1024*1024*1024) // increase buffer to 1GB to avoid scanner buffer overflow
 		firstLine := true
 		for s.Scan() {
 			line := s.Text()
@@ -63,6 +64,6 @@ func parseEnvFile(e Container, srcPath string, env *map[string]string) common.Ex
 			}
 		}
 		env = &localEnv
-		return nil
+		return s.Err()
 	}
 }

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -523,6 +523,7 @@ func (rc *RunContext) UpdateExtraPath(ctx context.Context, githubEnvPath string)
 		return err
 	}
 	s := bufio.NewScanner(reader)
+	s.Buffer(nil, 1024*1024*1024) // increase buffer to 1GB to avoid scanner buffer overflow
 	firstLine := true
 	for s.Scan() {
 		line := s.Text()
@@ -537,7 +538,7 @@ func (rc *RunContext) UpdateExtraPath(ctx context.Context, githubEnvPath string)
 			rc.addPath(ctx, line)
 		}
 	}
-	return nil
+	return s.Err()
 }
 
 // stopJobContainer removes the job container (if it exists) and its volume (if it exists)


### PR DESCRIPTION
* Increase max line buffer size to 1GB of some bufio scanner callers

Fixes #2739 or not