### PR TITLE
fix: use ubuntu-latest bookworm instead of buster for tests

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	baseImage = "node:16-buster-slim"
+	baseImage = "node:24-bookworm-slim"
 	platforms map[string]string
 	logLevel  = log.DebugLevel
 	workdir   = "testdata"


### PR DESCRIPTION
* buster is now end of life
* apt-get update fails for some tests using ubuntu-latest
* buster cdn moved to archived domain

_Yes this image could be overriden by an env Variable, then everybody would have to do this for a chance of a passing test suite_