### PR TITLE
Fix nested reusable workflows

### DIFF
--- a/pkg/runner/reusable_workflow.go
+++ b/pkg/runner/reusable_workflow.go
@@ -140,7 +140,7 @@ func NewReusableWorkflowRunner(rc *RunContext, workflowDir string) (Runner, erro
 	// Create a copy of the config to avoid modifying the original
 	configCopy := *rc.Config
 	configCopy.Workdir = workflowDir
-	
+
 	runner := &runnerImpl{
 		config:    &configCopy,
 		eventJSON: rc.EventJSON,

--- a/pkg/runner/reusable_workflow.go
+++ b/pkg/runner/reusable_workflow.go
@@ -70,7 +70,9 @@ func newActionCacheReusableWorkflowExecutor(rc *RunContext, filename string, rem
 			return err
 		}
 
-		runner, err := NewReusableWorkflowRunner(rc)
+		// Use the action cache directory path for the workdir
+		workflowDir := fmt.Sprintf("%s/%s", rc.ActionCacheDir(), safeFilename(filename))
+		runner, err := NewReusableWorkflowRunner(rc, workflowDir)
 		if err != nil {
 			return err
 		}
@@ -125,7 +127,7 @@ func newReusableWorkflowExecutor(rc *RunContext, directory string, workflow stri
 			return err
 		}
 
-		runner, err := NewReusableWorkflowRunner(rc)
+		runner, err := NewReusableWorkflowRunner(rc, directory)
 		if err != nil {
 			return err
 		}
@@ -134,9 +136,13 @@ func newReusableWorkflowExecutor(rc *RunContext, directory string, workflow stri
 	}
 }
 
-func NewReusableWorkflowRunner(rc *RunContext) (Runner, error) {
+func NewReusableWorkflowRunner(rc *RunContext, workflowDir string) (Runner, error) {
+	// Create a copy of the config to avoid modifying the original
+	configCopy := *rc.Config
+	configCopy.Workdir = workflowDir
+	
 	runner := &runnerImpl{
-		config:    rc.Config,
+		config:    &configCopy,
 		eventJSON: rc.EventJSON,
 		caller: &caller{
 			runContext: rc,

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -310,6 +310,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "workflow_dispatch-scalar", "workflow_dispatch", "", platforms, secrets},
 		{workdir, "workflow_dispatch-scalar-composite-action", "workflow_dispatch", "", platforms, secrets},
 		{workdir, "uses-workflow-defaults", "workflow_dispatch", "", platforms, secrets},
+		{workdir, "nested-reusable-workflow", "push", "local", platforms, secrets},
 		{workdir, "job-needs-context-contains-result", "push", "", platforms, secrets},
 		{"../model/testdata", "strategy", "push", "", platforms, secrets}, // TODO: move all testdata into pkg so we can validate it with planner and runner
 		{"../model/testdata", "container-volumes", "push", "", platforms, secrets},

--- a/pkg/runner/testdata/nested-reusable-workflow/.github/workflows/main.yml
+++ b/pkg/runner/testdata/nested-reusable-workflow/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: Main Reusable Workflow
+on:
+  workflow_call:
+    inputs:
+      message:
+        type: string
+        required: true
+
+jobs:
+  pre-task:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print message
+        run: echo "${{ inputs.message }}"
+  
+  nested-call:
+    needs: pre-task
+    uses: ./.github/workflows/nested.yml
+    with:
+      parent_message: "${{ inputs.message }}"
+    secrets: inherit

--- a/pkg/runner/testdata/nested-reusable-workflow/.github/workflows/nested.yml
+++ b/pkg/runner/testdata/nested-reusable-workflow/.github/workflows/nested.yml
@@ -1,0 +1,16 @@
+name: Nested Reusable Workflow
+on:
+  workflow_call:
+    inputs:
+      parent_message:
+        type: string
+        required: true
+
+jobs:
+  nested-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print nested message
+        run: |
+          echo "Parent message: ${{ inputs.parent_message }}"
+          echo "This is from the nested workflow"

--- a/pkg/runner/testdata/nested-reusable-workflow/local.yml
+++ b/pkg/runner/testdata/nested-reusable-workflow/local.yml
@@ -1,0 +1,9 @@
+name: Test Local Nested Reusable Workflows
+on: push
+
+jobs:
+  call-local-workflow:
+    uses: ./.github/workflows/main.yml
+    with:
+      message: "Hello from local caller"
+    secrets: inherit

--- a/pkg/runner/testdata/nested-reusable-workflow/push.yml
+++ b/pkg/runner/testdata/nested-reusable-workflow/push.yml
@@ -1,0 +1,9 @@
+name: Test Nested Reusable Workflows
+on: push
+
+jobs:
+  call-remote-workflow:
+    uses: nektos/act-test-actions/.github/workflows/nested-reusable-workflow.yml@nested-workflows
+    with:
+      message: "Hello from caller"
+    secrets: inherit


### PR DESCRIPTION
When a reusable workflow calls another local workflow using relative paths (uses: ./.github/workflows/...), act was incorrectly looking for the nested workflow in the caller's repository instead of the reusable workflow's repository.

This fix ensures that local workflow references are resolved relative to the reusable workflow's location by passing the correct working directory to the reusable workflow runner.

Fixes https://github.com/nektos/act/issues/1875