### PR TITLE
git: format error when directory is not a git repo

### DIFF
--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -64,7 +64,7 @@ func FindGitRevision(ctx context.Context, file string) (shortSha string, sha str
 	)
 
 	if err != nil {
-		logger.WithError(err).Error("path", file, "not located inside a git repository")
+		logger.WithError(err).Errorf("path %s not located inside a git repository", file)
 		return "", "", err
 	}
 


### PR DESCRIPTION
The logged message:

before
`path/home/user/Code/repo_namenot located inside a git repository` 
after
`path /home/user/Code/repo_name not located inside a git repository`