### PR TITLE
Add codespell-problem-matcher into codespell workflow

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,5 +19,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
Apparently long ago when I proposed codespell for this project, I did not yet know about codespell-problem-matcher . Since then I add it to all projects since it makes it very convenient in PRs to see where typos are.

ref: https://github.com/codespell-project/codespell-problem-matcher