### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/pkg/model/planner.go
+++ b/pkg/model/planner.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -293,9 +293,7 @@ func (wp *workflowPlanner) GetEvents() []string {
 	}
 
 	// sort the list based on depth of dependencies
-	sort.Slice(events, func(i, j int) bool {
-		return events[i] < events[j]
-	})
+	slices.Sort(events)
 
 	return events
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.