### PR TITLE
bug: fix slug regex for `rcp` style remotes

### DIFF
--- a/pkg/common/git/git.go
+++ b/pkg/common/git/git.go
@@ -26,7 +26,7 @@ var (
 	codeCommitHTTPRegex = regexp.MustCompile(`^https?://git-codecommit\.(.+)\.amazonaws.com/v1/repos/(.+)$`)
 	codeCommitSSHRegex  = regexp.MustCompile(`ssh://git-codecommit\.(.+)\.amazonaws.com/v1/repos/(.+)$`)
 	githubHTTPRegex     = regexp.MustCompile(`^https?://.*github.com.*/(.+)/(.+?)(?:.git)?$`)
-	githubSSHRegex      = regexp.MustCompile(`github.com[:/](.+)/(.+?)(?:.git)?$`)
+	githubSSHRegex      = regexp.MustCompile(`github.com(?::/?|/)(.+)/(.+?)(?:.git)?$`)
 
 	cloneLock sync.Mutex
 
@@ -209,7 +209,7 @@ func findGitSlug(url string, githubInstance string) (string, string, error) {
 		return "GitHub", fmt.Sprintf("%s/%s", matches[1], matches[2]), nil
 	} else if githubInstance != "github.com" {
 		gheHTTPRegex := regexp.MustCompile(fmt.Sprintf(`^https?://%s/(.+)/(.+?)(?:.git)?$`, githubInstance))
-		gheSSHRegex := regexp.MustCompile(fmt.Sprintf(`%s[:/](.+)/(.+?)(?:.git)?$`, githubInstance))
+		gheSSHRegex := regexp.MustCompile(fmt.Sprintf(`%s(?::/?|/)(.+)/(.+?)(?:.git)?$`, githubInstance))
 		if matches := gheHTTPRegex.FindStringSubmatch(url); matches != nil {
 			return "GitHubEnterprise", fmt.Sprintf("%s/%s", matches[1], matches[2]), nil
 		} else if matches := gheSSHRegex.FindStringSubmatch(url); matches != nil {


### PR DESCRIPTION
Fixes #5949