### PR TITLE
Add 24.04 images, override -latest with -24.04

### DIFF
--- a/IMAGES.md
+++ b/IMAGES.md
@@ -11,6 +11,7 @@
 | Image                                 | Size                                                       |
 | ------------------------------------- | ---------------------------------------------------------- |
 | [`node:16-bullseye`][hub/_/node]      | ![`bullseye-size`][hub/_/node/16-bullseye/size]            |
+| [`node:16-bookwork-slim`][hub/_/node] | ![`micro-bookwork-size`][hub/_/node/16-bookwork-slim/size] |
 | [`node:16-bullseye-slim`][hub/_/node] | ![`micro-bullseye-size`][hub/_/node/16-bullseye-slim/size] |
 | [`node:16-buster`][hub/_/node]        | ![`buster-size`][hub/_/node/16-buster/size]                |
 | [`node:16-buster-slim`][hub/_/node]   | ![`micro-buster-size`][hub/_/node/16-buster-slim/size]     |
@@ -19,7 +20,7 @@
 
 | Image                                                        | GitHub Repository                                             |
 | ------------------------------------------------------------ | ------------------------------------------------------------- |
-| [`catthehacker/ubuntu:act-latest`][ghcr/catthehacker/ubuntu] | [`catthehacker/docker-images`][gh/catthehacker/docker_images] |
+| [`catthehacker/ubuntu:act-24.04`][ghcr/catthehacker/ubuntu]  | [`catthehacker/docker-images`][gh/catthehacker/docker_images] |
 | [`catthehacker/ubuntu:act-22.04`][ghcr/catthehacker/ubuntu]  | [`catthehacker/docker-images`][gh/catthehacker/docker_images] |
 | [`catthehacker/ubuntu:act-20.04`][ghcr/catthehacker/ubuntu]  | [`catthehacker/docker-images`][gh/catthehacker/docker_images] |
 | [`catthehacker/ubuntu:act-18.04`][ghcr/catthehacker/ubuntu]  | [`catthehacker/docker-images`][gh/catthehacker/docker_images] |

--- a/IMAGES.md
+++ b/IMAGES.md
@@ -10,8 +10,9 @@
 
 | Image                                 | Size                                                       |
 | ------------------------------------- | ---------------------------------------------------------- |
+| [`node:16-bookworm`][hub/_/node]      | ![`bookworm-size`][hub/_/node/16-bookworm/size] |
+| [`node:16-bookworm-slim`][hub/_/node] | ![`micro-bookworm-size`][hub/_/node/16-bookworm-slim/size] |
 | [`node:16-bullseye`][hub/_/node]      | ![`bullseye-size`][hub/_/node/16-bullseye/size]            |
-| [`node:16-bookwork-slim`][hub/_/node] | ![`micro-bookwork-size`][hub/_/node/16-bookwork-slim/size] |
 | [`node:16-bullseye-slim`][hub/_/node] | ![`micro-bullseye-size`][hub/_/node/16-bullseye-slim/size] |
 | [`node:16-buster`][hub/_/node]        | ![`buster-size`][hub/_/node/16-buster/size]                |
 | [`node:16-buster-slim`][hub/_/node]   | ![`micro-buster-size`][hub/_/node/16-buster-slim/size]     |
@@ -45,6 +46,8 @@ Feel free to make a pull request with your image added here
 
 [hub/_/buildpack-deps]: https://hub.docker.com/_/buildpack-deps
 [hub/_/node]: https://hub.docker.com/r/_/node
+[hub/_/node/16-bookworm/size]: https://img.shields.io/docker/image-size/_/node/16-bookworm
+[hub/_/node/16-bookworm-slim/size]: https://img.shields.io/docker/image-size/_/node/16-bookworm-slim
 [hub/_/node/16-bullseye/size]: https://img.shields.io/docker/image-size/_/node/16-bullseye
 [hub/_/node/16-bullseye-slim/size]: https://img.shields.io/docker/image-size/_/node/16-bullseye-slim
 [hub/_/node/16-buster/size]: https://img.shields.io/docker/image-size/_/node/16-buster

--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -7,7 +7,7 @@ import (
 func (i *Input) newPlatforms() map[string]string {
 	platforms := map[string]string{
 		"ubuntu-latest": "node:16-bookworm-slim",
-		"ubuntu-24.04":  "node:16-bookwork-slim",
+		"ubuntu-24.04":  "node:16-bookworm-slim",
 		"ubuntu-22.04":  "node:16-bullseye-slim",
 		"ubuntu-20.04":  "node:16-buster-slim",
 		"ubuntu-18.04":  "node:16-buster-slim",

--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -6,7 +6,8 @@ import (
 
 func (i *Input) newPlatforms() map[string]string {
 	platforms := map[string]string{
-		"ubuntu-latest": "node:16-buster-slim",
+		"ubuntu-latest": "node:16-bookworm-slim",
+		"ubuntu-24.04":  "node:16-bookwork-slim",
 		"ubuntu-22.04":  "node:16-bullseye-slim",
 		"ubuntu-20.04":  "node:16-buster-slim",
 		"ubuntu-18.04":  "node:16-buster-slim",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -292,6 +292,11 @@ func readArgsFile(file string, split bool) []string {
 	for scanner.Scan() {
 		arg := os.ExpandEnv(strings.TrimSpace(scanner.Text()))
 
+		// using HasPrefix to not get caught up in newline handling
+		if strings.HasPrefix(arg, "-P ubuntu-latest=catthehacker/ubuntu:act-latest") {
+			log.Warn("actrc contains outdated aliases. To regenerate it, remove the file. For details, see https://github.com/nektos/act/pull/5951.")
+		}
+
 		if strings.HasPrefix(arg, "-") && split {
 			args = append(args, regexp.MustCompile(`\s`).Split(arg, 2)...)
 		} else if !split {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -292,9 +292,10 @@ func readArgsFile(file string, split bool) []string {
 	for scanner.Scan() {
 		arg := os.ExpandEnv(strings.TrimSpace(scanner.Text()))
 
-		// using HasPrefix to not get caught up in newline handling
-		if strings.HasPrefix(arg, "-P ubuntu-latest=catthehacker/ubuntu:act-latest") {
-			log.Warn("actrc contains outdated aliases. To regenerate it, remove the file. For details, see https://github.com/nektos/act/pull/5951.")
+		if arg == "-P ubuntu-latest=catthehacker/ubuntu:full-latest" ||
+			arg == "-P ubuntu-latest=catthehacker/ubuntu:act-latest" ||
+			arg == "-P ubuntu-latest=node:16-buster-slim" {
+			log.Warn("actrc contains outdated default aliases. To regenerate it, remove the file. For details, see https://github.com/nektos/act/pull/5951.")
 		}
 
 		if strings.HasPrefix(arg, "-") && split {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -730,11 +730,23 @@ func defaultImageSurvey(actrc string) error {
 	var option string
 	switch answer {
 	case "Large":
-		option = "-P ubuntu-latest=catthehacker/ubuntu:full-latest\n-P ubuntu-22.04=catthehacker/ubuntu:full-22.04\n-P ubuntu-20.04=catthehacker/ubuntu:full-20.04\n-P ubuntu-18.04=catthehacker/ubuntu:full-18.04\n"
+		option = "-P ubuntu-latest=catthehacker/ubuntu:full-24.04\n" +
+			"-P ubuntu-24.04=catthehacker/ubuntu:full-24.04\n" +
+			"-P ubuntu-22.04=catthehacker/ubuntu:full-22.04\n" +
+			"-P ubuntu-20.04=catthehacker/ubuntu:full-20.04\n" +
+			"-P ubuntu-18.04=catthehacker/ubuntu:full-18.04\n"
 	case "Medium":
-		option = "-P ubuntu-latest=catthehacker/ubuntu:act-latest\n-P ubuntu-22.04=catthehacker/ubuntu:act-22.04\n-P ubuntu-20.04=catthehacker/ubuntu:act-20.04\n-P ubuntu-18.04=catthehacker/ubuntu:act-18.04\n"
+		option = "-P ubuntu-latest=catthehacker/ubuntu:act-24.04\n" +
+			"-P ubuntu-24.04=catthehacker/ubuntu:act-24.04\n" +
+			"-P ubuntu-22.04=catthehacker/ubuntu:act-22.04\n" +
+			"-P ubuntu-20.04=catthehacker/ubuntu:act-20.04\n" +
+			"-P ubuntu-18.04=catthehacker/ubuntu:act-18.04\n"
 	case "Micro":
-		option = "-P ubuntu-latest=node:16-buster-slim\n-P ubuntu-22.04=node:16-bullseye-slim\n-P ubuntu-20.04=node:16-buster-slim\n-P ubuntu-18.04=node:16-buster-slim\n"
+		option = "-P ubuntu-latest=node:16-bookwork-slim\n" +
+			"-P ubuntu-22.04=node:16-bookwork-slim\n" +
+			"-P ubuntu-22.04=node:16-bullseye-slim\n" +
+			"-P ubuntu-20.04=node:16-buster-slim\n" +
+			"-P ubuntu-18.04=node:16-buster-slim\n"
 	}
 
 	f, err := os.Create(actrc)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -742,8 +742,8 @@ func defaultImageSurvey(actrc string) error {
 			"-P ubuntu-20.04=catthehacker/ubuntu:act-20.04\n" +
 			"-P ubuntu-18.04=catthehacker/ubuntu:act-18.04\n"
 	case "Micro":
-		option = "-P ubuntu-latest=node:16-bookwork-slim\n" +
-			"-P ubuntu-22.04=node:16-bookwork-slim\n" +
+		option = "-P ubuntu-latest=node:16-bookworm-slim\n" +
+			"-P ubuntu-24.04=node:16-bookworm-slim\n" +
 			"-P ubuntu-22.04=node:16-bullseye-slim\n" +
 			"-P ubuntu-20.04=node:16-buster-slim\n" +
 			"-P ubuntu-18.04=node:16-buster-slim\n"


### PR DESCRIPTION
Unfortunately the repo with the images hasn't updated their -latest tag in the last year, so we explicitly set it here.

Closes #2329