### PR TITLE
Limit servers to IPv4 to make them work with WSL (only for WSL environments)

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -65,6 +65,8 @@ type Input struct {
 	validate                           bool
 	strict                             bool
 	concurrentJobs                     int
+	artifactServerNetwork              string
+	cacheServerNetwork                 string
 }
 
 func (i *Input) resolve(path string) string {

--- a/pkg/artifactcache/handler.go
+++ b/pkg/artifactcache/handler.go
@@ -42,7 +42,7 @@ type Handler struct {
 	customExternalURL string
 }
 
-func StartHandler(dir, customExternalURL string, outboundIP string, port uint16, logger logrus.FieldLogger) (*Handler, error) {
+func StartHandler(dir, customExternalURL string, outboundIP string, port uint16, network string, logger logrus.FieldLogger) (*Handler, error) {
 	h := &Handler{}
 
 	if logger == nil {
@@ -96,7 +96,7 @@ func StartHandler(dir, customExternalURL string, outboundIP string, port uint16,
 
 	h.gcCache()
 
-	listener, err := net.Listen("tcp4", fmt.Sprintf(":%d", port)) // listen on all interfaces
+	listener, err := net.Listen(network, fmt.Sprintf(":%d", port)) // listen on all interfaces
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/artifactcache/handler_test.go
+++ b/pkg/artifactcache/handler_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestHandler(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "artifactcache")
-	handler, err := StartHandler(dir, "", "", 0, nil)
+	handler, err := StartHandler(dir, "", "", 0, "tcp", nil)
 	require.NoError(t, err)
 
 	base := fmt.Sprintf("%s%s", handler.ExternalURL(), urlBase)
@@ -589,7 +589,7 @@ func uploadCacheNormally(t *testing.T, base, key, version string, content []byte
 
 func TestHandler_CustomExternalURL(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "artifactcache")
-	handler, err := StartHandler(dir, "", "", 0, nil)
+	handler, err := StartHandler(dir, "", "", 0, "tcp", nil)
 	require.NoError(t, err)
 
 	defer func() {
@@ -623,7 +623,7 @@ func TestHandler_CustomExternalURL(t *testing.T) {
 
 func TestHandler_gcCache(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "artifactcache")
-	handler, err := StartHandler(dir, "", "", 0, nil)
+	handler, err := StartHandler(dir, "", "", 0, "tcp", nil)
 	require.NoError(t, err)
 
 	defer func() {

--- a/pkg/artifacts/server.go
+++ b/pkg/artifacts/server.go
@@ -276,7 +276,7 @@ func downloads(router *httprouter.Router, baseDir string, fsys fs.FS) {
 	})
 }
 
-func Serve(ctx context.Context, artifactPath string, addr string, port string) context.CancelFunc {
+func Serve(ctx context.Context, artifactPath string, addr string, port string, network string) context.CancelFunc {
 	serverContext, cancel := context.WithCancel(ctx)
 	logger := common.Logger(serverContext)
 
@@ -292,7 +292,7 @@ func Serve(ctx context.Context, artifactPath string, addr string, port string) c
 	downloads(router, artifactPath, fsys)
 	RoutesV4(router, artifactPath, fsys, fsys)
 
-	listener, err := net.Listen("tcp4", fmt.Sprintf("%s:%s", addr, port))
+	listener, err := net.Listen(network, fmt.Sprintf("%s:%s", addr, port))
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/pkg/artifacts/server_test.go
+++ b/pkg/artifacts/server_test.go
@@ -252,7 +252,7 @@ func TestArtifactFlow(t *testing.T) {
 
 	ctx := context.Background()
 
-	cancel := Serve(ctx, artifactsPath, artifactsAddr, artifactsPort)
+	cancel := Serve(ctx, artifactsPath, artifactsAddr, artifactsPort, "tcp")
 	defer cancel()
 
 	platforms := map[string]string{


### PR DESCRIPTION
## Summary

Builds on the work by @stickeegreg in #5912 and responds to the [comment from @ChristopherHX](https://github.com/nektos/act/pull/5912#issuecomment-3265291531) to making the default network stack for the artifact and cache services `tcp4` if running in WSL. Also added the option to configure via CLI flags. 

## Changes

- Default behavior change:
  - **WSL2**: If [environment variable `WSL_DISTRO_NAME`](https://github.com/microsoft/WSL/blob/fdfe1eb8439370c9eb6780467abc1e3f08f90eb1/src/linux/init/config.cpp#L845) is set: Uses `tcp4` (IPv4-only) when launching the artifact & cache services to avoid EHOSTUNREACH/ECONNREFUSED errors (see #2636 & #1866)
  - **Other environments**: Uses `tcp` (dual-stack IPv4/IPv6) as before. 
- Added `--artifact-server-network` and `--cache-server-network` CLI flags with validation for valid stack values (`tcp`, `tcp4`, `tcp6`)
- Updated `StartHandler()` and `Serve()` to accept network parameter

## Usage

```bash
# Use defaults (tcp4 on WSL2, tcp otherwise)
act

# On WSL2 override to use standard TCP
act --artifact-server-network tcp --cache-server-network tcp

# On non-WSL2 or if `WSL_DISTRO_NAME` isn't set for some reason: 
act --artifact-server-network tcp4 --cache-server-network tcp4

# Force IPv6 - I have no ability to test this as I don't have an ipv6 enabled machine to test on. 
act --artifact-server-network tcp6
```

## Related Issues

Fixes #2636 - ECONNREFUSED to artifact service on WSL2  
Fixes #1866 - Cache server EHOSTUNREACH on WSL2  
Based on #5912 - Initial hardcoded fix