### PR TITLE
Fix platform parsing to support multiple equals signs

### DIFF
--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -13,9 +13,9 @@ func (i *Input) newPlatforms() map[string]string {
 	}
 
 	for _, p := range i.platforms {
-		pParts := strings.Split(p, "=")
-		if len(pParts) == 2 {
-			platforms[strings.ToLower(pParts[0])] = pParts[1]
+		idx := strings.LastIndex(p, "=")
+		if idx != -1 {
+			platforms[strings.ToLower(p[:idx])] = p[idx+1:]
 		}
 	}
 	return platforms

--- a/cmd/platforms_test.go
+++ b/cmd/platforms_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPlatforms(t *testing.T) {
+	tests := []struct {
+		name      string
+		platforms []string
+		expected  map[string]string
+	}{
+		{
+			name:      "default platforms",
+			platforms: []string{},
+			expected: map[string]string{
+				"ubuntu-latest": "node:16-buster-slim",
+				"ubuntu-22.04":  "node:16-bullseye-slim",
+				"ubuntu-20.04":  "node:16-buster-slim",
+				"ubuntu-18.04":  "node:16-buster-slim",
+			},
+		},
+		{
+			name:      "simple platform override",
+			platforms: []string{"ubuntu-latest=custom:image"},
+			expected: map[string]string{
+				"ubuntu-latest": "custom:image",
+				"ubuntu-22.04":  "node:16-bullseye-slim",
+				"ubuntu-20.04":  "node:16-buster-slim",
+				"ubuntu-18.04":  "node:16-buster-slim",
+			},
+		},
+		{
+			name:      "platform with multiple equals signs",
+			platforms: []string{"runner=fast-disk-network=catthehacker/ubuntu:act-22.04"},
+			expected: map[string]string{
+				"ubuntu-latest":            "node:16-buster-slim",
+				"ubuntu-22.04":             "node:16-bullseye-slim",
+				"ubuntu-20.04":             "node:16-buster-slim",
+				"ubuntu-18.04":             "node:16-buster-slim",
+				"runner=fast-disk-network": "catthehacker/ubuntu:act-22.04",
+			},
+		},
+		{
+			name: "multiple platform overrides",
+			platforms: []string{
+				"ubuntu-latest=custom:image",
+				"runner=fast-disk-network=catthehacker/ubuntu:act-22.04",
+			},
+			expected: map[string]string{
+				"ubuntu-latest":            "custom:image",
+				"ubuntu-22.04":             "node:16-bullseye-slim",
+				"ubuntu-20.04":             "node:16-buster-slim",
+				"ubuntu-18.04":             "node:16-buster-slim",
+				"runner=fast-disk-network": "catthehacker/ubuntu:act-22.04",
+			},
+		},
+		{
+			name:      "case insensitive platform key",
+			platforms: []string{"UBUNTU-LATEST=custom:image"},
+			expected: map[string]string{
+				"ubuntu-latest": "custom:image",
+				"ubuntu-22.04":  "node:16-bullseye-slim",
+				"ubuntu-20.04":  "node:16-buster-slim",
+				"ubuntu-18.04":  "node:16-buster-slim",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &Input{
+				platforms: tt.platforms,
+			}
+			result := input.newPlatforms()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Use strings.LastIndex instead of strings.Split to correctly parse platform strings containing multiple equals signs (e.g., runner=fast-disk-network=catthehacker/ubuntu:act-22.04).

This allows the platform key to contain equals signs, splitting only on the last occurrence to separate the key from the value.