### PR TITLE
fix possible leakage of secrets in debug logging

### DIFF
--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -234,11 +234,11 @@ type expressionEvaluator struct {
 
 func (ee expressionEvaluator) evaluate(ctx context.Context, in string, defaultStatusCheck exprparser.DefaultStatusCheck) (interface{}, error) {
 	logger := common.Logger(ctx)
-	logger.Debugf("evaluating expression '%s'", in)
+	printableInput := regexp.MustCompile(`::add-mask::.*`).ReplaceAllString(in, "::add-mask::***")
+	logger.Debugf("evaluating expression '%s'", printableInput)
 	evaluated, err := ee.interpreter.Evaluate(in, defaultStatusCheck)
 
-	printable := regexp.MustCompile(`::add-mask::.*`).ReplaceAllString(fmt.Sprintf("%t", evaluated), "::add-mask::***)")
-	logger.Debugf("expression '%s' evaluated to '%s'", in, printable)
+	logger.Debugf("expression '%s' evaluated to '%t'", printableInput, evaluated)
 
 	return evaluated, err
 }

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -234,11 +234,13 @@ type expressionEvaluator struct {
 
 func (ee expressionEvaluator) evaluate(ctx context.Context, in string, defaultStatusCheck exprparser.DefaultStatusCheck) (interface{}, error) {
 	logger := common.Logger(ctx)
-	printableInput := regexp.MustCompile(`::add-mask::.*`).ReplaceAllString(in, "::add-mask::***")
+	addMaskRegexp := regexp.MustCompile(`::add-mask::.*`)
+	printableInput := addMaskRegexp.ReplaceAllString(in, "::add-mask::***")
 	logger.Debugf("evaluating expression '%s'", printableInput)
-	evaluated, err := ee.interpreter.Evaluate(in, defaultStatusCheck)
 
-	logger.Debugf("expression '%s' evaluated to '%t'", printableInput, evaluated)
+	evaluated, err := ee.interpreter.Evaluate(in, defaultStatusCheck)
+	printableEvaluated := addMaskRegexp.ReplaceAllString(fmt.Sprintf("%v", evaluated), "::add-mask::***")
+	logger.Debugf("expression '%s' evaluated to '%s'", printableInput, printableEvaluated)
 
 	return evaluated, err
 }


### PR DESCRIPTION
Found this while browsing the source code.

I just thought it was odd to to a regex replace on the string 'true' or 'false' so it caught my attention.

I know it's not an important fix but I was here so why not.

reference to the commit that originally changed this:
https://github.com/nektos/act/commit/4391a10d5a013afb3a4cbc1640eb745132593d7a#diff-4fe45e900ed33a3395bb42c8d8a85c1afb94987b2368bfe31d62e9e1ebd69060R124
<img width="962" height="330" alt="image" src="https://github.com/user-attachments/assets/78502cce-2b2b-41ff-86b8-41e70b923fa3" />
