### PR TITLE
fix: guard GetHealth against nil docker client in dry-run mode

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -170,6 +170,10 @@ func (cr *containerReference) Remove() common.Executor {
 }
 
 func (cr *containerReference) GetHealth(ctx context.Context) Health {
+	if cr.cli == nil {
+		common.Logger(ctx).Debugf("skip health check: no docker client (dry-run)")
+		return HealthHealthy
+	}
 	resp, err := cr.cli.ContainerInspect(ctx, cr.id)
 	logger := common.Logger(ctx)
 	if err != nil {


### PR DESCRIPTION
When running `act -n` (dry-run mode) with workflows that define service containers, the process panics with a SIGSEGV because `GetHealth()` tries to call `ContainerInspect` on a nil docker client.

In dry-run mode, `connect()` is skipped via `.IfNot(common.Dryrun)`, so `cr.cli` is never set. But `waitForServiceContainer` still calls `GetHealth()` unconditionally, which dereferences the nil client.

The fix adds a nil check on `cr.cli` at the top of `GetHealth()` — if there's no client, we just return `HealthHealthy` and move on. This matches the pattern already used by `Start()` and `Remove()` which skip execution during dry-run.

Tested by verifying the build compiles cleanly. The existing container tests require a live Docker daemon so they can't run in CI-less environments, but the logic is straightforward — just a nil guard.

Fixes #5934