### PR TITLE
fix: add --name and --detach flags to container options parser

### DIFF
--- a/pkg/container/docker_cli.go
+++ b/pkg/container/docker_cli.go
@@ -135,6 +135,8 @@ type containerOptions struct {
 	runtime            string
 	autoRemove         bool
 	init               bool
+	name               string
+	detach             bool
 
 	Image string
 	Args  []string
@@ -203,6 +205,11 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.StringVarP(&copts.user, "user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
 	flags.StringVarP(&copts.workingDir, "workdir", "w", "", "Working directory inside the container")
 	flags.BoolVar(&copts.autoRemove, "rm", false, "Automatically remove the container when it exits")
+
+	// These flags are accepted for compatibility with docker create/run but are
+	// not used by act, which manages container names and lifecycle internally.
+	flags.StringVar(&copts.name, "name", "", "Assign a name to the container")
+	flags.BoolVarP(&copts.detach, "detach", "d", false, "Run container in background and print container ID")
 
 	// Security
 	flags.Var(&copts.capAdd, "cap-add", "Add Linux capabilities")


### PR DESCRIPTION
Fixes #5929

## Problem

When using `--name` or `-d` in the `options` field of service containers (which is valid in GitHub Actions), act fails with:

```
Cannot parse container options: '--name my-redis-container': 'unknown flag: --name'
```

This happens because the container options flag parser in `docker_cli.go` doesn't register these flags, so pflag rejects them as unknown.

## Fix

Added `--name` and `--detach`/`-d` to the flag set in `addFlags()`. These flags are accepted for compatibility with `docker create`/`docker run` but the values are not used by act, which manages container names and lifecycle internally. This follows the same pattern as `--rm`, which is already accepted but unused.

## Example workflow that now works

```yaml
services:
  redis:
    image: redis:latest
    ports:
      - 9003:6379
    options: --name my-redis-container
```