### PR TITLE
fix: serialize concurrent GoGitActionCache access per repo

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -649,7 +649,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 		if input.useNewActionCache || len(input.localRepository) > 0 {
 			if input.actionOfflineMode {
 				config.ActionCache = &runner.GoGitActionCacheOfflineMode{
-					Parent: runner.GoGitActionCache{
+					Parent: &runner.GoGitActionCache{
 						Path: config.ActionCacheDir,
 					},
 				}

--- a/pkg/runner/action_cache.go
+++ b/pkg/runner/action_cache.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	git "github.com/go-git/go-git/v5"
@@ -28,15 +29,27 @@ type ActionCache interface {
 }
 
 type GoGitActionCache struct {
-	Path string
+	Path  string
+	locks sync.Map
 }
 
-func (c GoGitActionCache) Fetch(ctx context.Context, cacheDir, url, ref, token string) (string, error) {
+// repoMu returns a per-gitPath mutex to serialize concurrent access to the
+// same bare git repository. Different repos are not contended.
+func (c *GoGitActionCache) repoMu(gitPath string) *sync.Mutex {
+	v, _ := c.locks.LoadOrStore(gitPath, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+func (c *GoGitActionCache) Fetch(ctx context.Context, cacheDir, url, ref, token string) (string, error) {
 	logger := common.Logger(ctx)
 
 	gitPath := path.Join(c.Path, safeFilename(cacheDir)+".git")
 
 	logger.Infof("GoGitActionCache fetch %s with ref %s at %s", url, ref, gitPath)
+
+	mu := c.repoMu(gitPath)
+	mu.Lock()
+	defer mu.Unlock()
 
 	gogitrepo, err := git.PlainInit(gitPath, true)
 	if errors.Is(err, git.ErrRepositoryAlreadyExists) {
@@ -127,12 +140,16 @@ func (g *GitFileInfo) Sys() any {
 	return nil
 }
 
-func (c GoGitActionCache) GetTarArchive(ctx context.Context, cacheDir, sha, includePrefix string) (io.ReadCloser, error) {
+func (c *GoGitActionCache) GetTarArchive(ctx context.Context, cacheDir, sha, includePrefix string) (io.ReadCloser, error) {
 	logger := common.Logger(ctx)
 
 	gitPath := path.Join(c.Path, safeFilename(cacheDir)+".git")
 
 	logger.Infof("GoGitActionCache get content %s with sha %s subpath '%s' at %s", cacheDir, sha, includePrefix, gitPath)
+
+	mu := c.repoMu(gitPath)
+	mu.Lock()
+	defer mu.Unlock()
 
 	gogitrepo, err := git.PlainOpen(gitPath)
 	if err != nil {

--- a/pkg/runner/action_cache_offline_mode.go
+++ b/pkg/runner/action_cache_offline_mode.go
@@ -11,7 +11,7 @@ import (
 )
 
 type GoGitActionCacheOfflineMode struct {
-	Parent GoGitActionCache
+	Parent *GoGitActionCache
 }
 
 func (c GoGitActionCacheOfflineMode) Fetch(ctx context.Context, cacheDir, url, ref, token string) (string, error) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -353,8 +353,8 @@ func TestRunEvent(t *testing.T) {
 				if yaml.Unmarshal(file, testConfig) == nil {
 					if testConfig.LocalRepositories != nil {
 						config.ActionCache = &LocalRepositoryCache{
-							Parent: GoGitActionCache{
-								path.Clean(path.Join(workdir, "cache")),
+							Parent: &GoGitActionCache{
+								Path: path.Clean(path.Join(workdir, "cache")),
 							},
 							LocalRepositories: testConfig.LocalRepositories,
 							CacheDirCache:     map[string]string{},
@@ -386,7 +386,7 @@ func TestPullAndPostStepFailureIsJobFailure(t *testing.T) {
 	}
 
 	defCache := &GoGitActionCache{
-		path.Clean(path.Join(workdir, "cache")),
+		Path: path.Clean(path.Join(workdir, "cache")),
 	}
 
 	mockCache := &mockCache{}


### PR DESCRIPTION
## Summary

When multiple matrix jobs within a reusable workflow concurrently fetch the same action, they share a bare git repository via `GoGitActionCache`. Concurrent `PlainInit`/`FetchContext`/`GetTarArchive` calls on the same repo cause intermittent failures:

- `failed to read 'action.yml'` — objects not yet written when another goroutine reads
- `repository not found` — bare repo in inconsistent state during concurrent init/fetch

## Fix

Add a per-repo `sync.Mutex` (stored in a `sync.Map` on `GoGitActionCache`) to serialize `Fetch` and `GetTarArchive` calls for the same `gitPath`. Different repos remain fully parallel.

Changes:
- `GoGitActionCache`: add `locks sync.Map` field and `repoMu()` helper
- `Fetch()` / `GetTarArchive()`: acquire per-repo mutex before git operations
- Receivers changed from value to pointer (`*GoGitActionCache`) since `sync.Map` must not be copied
- `GoGitActionCacheOfflineMode.Parent`: changed to `*GoGitActionCache` accordingly
- `cmd/root.go` and test files: updated to use pointer instantiation

## Reproduction

1. Create a workflow calling a reusable workflow with a `fromJSON()` matrix (2+ entries)
2. Each matrix job references the same external action (e.g., `aws-actions/configure-aws-credentials`)
3. Run with act using containerized runners
4. Failure is intermittent — depends on goroutine scheduling

Fixes #6028