### PR TITLE
fix: clone shared maps to prevent concurrent map read/write panics

### DIFF
--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"reflect"
 	"regexp"
@@ -49,7 +50,7 @@ func (rc *RunContext) NewExpressionEvaluatorWithEnv(ctx context.Context, env map
 
 		for _, needs := range jobNeeds {
 			using[needs] = exprparser.Needs{
-				Outputs: jobs[needs].Outputs,
+				Outputs: maps.Clone(jobs[needs].Outputs),
 				Result:  jobs[needs].Result,
 			}
 		}
@@ -135,7 +136,7 @@ func (rc *RunContext) newStepExpressionEvaluator(ctx context.Context, step step,
 	using := make(map[string]exprparser.Needs)
 	for _, needs := range jobNeeds {
 		using[needs] = exprparser.Needs{
-			Outputs: jobs[needs].Outputs,
+			Outputs: maps.Clone(jobs[needs].Outputs),
 			Result:  jobs[needs].Result,
 		}
 	}
@@ -569,10 +570,10 @@ func setupWorkflowInputs(ctx context.Context, inputs *map[string]interface{}, rc
 func getWorkflowSecrets(ctx context.Context, rc *RunContext) map[string]string {
 	if rc.caller != nil {
 		job := rc.caller.runContext.Run.Job()
-		secrets := job.Secrets()
+		secrets := maps.Clone(job.Secrets())
 
 		if secrets == nil && job.InheritSecrets() {
-			secrets = rc.caller.runContext.Config.Secrets
+			secrets = maps.Clone(rc.caller.runContext.Config.Secrets)
 		}
 
 		if secrets == nil {
@@ -586,9 +587,9 @@ func getWorkflowSecrets(ctx context.Context, rc *RunContext) map[string]string {
 		return secrets
 	}
 
-	return rc.Config.Secrets
+	return maps.Clone(rc.Config.Secrets)
 }
 
 func getWorkflowVars(_ context.Context, rc *RunContext) map[string]string {
-	return rc.Config.Vars
+	return maps.Clone(rc.Config.Vars)
 }


### PR DESCRIPTION
## Summary

Reusable workflows evaluate expressions in parallel goroutines that share mutable map references for secrets, vars, and job outputs. When one goroutine interpolates secrets in-place (line 584: `secrets[k] = rc.caller.runContext.ExprEval.Interpolate(ctx, v)`) while another reads the same map, Go panics with:

```
fatal error: concurrent map iteration and map write
```

## Fix

Clone maps at sharing boundaries using `maps.Clone()` (Go 1.21+):

| Site | Why it's shared |
|------|----------------|
| `getWorkflowSecrets`: `job.Secrets()` | Returned by reference; mutated in-place by `Interpolate` loop |
| `getWorkflowSecrets`: `rc.caller.runContext.Config.Secrets` | Inherited secrets shared across all caller goroutines |
| `getWorkflowSecrets`: `rc.Config.Secrets` | Direct config reference returned to multiple consumers |
| `getWorkflowVars`: `rc.Config.Vars` | Config vars shared across goroutines |
| `NewExpressionEvaluator(WithEnv)`: `jobs[needs].Outputs` | Job outputs read by multiple downstream needs evaluations |

## Context

PR #5026 previously fixed a concurrent map write in `valueMasker` (logger.go) by adding a `sync.Mutex`. The sites in `expression.go` were not addressed — they share maps by reference without any synchronization. `maps.Clone()` is a simpler fix here since the callers don't need the shared reference; they only need a snapshot.

Fixes #2199