### PR TITLE
fix: accept unknown JSON fields in artifact v4 Twirp decode

### DIFF
--- a/pkg/artifacts/artifacts_v4.go
+++ b/pkg/artifacts/artifacts_v4.go
@@ -244,7 +244,7 @@ func (r *artifactV4Routes) parseProtbufBody(ctx *ArtifactContext, req protorefle
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")
 		return false
 	}
-	err = protojson.Unmarshal(body, req)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(body, req)
 	if err != nil {
 		log.Errorf("Error decode request body: %v", err)
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")


### PR DESCRIPTION
Fixes #6022.

**Root cause:** Default protojson.Unmarshal errors on keys absent from our generated protos. upload-artifact@v7 sends mime_type.

**Fix:** Decode Twirp JSON with UnmarshalOptions{DiscardUnknown: true} in parseProtbufBody.

**Changes**
- pkg/artifacts/artifacts_v4.go: one-line option on unmarshal.

**Testing**
- go build ./... OK. go test ./pkg/artifacts/... needs Docker for existing integration tests; not run here.