### PR TITLE
fix: discard unknown fields in protobuf unmarshal for artifact v4 API

### DIFF
--- a/pkg/artifacts/artifacts_v4.go
+++ b/pkg/artifacts/artifacts_v4.go
@@ -244,7 +244,7 @@ func (r *artifactV4Routes) parseProtbufBody(ctx *ArtifactContext, req protorefle
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")
 		return false
 	}
-	err = protojson.Unmarshal(body, req)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(body, req)
 	if err != nil {
 		log.Errorf("Error decode request body: %v", err)
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")

--- a/pkg/artifacts/server_test.go
+++ b/pkg/artifacts/server_test.go
@@ -317,6 +317,24 @@ func runTestJobFile(ctx context.Context, t *testing.T, tjfi TestJobFileInfo) {
 	})
 }
 
+func TestCreateArtifactV4UnknownField(t *testing.T) {
+	assert := assert.New(t)
+
+	var memfs = fstest.MapFS(map[string]*fstest.MapFile{})
+
+	router := httprouter.New()
+	RoutesV4(router, "artifact/server/path", writeMapFS{memfs}, memfs)
+
+	// Simulate upload-artifact@v7 sending an unknown field (mime_type)
+	body := `{"workflow_run_backend_id":"1","workflow_job_run_backend_id":"2","name":"test-artifact","version":4,"mime_type":"application/zip"}`
+	req, _ := http.NewRequest("POST", "http://localhost"+path.Join(ArtifactV4RouteBase, "CreateArtifact"), strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(http.StatusOK, rr.Code, "CreateArtifact should succeed even with unknown fields like mime_type")
+}
+
 func TestMkdirFsImplSafeResolve(t *testing.T) {
 	baseDir := "/foo/bar"
 


### PR DESCRIPTION
Fixes #6022

## Summary

`upload-artifact@v7` sends new fields (e.g. `mime_type`) in `CreateArtifact` requests that are not in the proto definition (`artifact.pb.go`). The default strict `protojson.Unmarshal` rejects these, causing a 500 error.

This changes `parseProtbufBody` in `pkg/artifacts/artifacts_v4.go` to use `protojson.UnmarshalOptions{DiscardUnknown: true}`, which silently ignores unknown fields. This is the standard approach for forward-compatible protobuf handling.

## Changes

- `pkg/artifacts/artifacts_v4.go`: Use `UnmarshalOptions{DiscardUnknown: true}` instead of plain `protojson.Unmarshal`
- `pkg/artifacts/server_test.go`: Add unit test verifying `CreateArtifact` succeeds when request contains unknown fields

## Test Plan

- `go test ./pkg/artifacts/...` passes
- New test `TestCreateArtifactWithUnknownFields` sends a request body with an extra `mime_type` field and asserts HTTP 200