### PR TITLE
fix(artifacts): tolerate unknown protobuf fields in artifact server

### DIFF
--- a/pkg/artifacts/artifacts_v4.go
+++ b/pkg/artifacts/artifacts_v4.go
@@ -244,7 +244,7 @@ func (r *artifactV4Routes) parseProtbufBody(ctx *ArtifactContext, req protorefle
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")
 		return false
 	}
-	err = protojson.Unmarshal(body, req)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(body, req)
 	if err != nil {
 		log.Errorf("Error decode request body: %v", err)
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")


### PR DESCRIPTION
## Summary

Fixes artifact server compatibility with `upload-artifact@v7` by tolerating unknown protobuf fields.

## Problem

When using `upload-artifact@v7`, act's artifact server fails with:
```
unknown field "mime_type" in CreateArtifactRequest
```

GitHub added a new `mime_type` field to the `CreateArtifactRequest` protobuf message, but act's protobuf definition doesn't include this field. `protojson.Unmarshal()` uses strict mode by default, rejecting unknown fields.

## Solution

Modified `parseProtbufBody` function in `pkg/artifacts/artifacts_v4.go`:

```go
// Before
err = protojson.Unmarshal(body, req)

// After
err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(body, req)
```

Using `DiscardUnknown: true` makes the artifact server forward-compatible with new fields added by GitHub.

## Changes

- `pkg/artifacts/artifacts_v4.go` (1 line)

Fixes #6022