### PR TITLE
fix: add mutex to LocalRepositoryCache to prevent concurrent map panic

### DIFF
--- a/pkg/runner/local_repository_cache.go
+++ b/pkg/runner/local_repository_cache.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/filecollector"
@@ -20,6 +21,7 @@ type LocalRepositoryCache struct {
 	Parent            ActionCache
 	LocalRepositories map[string]string
 	CacheDirCache     map[string]string
+	cacheDirMu        sync.RWMutex
 }
 
 func (l *LocalRepositoryCache) Fetch(ctx context.Context, cacheDir, url, ref, token string) (string, error) {
@@ -27,13 +29,17 @@ func (l *LocalRepositoryCache) Fetch(ctx context.Context, cacheDir, url, ref, to
 	logger.Debugf("LocalRepositoryCache fetch %s with ref %s", url, ref)
 	if dest, ok := l.LocalRepositories[fmt.Sprintf("%s@%s", url, ref)]; ok {
 		logger.Infof("LocalRepositoryCache matched %s with ref %s to %s", url, ref, dest)
+		l.cacheDirMu.Lock()
 		l.CacheDirCache[fmt.Sprintf("%s@%s", cacheDir, ref)] = dest
+		l.cacheDirMu.Unlock()
 		return ref, nil
 	}
 	if purl, err := goURL.Parse(url); err == nil {
 		if dest, ok := l.LocalRepositories[fmt.Sprintf("%s@%s", strings.TrimPrefix(purl.Path, "/"), ref)]; ok {
 			logger.Infof("LocalRepositoryCache matched %s with ref %s to %s", url, ref, dest)
+			l.cacheDirMu.Lock()
 			l.CacheDirCache[fmt.Sprintf("%s@%s", cacheDir, ref)] = dest
+			l.cacheDirMu.Unlock()
 			return ref, nil
 		}
 	}
@@ -44,7 +50,10 @@ func (l *LocalRepositoryCache) Fetch(ctx context.Context, cacheDir, url, ref, to
 func (l *LocalRepositoryCache) GetTarArchive(ctx context.Context, cacheDir, sha, includePrefix string) (io.ReadCloser, error) {
 	logger := common.Logger(ctx)
 	// sha is mapped to ref in fetch if there is a local override
-	if dest, ok := l.CacheDirCache[fmt.Sprintf("%s@%s", cacheDir, sha)]; ok {
+	l.cacheDirMu.RLock()
+	dest, ok := l.CacheDirCache[fmt.Sprintf("%s@%s", cacheDir, sha)]
+	l.cacheDirMu.RUnlock()
+	if ok {
 		logger.Infof("LocalRepositoryCache read cachedir %s with ref %s and subpath '%s' from %s", cacheDir, sha, includePrefix, dest)
 		srcPath := filepath.Join(dest, includePrefix)
 		buf := &bytes.Buffer{}


### PR DESCRIPTION
## Summary

`LocalRepositoryCache.CacheDirCache` is a plain `map[string]string` accessed concurrently by `Fetch` (write) and `GetTarArchive` (read) when multiple matrix jobs resolve `--local-repository` actions in parallel. This causes an intermittent panic:

```
fatal error: concurrent map read and map write

goroutine 313114 [running]:
LocalRepositoryCache.GetTarArchive(...)
    local_repository_cache.go:47
```

This is the same class of bug as #6028 (fixed in #6029 for `GoGitActionCache`), but in the `--local-repository` code path. The `GoGitActionCache` fix added per-repo mutexes to serialize git operations — this PR applies the same pattern to `LocalRepositoryCache`.

## Fix

Add a `sync.RWMutex` to serialize access to `CacheDirCache`:
- `Fetch()`: write lock when updating the cache
- `GetTarArchive()`: read lock when looking up cached paths

`LocalRepositories` is set at initialization and only read after, so it does not need synchronization.

## Reproduction

1. Create a workflow calling a reusable workflow with a matrix (2+ entries)
2. Each matrix job references the same external action via `--local-repository`
3. Run with act using containerized runners
4. Failure is intermittent — depends on goroutine scheduling

Crash observed in CI: https://github.com/MercuryTechnologies/mercury-web-backend/actions/runs/23767992978/job/69252242640

## Context

Hi @cplee — this is a companion to #6029, which we submitted a few weeks ago for the same race condition in `GoGitActionCache`. We've been running act with the #6029 patch in our CI for a couple of weeks now (hundreds of runs across multiple environments) and it's been stable. This new crash surfaced because `LocalRepositoryCache` has the same unprotected map pattern but in a different code path that we didn't catch initially.

We'd appreciate a review when you get a chance — both this and #6029 are small, targeted fixes. Happy to address any feedback.

Related: #6028 (issue), #6029 (GoGitActionCache fix)