### PR TITLE
fix: using variable interpolation `${{ in artifacts.yml...

### DIFF
--- a/pkg/artifacts/testdata/v4/artifacts.yml
+++ b/pkg/artifacts/testdata/v4/artifacts.yml
@@ -5,18 +5,26 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - run: env
-    - run: |
-        github:
-        ${{ tojson(github) }}
-        inputs:
-        ${{ tojson(inputs) }}
-        matrix:
-        ${{ tojson(matrix) }}
-        needs:
-        ${{ tojson(needs) }}
-        strategy:
-        ${{ tojson(strategy) }}            
-      shell: cp {0} context.txt
+    - env:
+        GITHUB_CTX: ${{ toJSON(github) }}
+        INPUTS_CTX: ${{ toJSON(inputs) }}
+        MATRIX_CTX: ${{ toJSON(matrix) }}
+        NEEDS_CTX: ${{ toJSON(needs) }}
+        STRATEGY_CTX: ${{ toJSON(strategy) }}
+      run: |
+        {
+          echo "github:"
+          echo "$GITHUB_CTX"
+          echo "inputs:"
+          echo "$INPUTS_CTX"
+          echo "matrix:"
+          echo "$MATRIX_CTX"
+          echo "needs:"
+          echo "$NEEDS_CTX"
+          echo "strategy:"
+          echo "$STRATEGY_CTX"
+        } > context.txt
+      shell: bash
     - run: echo Artifact2 > data.txt
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Fix high severity security issue in `pkg/artifacts/testdata/v4/artifacts.yml`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.run-shell-injection.run-shell-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.run-shell-injection.run-shell-injection` |
| **File** | `pkg/artifacts/testdata/v4/artifacts.yml:8` |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Changes
- `pkg/artifacts/testdata/v4/artifacts.yml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---