### PR TITLE
Clearer job status at the last line

### DIFF
--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -174,9 +174,9 @@ func setJobResult(ctx context.Context, info jobInfo, rc *RunContext, success boo
 		rc.caller.runContext.result(jobResult)
 	}
 
-	jobResultMessage := "succeeded"
+	jobResultMessage := "succeeded \u2705"
 	if jobResult != "success" {
-		jobResultMessage = "failed"
+		jobResultMessage = "failed \u274C"
 	}
 
 	logger.WithField("jobResult", jobResult).Infof("\U0001F3C1  Job %s", jobResultMessage)


### PR DESCRIPTION
The last line in the terminal output will be:

- `🏁  Job failed ❌`
- `🏁  Job succeeded ✅`

instead of:
- `🏁  Job failed`
- `🏁  Job succeeded`

Closes: #6079