### PR TITLE
Fix: prevent path escape in CopyTarStream when network=host

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -710,11 +710,14 @@ func (cr *containerReference) CopyTarStream(ctx context.Context, destPath string
 	if common.Dryrun(ctx) {
 		return nil
 	}
-	// Mkdir
+	// Mkdir — strip leading "/" so the path is relative to DestinationPath="/"
+	// Without this, Docker rejects mkdirat with "path escapes from parent" when
+	// network=host maps the container's /var/run to the host's /var/run.
+	tarName := strings.TrimPrefix(destPath, "/")
 	buf := &bytes.Buffer{}
 	tw := tar.NewWriter(buf)
 	_ = tw.WriteHeader(&tar.Header{
-		Name:     destPath,
+		Name:     tarName,
 		Mode:     0o777,
 		Typeflag: tar.TypeDir,
 	})


### PR DESCRIPTION
## Fix: prevent path escape in CopyTarStream when network=host

**Issue:** #6092

### Root Cause

In `CopyTarStream` (pkg/container/docker_run.go), the tar header Name was set to the absolute path (`/var/run/act`), which Docker rejects with `mkdirat: path escapes from parent` when `network=host` maps the container `/var/run` to the host `/var/run`.

### Fix

Strip leading `/` from tar header Name so it is relative to `DestinationPath="/"`:

```go
tarName := strings.TrimPrefix(destPath, "/")
_ = tw.WriteHeader(&tar.Header{
    Name:     tarName,  // was: destPath
    ...
})
```

This allows Docker to correctly create `var/run/act` inside the container.