### PR TITLE
fix: add deployment boolean to job-environment-mapping schema (#6086)

### DIFF
--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1662,6 +1662,10 @@
           "url": {
             "type": "string-runner-context-no-secrets",
             "description": "The environment URL, which maps to `environment_url` in the deployments API."
+          },
+          "deployment": {
+            "type": "boolean",
+            "description": "When set to true, runs the workflow without creating a deployment object."
           }
         }
       }


### PR DESCRIPTION
## Summary

Add the `deployment` boolean field to `job-environment-mapping` in the workflow schema to support the new GitHub Actions syntax that allows workflows to run in an environment without creating a deployment object.

## Changes

- Added `deployment` field (type: `boolean`) to `job-environment-mapping.properties` in `pkg/schema/workflow_schema.json`

## Test Case

The following workflow now validates correctly:

```yaml
jobs:
  example:
    runs-on: ubuntu-latest
    environment:
      name: production
      deployment: false  # New field
    steps:
      - run: echo "Hello"
```

## Issue

Fixes nektos/act#6086