### PR TITLE
feat(platforms): fall back to ubuntu-latest image for ubuntu-slim runner

### DIFF
--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -7,6 +7,7 @@ import (
 func (i *Input) newPlatforms() map[string]string {
 	platforms := map[string]string{
 		"ubuntu-latest": "node:16-buster-slim",
+		"ubuntu-slim":   "node:16-buster-slim",
 		"ubuntu-22.04":  "node:16-bullseye-slim",
 		"ubuntu-20.04":  "node:16-buster-slim",
 		"ubuntu-18.04":  "node:16-buster-slim",

--- a/cmd/platforms_test.go
+++ b/cmd/platforms_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPlatformsDefaults(t *testing.T) {
+	i := &Input{}
+	platforms := i.newPlatforms()
+
+	// ubuntu-latest must be present and resolve to a default image
+	latest, ok := platforms["ubuntu-latest"]
+	assert.True(t, ok, "ubuntu-latest should be a default platform")
+	assert.NotEmpty(t, latest)
+
+	// ubuntu-slim should fall back to the same image as ubuntu-latest
+	// (GitHub's 1-vCPU runner uses the same base distro, see issue #6003)
+	slim, ok := platforms["ubuntu-slim"]
+	assert.True(t, ok, "ubuntu-slim should be a default platform")
+	assert.Equal(t, latest, slim, "ubuntu-slim should default to the same image as ubuntu-latest")
+}
+
+func TestNewPlatformsUserOverride(t *testing.T) {
+	i := &Input{platforms: []string{"ubuntu-slim=catthehacker/ubuntu:act-latest"}}
+	platforms := i.newPlatforms()
+
+	assert.Equal(t, "catthehacker/ubuntu:act-latest", platforms["ubuntu-slim"],
+		"user-supplied -P value should override the default")
+}


### PR DESCRIPTION
## Summary

GitHub Actions' [`ubuntu-slim`](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) 1-vCPU runner (in public preview since 2025-10-28) uses the same base distro as `ubuntu-latest`. Today act prints:

```
🚧  Skipping unsupported platform -- Try running with `-P ubuntu-slim=...`
```

and the user has to manually pass `-P ubuntu-slim=ghcr.io/catthehacker/ubuntu:act-latest` every time, which defeats the point of having a fallback for "latest" Ubuntu runners.

This change adds `ubuntu-slim` to the default platform map in `cmd/platforms.go`, resolving it to the same image as `ubuntu-latest` (`node:16-buster-slim`). Users can still override it via `-P ubuntu-slim=...` exactly like the other platforms — `newPlatforms()` already supports overriding any default.

## Changes

- `cmd/platforms.go`: add `ubuntu-slim` → `node:16-buster-slim` to the default platforms map (1 line).
- `cmd/platforms_test.go` (new): two unit tests covering the default and the user-override path.

## Testing

```
$ go test ./cmd/ -run 'TestNewPlatforms' -v
=== RUN   TestNewPlatformsDefaults
--- PASS: TestNewPlatformsDefaults (0.00s)
=== RUN   TestNewPlatformsUserOverride
--- PASS: TestNewPlatformsUserOverride (0.00s)
PASS
ok      github.com/nektos/act/cmd       0.782s
```

`go vet ./cmd/` passes. Pre-existing `TestFlags/TestFlag-bug-report` failure is unrelated (requires a running Docker daemon).

Closes #6003