### PR TITLE
fix: change default install dir from ./bin to $HOME/.local/bin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ usage() {
 $this: download go binaries for nektos/act
 
 Usage: $this [-b bindir] [-d] [-f] [tag]
-  -b sets bindir or installation directory, Defaults to ./bin
+  -b sets bindir or installation directory, Defaults to $HOME/.local/bin
   -d turns on debug logging
   -f forces installation, bypassing version checks
    [tag] is a tag from
@@ -21,10 +21,10 @@ EOF
 }
 
 parse_args() {
-  #BINDIR is ./bin unless set be ENV
+  #BINDIR is $HOME/.local/bin unless set by ENV
   # over-ridden by flag below
 
-  BINDIR=${BINDIR:-./bin}
+  BINDIR=${BINDIR:-"$HOME/.local/bin"}
   while getopts "b:dfh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;


### PR DESCRIPTION
Small fix for the install script. Right now when you run the curl install it drops the binary into ./bin relative to wherever you happened to be sitting. So like if you ran it from your home dir, act ends up in ~/bin which probably isn't in your PATH.

Changed the default to $HOME/.local/bin which is at least a standard location.

Fixes #2519