### PR TITLE
fix(schema): add deployment field to environment schema

### DIFF
--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1659,6 +1659,10 @@
             "type": "job-environment-name",
             "required": true
           },
+          "deployment": {
+            "type": "boolean",
+            "description": "When set to false, disables deployment creation for the environment."
+          },
           "url": {
             "type": "string-runner-context-no-secrets",
             "description": "The environment URL, which maps to `environment_url` in the deployments API."


### PR DESCRIPTION
Closes #6086

  GitHub recently added support for `deployment: false` in the `environment`
  job setting, allowing workflows to run in an environment without creating
  a deployment object.

  Act's schema was missing this field, causing `--validate --strict` to fail
  with "Unknown Property deployment".