### PR TITLE
fix(artifacts): support upload-artifact@v7 / download-artifact@v8

### DIFF
--- a/pkg/artifacts/artifacts_v4.go
+++ b/pkg/artifacts/artifacts_v4.go
@@ -219,7 +219,13 @@ func (r artifactV4Routes) verifySignature(ctx *ArtifactContext, endp string) (in
 	sig := ctx.Req.URL.Query().Get("sig")
 	expires := ctx.Req.URL.Query().Get("expires")
 	artifactName := ctx.Req.URL.Query().Get("artifactName")
-	dsig, _ := base64.URLEncoding.DecodeString(sig)
+	// Newer @actions/upload-artifact releases (v7+) upload blob content with
+	// the Azure storage SDK, which strips the `=` base64 padding from the `sig`
+	// query value when it re-serializes the signed URL to append comp/blockid.
+	// v4-era clients keep the padding. RawURLEncoding + TrimRight decodes both
+	// the padded and unpadded forms, so the signature check works across every
+	// supported artifact-action version.
+	dsig, _ := base64.RawURLEncoding.DecodeString(strings.TrimRight(sig, "="))
 	taskID, _ := strconv.ParseInt(rawTaskID, 10, 64)
 
 	expecedsig := r.buildSignature(endp, expires, artifactName, taskID)
@@ -244,7 +250,12 @@ func (r *artifactV4Routes) parseProtbufBody(ctx *ArtifactContext, req protorefle
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")
 		return false
 	}
-	err = protojson.Unmarshal(body, req)
+	// DiscardUnknown keeps the artifact server forward-compatible with newer
+	// @actions/upload-artifact releases that add optional request fields the
+	// vendored protobuf doesn't know about yet (e.g. mime_type in v7+). act
+	// doesn't consume those fields, so silently dropping them is safe and
+	// avoids hard-failing the upload with `unknown field "..."`.
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(body, req)
 	if err != nil {
 		log.Errorf("Error decode request body: %v", err)
 		ctx.Error(http.StatusInternalServerError, "Error decode request body")

--- a/pkg/artifacts/server_test.go
+++ b/pkg/artifacts/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -315,6 +316,62 @@ func runTestJobFile(ctx context.Context, t *testing.T, tjfi TestJobFileInfo) {
 
 		fmt.Println("::endgroup::")
 	})
+}
+
+func TestCreateArtifactV4IgnoresUnknownFields(t *testing.T) {
+	assert := assert.New(t)
+
+	var memfs = fstest.MapFS(map[string]*fstest.MapFile{})
+
+	router := httprouter.New()
+	RoutesV4(router, "artifact/server/path", writeMapFS{memfs}, memfs)
+
+	// `mime_type` is sent by @actions/upload-artifact v7+ but isn't part of
+	// act's vendored protobuf. The server must ignore it instead of failing
+	// the upload with `unknown field "mime_type"`.
+	body := `{"workflow_run_backend_id":"1","workflow_job_run_backend_id":"1","name":"test","version":4,"mime_type":"application/zip"}`
+	req, _ := http.NewRequest("POST", "http://localhost"+path.Join(ArtifactV4RouteBase, "CreateArtifact"), strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(http.StatusOK, rr.Code)
+
+	response := CreateArtifactResponse{}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.Nil(err)
+	assert.True(response.Ok)
+}
+
+func TestUploadArtifactV4AcceptsUnpaddedSignature(t *testing.T) {
+	assert := assert.New(t)
+
+	var memfs = fstest.MapFS(map[string]*fstest.MapFile{})
+
+	router := httprouter.New()
+	RoutesV4(router, "artifact/server/path", writeMapFS{memfs}, memfs)
+
+	// Build a genuine signed upload URL the same way the server does. The HMAC
+	// secret and inputs match what the router's verifySignature recomputes, so a
+	// well-formed request authorizes regardless of AppURL.
+	signer := artifactV4Routes{prefix: ArtifactV4RouteBase, AppURL: "localhost"}
+	signedURL := signer.buildArtifactURL("UploadArtifact", "test", 1)
+
+	// The Azure storage SDK in @actions/upload-artifact v7+ strips the `=`
+	// base64 padding from the `sig` query value when it re-serializes the URL.
+	// Reproduce that and confirm the server still authorizes the block upload.
+	parsed, err := url.Parse(signedURL)
+	assert.Nil(err)
+	q := parsed.Query()
+	q.Set("sig", strings.TrimRight(q.Get("sig"), "="))
+	q.Set("comp", "block")
+	parsed.RawQuery = q.Encode()
+
+	uploadReq, _ := http.NewRequest("PUT", parsed.String(), strings.NewReader("content"))
+	uploadRR := httptest.NewRecorder()
+	router.ServeHTTP(uploadRR, uploadReq)
+
+	assert.Equal(http.StatusCreated, uploadRR.Code)
 }
 
 func TestMkdirFsImplSafeResolve(t *testing.T) {


### PR DESCRIPTION
Fixes #6114.

The v4 artifact server rejected uploads from `actions/upload-artifact@v7` (and the matching `download-artifact@v8`) for two independent reasons. Both are narrow, backward-compatible relaxations of request parsing.

### 1. `unknown field "mime_type"`

`parseProtbufBody` used a strict `protojson.Unmarshal`, which fails on any field absent from act's vendored protobuf. `upload-artifact@v7` adds a `mime_type` field, producing `Error decode request body: unknown field "mime_type"` at `CreateArtifact`.

Decoding with `protojson.UnmarshalOptions{DiscardUnknown: true}` ignores fields act doesn't consume and keeps the server forward-compatible with future optional additions.

### 2. `Error unauthorized`

`verifySignature` decoded the `sig` query parameter with `base64.URLEncoding`, which requires `=` padding. The Azure storage SDK used by `upload-artifact@v7` for blob upload strips the padding when it re-serializes the signed URL to append `comp`/`blockid`, so the strict decode failed silently and the HMAC check rejected the upload.

Decoding with `base64.RawURLEncoding` after trimming any `=` accepts both the padded (v4-era) and unpadded (v7+) forms.

### Compatibility

Both changes only *relax* parsing — they never reject anything the previous code accepted, so v4/v5/v6 clients are unaffected. (`upload-artifact@v1`–`v3` use a separate, non-protobuf code path that this change does not touch.)

### Testing

- Added `TestCreateArtifactV4IgnoresUnknownFields` and `TestUploadArtifactV4AcceptsUnpaddedSignature`.
- `go test ./pkg/artifacts/` passes.
- Verified end-to-end with real workflows: `upload-artifact@v4` → `download-artifact@v4`, and `upload-artifact@v7` → `download-artifact@v8`, both round-trip successfully (including a ~160 MB artifact).