### PR TITLE
fix: close HijackedResponse in attach() to prevent connection leak

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -862,6 +862,7 @@ func (cr *containerReference) attach() common.Executor {
 			errWriter = os.Stderr
 		}
 		go func() {
+			defer out.Close()
 			if !isTerminal || os.Getenv("NORAW") != "" {
 				_, err = stdcopy.StdCopy(outWriter, errWriter, out.Reader)
 			} else {


### PR DESCRIPTION
The `attach()` method creates a `HijackedResponse` via `ContainerAttach` but never closes it. The goroutine reading from `out.Reader` keeps the underlying TCP connection open even after the read completes with EOF.

The sibling `exec()` method in the same file correctly uses `defer resp.Close()` for the same resource type (line 600).

This adds `defer out.Close()` inside the reader goroutine so the connection is released after the container output stream ends. The placement inside the goroutine (rather than at function level) is intentional: `attach()` returns immediately after spawning the goroutine, so a function-level defer would close the connection prematurely.

This leak has been present since commit 532af98 (2020-02-06).