### PR TITLE
Implemented podman support

### DIFF
--- a/pkg/container/docker_socket.go
+++ b/pkg/container/docker_socket.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,10 +20,62 @@ var CommonSocketLocations = []string{
 	"$HOME/.docker/run/docker.sock",
 }
 
+func getPodmanSocet() (string, bool) {
+	// Podman uses api compatible with Docker v1.40 API,
+	// so no further modifications are needed.
+	// It is worth noting that correct communication with podman over socket depends
+	// on systemd, which may cause compatibility problems with some distributions
+
+	// After install you have to do: systemctl --user enable --now podman.socket
+	/* https://docs.podman.io/en/latest/markdown/podman-system-service.1.html
+		The systemd unit files that declares the Podman API service for users are
+	   		/usr/lib/systemd/user/podman.service
+	    	/usr/lib/systemd/user/podman.socket
+
+	     In the file podman.socket the path of the listening Unix socket is defined by
+	     	ListenStream=%t/podman/podman.sock
+		The path contains the systemd specifier %t which systemd expands to the value of the
+		environment variable XDG_RUNTIME_DIR (see systemd specifiers in the systemd.unit(5) man page
+	*/
+
+	const (
+		DEFAULT_PODMAN_PATH   = "/usr/lib/systemd/user/podman.socket"
+		DEFAULT_PODMAN_PREFIX = "ListenStream="
+		DEFULT_SYSTEMD_ENV    = "XDG_RUNTIME_DIR"
+		DEFULT_SOCET_PREIFX   = "unix://"
+	)
+
+	f, err := os.Open(DEFAULT_PODMAN_PATH)
+	if err != nil {
+		return "", false
+	}
+	input := bufio.NewScanner(f)
+
+	if input.Err() != nil {
+		return "", false
+	}
+
+	for input.Scan() {
+		line := input.Text()
+		if strings.HasPrefix(line, DEFAULT_PODMAN_PREFIX) {
+			if env, ok := os.LookupEnv(DEFULT_SYSTEMD_ENV); ok {
+				// e.g line = "ListenStream=%t/podman/podman.sock"
+				// line[len(DEFAULT_PODMAN_PREFIX)+len("%t"):] =/podman/podman.sock
+				return DEFULT_SOCET_PREIFX + env + line[len(DEFAULT_PODMAN_PREFIX)+len("%t"):], true
+			}
+		}
+	}
+
+	return "", false
+}
+
 // returns socket URI or false if not found any
 func socketLocation() (string, bool) {
 	if dockerHost, exists := os.LookupEnv("DOCKER_HOST"); exists {
 		return dockerHost, true
+	}
+	if podmanHost, exist := getPodmanSocet(); exist {
+		return podmanHost, exist
 	}
 
 	for _, p := range CommonSocketLocations {


### PR DESCRIPTION
Podman is the second most popular container management program in the world. Its socetu implementation is compatible with the Docker v1.40 API. So I added a feature that allows you to connect to Podman. I was able to run the entire project's CI/CD workflow except for the release step because I don't have a token.

Funcion:
```go
func getPodmanSocet() (string, bool) {
	// Podman uses api compatible with Docker v1.40 API,
	// so no further modifications are needed.
	// It is worth noting that correct communication with podman over socket depends
	// on systemd, which may cause compatibility problems with some distributions

	// After install you have to do: systemctl --user enable --now podman.socket
	/* https://docs.podman.io/en/latest/markdown/podman-system-service.1.html
		The systemd unit files that declares the Podman API service for users are
	   		/usr/lib/systemd/user/podman.service
	    	/usr/lib/systemd/user/podman.socket

	     In the file podman.socket the path of the listening Unix socket is defined by
	     	ListenStream=%t/podman/podman.sock
		The path contains the systemd specifier %t which systemd expands to the value of the
		environment variable XDG_RUNTIME_DIR (see systemd specifiers in the systemd.unit(5) man page
	*/

	const (
		DEFAULT_PODMAN_PATH   = "/usr/lib/systemd/user/podman.socket"
		DEFAULT_PODMAN_PREFIX = "ListenStream="
		DEFULT_SYSTEMD_ENV    = "XDG_RUNTIME_DIR"
		DEFULT_SOCET_PREIFX   = "unix://"
	)

	f, err := os.Open(DEFAULT_PODMAN_PATH)
	if err != nil {
		return "", false
	}
	input := bufio.NewScanner(f)

	if input.Err() != nil {
		return "", false
	}

	for input.Scan() {
		line := input.Text()
		if strings.HasPrefix(line, DEFAULT_PODMAN_PREFIX) {
			if env, ok := os.LookupEnv(DEFULT_SYSTEMD_ENV); ok {
				// e.g line = "ListenStream=%t/podman/podman.sock"
				// line[len(DEFAULT_PODMAN_PREFIX)+len("%t"):] =/podman/podman.sock
				return DEFULT_SOCET_PREIFX + env + line[len(DEFAULT_PODMAN_PREFIX)+len("%t"):], true
			}
		}
	}

	return "", false
}
```
Usage:
```go
// returns socket URI or false if not found any
func socketLocation() (string, bool) {
	if dockerHost, exists := os.LookupEnv("DOCKER_HOST"); exists {
		return dockerHost, true
	}
	if podmanHost, exist := getPodmanSocet(); exist {
		return podmanHost, exist
	}

	for _, p := range CommonSocketLocations {
		if _, err := os.Lstat(os.ExpandEnv(p)); err == nil {
			if strings.HasPrefix(p, `\\.\`) {
				return "npipe://" + filepath.ToSlash(os.ExpandEnv(p)), true
			}
			return "unix://" + filepath.ToSlash(os.ExpandEnv(p)), true
		}
	}

	return "", false
}
```

Project ci:
```
mchal@localhost:~/Dokumenty/github/act$ ./dist/local/act
INFO[0000] Using docker host 'unix:///run/user/1000/podman/podman.sock', and daemon socket 'unix:///run/user/1000/podman/podman.sock'
[release/release                    ] ⭐ Run Set up job
[Codespell/Check for spelling errors] ⭐ Run Set up job
[release/release                    ] 🚀  Start image=catthehacker/ubuntu:act-latest
[Codespell/Check for spelling errors] 🚀  Start image=catthehacker/ubuntu:act-latest
[release/release                    ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[Codespell/Check for spelling errors]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[Codespell/Check for spelling errors]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Codespell/Check for spelling errors]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Codespell/Check for spelling errors]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[Codespell/Check for spelling errors]   ✅  Success - Set up job
[Codespell/Check for spelling errors]   ☁  git clone 'https://github.com/codespell-project/actions-codespell' # ref=406322ec52dd7b488e48c1c4b82e2a8b3a1bf630
[Codespell/Check for spelling errors] ⭐ Run Main Checkout
[Codespell/Check for spelling errors]   🐳  docker cp src=/home/mchal/Dokumenty/github/act/. dst=/home/mchal/Dokumenty/github/act
[Codespell/Check for spelling errors]   ✅  Success - Main Checkout [671.584796ms]
[Codespell/Check for spelling errors] ⭐ Run Main Codespell
[Codespell/Check for spelling errors]   🐳  docker build -t act-codespell-project-actions-codespell-406322ec52dd7b488e48c1c4b82e2a8b3a1bf630-dockeraction:latest /home/mchal/.cache/act/codespell-project-actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630
[Codespell/Check for spelling errors]   🐳  docker pull image=act-codespell-project-actions-codespell-406322ec52dd7b488e48c1c4b82e2a8b3a1bf630-dockeraction:latest platform= username= forcePull=false
[Codespell/Check for spelling errors]   🐳  docker create image=act-codespell-project-actions-codespell-406322ec52dd7b488e48c1c4b82e2a8b3a1bf630-dockeraction:latest platform= entrypoint=[] cmd=[] network="container:act-Codespell-Check-for-spelling-errors-958121ecdecd5bbb50a1fd74f9707b36ff3ef40bbf09390427c12abf5ec45632"
[Codespell/Check for spelling errors]   🐳  docker run image=act-codespell-project-actions-codespell-406322ec52dd7b488e48c1c4b82e2a8b3a1bf630-dockeraction:latest platform= entrypoint=[] cmd=[] network="container:act-Codespell-Check-for-spelling-errors-958121ecdecd5bbb50a1fd74f9707b36ff3ef40bbf09390427c12abf5ec45632"
| cp: can't create '/github/workflow/codespell-matcher.json': No such file or directory
[Codespell/Check for spelling errors]   ❓ add-matcher /tmp/_github_workflow/codespell-matcher.json
| Running codespell on '' with the following options...
| Check filenames? ''
| Check hidden? ''
| Exclude file ''
| Skipping './.git'
| Builtin dictionaries ''
| Ignore words file ''
| Ignore words list ''
| Ignore URI words list ''
| Resulting CLI options  --skip ./.git
| 0
| Codespell found no problems
[Codespell/Check for spelling errors]   ❓  ::remove-matcher owner=codespell-matcher-default::
[Codespell/Check for spelling errors]   ❓  ::remove-matcher owner=codespell-matcher-specified::
[Codespell/Check for spelling errors]   ✅  Success - Main Codespell [1.297749273s]
[Codespell/Check for spelling errors] ⭐ Run Complete job
[Codespell/Check for spelling errors] Cleaning up container for job Check for spelling errors
[release/release                    ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[release/release                    ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[release/release                    ]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[release/release                    ]   ✅  Success - Set up job
[release/release                    ]   ☁  git clone 'https://github.com/actions/setup-go' # ref=v6
[release/release                    ]   ☁  git clone 'https://github.com/goreleaser/goreleaser-action' # ref=ec59f474b9834571250b370d4735c50f8e2d1e29
[release/release                    ]   ☁  git clone 'https://github.com/vedantmgoyal2009/winget-releaser' # ref=4ffc7888bffd451b357355dc214d43bb9f23917e
[release/release                    ] ⭐ Run Pre Winget
[release/release                    ]   ☁  git clone 'https://github.com/cargo-bins/cargo-binstall' # ref=main
[Codespell/Check for spelling errors]   ✅  Success - Complete job
[Codespell/Check for spelling errors] 🏁  Job succeeded
[release/release                    ] ⭐ Run Pre cargo-bins/cargo-binstall@main
[release/release                    ]   ✅  Success - Pre cargo-bins/cargo-binstall@main [174.682094ms]
[release/release                    ]   ✅  Success - Pre Winget [1.970510026s]
[release/release                    ]   ☁  git clone 'https://github.com/actions/github-script' # ref=v7
[release/release                    ] ⭐ Run Main actions/checkout@v6
[release/release                    ]   🐳  docker cp src=/home/mchal/Dokumenty/github/act/. dst=/home/mchal/Dokumenty/github/act
[release/release                    ]   ✅  Success - Main actions/checkout@v6 [605.552817ms]
[release/release                    ] ⭐ Run Main actions/setup-go@v6
[release/release                    ]   🐳  docker cp src=/home/mchal/.cache/act/actions-setup-go@v6/ dst=/var/run/act/actions/actions-setup-go@v6/
[release/release                    ]   🐳  docker exec cmd=[/opt/acttoolcache/node/24.18.0/x64/bin/node /var/run/act/actions/actions-setup-go@v6/dist/setup/index.js] user= workdir=
| Setup go version spec 1.25.0
| Found in cache @ /opt/hostedtoolcache/go/1.25.0/x64
| Added go to the path
| Successfully set up Go version 1.25.0
| [command]/opt/hostedtoolcache/go/1.25.0/x64/bin/go env GOMODCACHE
| [command]/opt/hostedtoolcache/go/1.25.0/x64/bin/go env GOCACHE
| /root/go/pkg/mod
| /root/.cache/go-build
| Cache is not found
[release/release                    ]   ❓ add-matcher /run/act/actions/actions-setup-go@v6/matchers.json
| go version go1.25.0 linux/amd64
|
[release/release                    ]   ❓  ::group::go env
| AR='ar'
| CC='gcc'
| CGO_CFLAGS='-O2 -g'
| CGO_CPPFLAGS=''
| CGO_CXXFLAGS='-O2 -g'
| CGO_ENABLED='1'
| CGO_FFLAGS='-O2 -g'
| CGO_LDFLAGS='-O2 -g'
| CXX='g++'
| GCCGO='gccgo'
| GO111MODULE=''
| GOAMD64='v1'
| GOARCH='amd64'
| GOAUTH='netrc'
| GOBIN=''
| GOCACHE='/root/.cache/go-build'
| GOCACHEPROG=''
| GODEBUG=''
| GOENV='/root/.config/go/env'
| GOEXE=''
| GOEXPERIMENT=''
| GOFIPS140='off'
| GOFLAGS=''
| GOGCCFLAGS='-fPIC -m64 -pthread -Wl,--no-gc-sections -fmessage-length=0 -ffile-prefix-map=/tmp/go-build153634489=/tmp/go-build -gno-record-gcc-switches'
| GOHOSTARCH='amd64'
| GOHOSTOS='linux'
| GOINSECURE=''
| GOMOD='/home/mchal/Dokumenty/github/act/go.mod'
| GOMODCACHE='/root/go/pkg/mod'
| GONOPROXY=''
| GONOSUMDB=''
| GOOS='linux'
| GOPATH='/root/go'
| GOPRIVATE=''
| GOPROXY='https://proxy.golang.org,direct'
| GOROOT='/opt/hostedtoolcache/go/1.25.0/x64'
| GOSUMDB='sum.golang.org'
| GOTELEMETRY='local'
| GOTELEMETRYDIR='/root/.config/go/telemetry'
| GOTMPDIR=''
| GOTOOLCHAIN='local'
| GOTOOLDIR='/opt/hostedtoolcache/go/1.25.0/x64/pkg/tool/linux_amd64'
| GOVCS=''
| GOVERSION='go1.25.0'
| GOWORK=''
| PKG_CONFIG='pkg-config'
|
[release/release                    ]   ❓  ::endgroup::
[release/release                    ]   ✅  Success - Main actions/setup-go@v6 [540.557184ms]
[release/release                    ]   ⚙  ::set-env:: GOTOOLCHAIN=local
[release/release                    ]   ⚙  ::set-output:: cache-hit=false
[release/release                    ]   ⚙  ::set-output:: go-version=1.25.0
[release/release                    ]   ⚙  ::add-path:: /opt/hostedtoolcache/go/1.25.0/x64/bin
[release/release                    ]   ⚙  ::add-path:: /root/go/bin
[release/release                    ] ⭐ Run Main GoReleaser
[release/release                    ]   🐳  docker cp src=/home/mchal/.cache/act/goreleaser-goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29/ dst=/var/run/act/actions/goreleaser-goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29/
[release/release                    ]   🐳  docker exec cmd=[/opt/acttoolcache/node/24.18.0/x64/bin/node /var/run/act/actions/goreleaser-goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29/dist/index.js] user= workdir=
| Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.17.0/goreleaser_Linux_x86_64.tar.gz
| Extracting GoReleaser
| [command]/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /tmp/84579d07-549c-42a2-834e-0a464ff8be5f -f /tmp/3d9e176b-5085-4465-8cf3-902630b294d5
| GoReleaser ~> v2 installed successfully
| [command]/opt/hostedtoolcache/goreleaser-action/2.17.0/x64/goreleaser release --clean
|   • starting release
|   • cleaning distribution directory
|   • loading environment variables
|   ⨯ release failed after 0s                          error=missing GITHUB_TOKEN, GITLAB_TOKEN and GITEA_TOKEN
[release/release                    ]   ❗  ::error::The process '/opt/hostedtoolcache/goreleaser-action/2.17.0/x64/goreleaser' failed with exit code 1
[release/release                    ]   ❌  Failure - Main GoReleaser [2.466002466s]
[release/release                    ] exitcode '1': failure
[release/release                    ] ⭐ Run Complete job
[release/release                    ]   ✅  Success - Complete job
[release/release                    ] 🏁  Job failed
Error: Job 'release' failed
mchal@localhost:~/Dokumenty/github/act$ podman --version
podman version 6.0.0
mchal@localhost:~/Dokumenty/github/act$ docker --version
bash: docker: nie odnaleziono polecenia...
Zainstalować pakiet „podman-docker”, aby dostarczyć polecenie „docker”? [N/y] n


mchal@localhost:~/Dokumenty/github/act$ systemctl status podman.socket
● podman.socket - Podman API Socket
     Loaded: loaded (/usr/lib/systemd/system/podman.socket; disabled; preset: disabled)
     Active: active (listening) since Thu 2026-07-09 17:44:14 CEST; 12min ago
 Invocation: 4bb2862477b24f5d84b1f58a214c7924
   Triggers: ● podman.service
       Docs: man:podman-system-service(1)
     Listen: /run/podman/podman.sock (Stream)
     CGroup: /system.slice/podman.socket

lip 09 17:44:14 localhost.localdomain systemd[1]: Listening on podman.socket - Podman API Socket.
mchal@localhost:~/Dokumenty/github/act$
```
