### PR TITLE
fix(schema): allow environment.deployment boolean

### DIFF
--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -90,3 +90,50 @@ jobs:
 	}).UnmarshalYAML(&node)
 	assert.NoError(t, err)
 }
+
+func TestEnvironmentDeploymentFalse(t *testing.T) {
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(`
+on: push
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    steps:
+    - run: echo "Hello"
+`), &node)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = (&Node{
+		Definition: "workflow-root-strict",
+		Schema:     GetWorkflowSchema(),
+	}).UnmarshalYAML(&node)
+	assert.NoError(t, err)
+}
+
+func TestEnvironmentDeploymentTrue(t *testing.T) {
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(`
+on: push
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: true
+      url: https://example.com
+    steps:
+    - run: echo "Hello"
+`), &node)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = (&Node{
+		Definition: "workflow-root-strict",
+		Schema:     GetWorkflowSchema(),
+	}).UnmarshalYAML(&node)
+	assert.NoError(t, err)
+}

--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1659,6 +1659,10 @@
             "type": "job-environment-name",
             "required": true
           },
+          "deployment": {
+            "type": "boolean",
+            "description": "When set to false, runs the job in the environment without creating a deployment object."
+          },
           "url": {
             "type": "string-runner-context-no-secrets",
             "description": "The environment URL, which maps to `environment_url` in the deployments API."


### PR DESCRIPTION
## Summary

Fixes #6086.

GitHub Actions added `environment.deployment` so workflows can use an environment **without** creating a deployment:

```yaml
jobs:
  example:
    runs-on: ubuntu-latest
    environment:
      name: production
      deployment: false
```

Act's strict schema (`job-environment-mapping`) only allowed `name` and `url`, so `act --validate --strict` failed with `Unknown Property deployment`.

## Changes

- Add `deployment` (`boolean`) to `pkg/schema/workflow_schema.json`
- Schema unit tests for `deployment: true` and `deployment: false`

## Test plan

```bash
go test ./pkg/schema/ -count=1
# ok
```
