### PR TITLE
Fix panic in format() on negative replacement index

### DIFF
--- a/pkg/exprparser/functions.go
+++ b/pkg/exprparser/functions.go
@@ -93,7 +93,7 @@ func (impl *interperterImpl) format(str reflect.Value, replaceValue ...reflect.V
 
 			case '}':
 				index, err := strconv.ParseInt(replacementIndex, 10, 32)
-				if err != nil {
+				if err != nil || index < 0 {
 					return "", fmt.Errorf("The following format string is invalid: '%s'", input)
 				}
 

--- a/pkg/exprparser/functions_test.go
+++ b/pkg/exprparser/functions_test.go
@@ -237,6 +237,7 @@ func TestFunctionFormat(t *testing.T) {
 		{"format('{0', '{1}', 'World')", nil, "Unclosed brackets. The following format string is invalid: '{0'", "format-invalid-format-string"},
 		{"format('{2}', '{1}', 'World')", "", "The following format string references more arguments than were supplied: '{2}'", "format-invalid-replacement-reference"},
 		{"format('{2147483648}')", "", "The following format string is invalid: '{2147483648}'", "format-invalid-replacement-reference"},
+		{"format('{-1}', 'x')", "", "The following format string is invalid: '{-1}'", "format-invalid-negative-index"},
 		{"format('{0} {1} {2} {3}', 1.0, 1.1, 1234567890.0, 12345678901234567890.0)", "1 1.1 1234567890 1.23456789012346E+19", nil, "format-floats"},
 	}
 


### PR DESCRIPTION
## Description

`format()` panics with `runtime error: index out of range [-1]` when a placeholder uses a negative index, e.g. `format('{-1}', 'x')`.

When parsing a `{N}` placeholder, the `-` and digits are collected into `replacementIndex`, so `strconv.ParseInt("-1", 10, 32)` succeeds and returns `-1`. The only guards were a parse error and an index that is too large (`len(replaceValue) <= int(index)`), which is `false` for a negative index. Execution then reaches `replaceValue[index]` with a negative index and the runtime panics.

GitHub Actions instead returns a handled expression error for such input, the same way `act` already handles the out-of-range case `{2147483648}`.

## Reproduction

```go
NewInterpeter(&EvaluationEnvironment{}, Config{}).Evaluate("format('{-1}', 'x')", DefaultStatusCheckNone)
```

Before: `panic: runtime error: index out of range [-1]`
After: returns error `The following format string is invalid: '{-1}'`

## Fix

Reject a negative index alongside the existing parse-error guard. A test case `format('{-1}', 'x')` is added next to the existing `{2147483648}` case.
