### PR TITLE
fix(exprparser): panic in format() on negative replacement index (rebase of #6136)

### DIFF
--- a/pkg/exprparser/functions.go
+++ b/pkg/exprparser/functions.go
@@ -93,7 +93,7 @@ func (impl *interperterImpl) format(str reflect.Value, replaceValue ...reflect.V
 
 			case '}':
 				index, err := strconv.ParseInt(replacementIndex, 10, 32)
-				if err != nil {
+				if err != nil || index < 0 {
 					return "", fmt.Errorf("The following format string is invalid: '%s'", input)
 				}
 

--- a/pkg/exprparser/functions_test.go
+++ b/pkg/exprparser/functions_test.go
@@ -237,6 +237,7 @@ func TestFunctionFormat(t *testing.T) {
 		{"format('{0', '{1}', 'World')", nil, "Unclosed brackets. The following format string is invalid: '{0'", "format-invalid-format-string"},
 		{"format('{2}', '{1}', 'World')", "", "The following format string references more arguments than were supplied: '{2}'", "format-invalid-replacement-reference"},
 		{"format('{2147483648}')", "", "The following format string is invalid: '{2147483648}'", "format-invalid-replacement-reference"},
+		{"format('{-1}', 'x')", "", "The following format string is invalid: '{-1}'", "format-invalid-negative-index"},
 		{"format('{0} {1} {2} {3}', 1.0, 1.1, 1234567890.0, 12345678901234567890.0)", "1 1.1 1234567890 1.23456789012346E+19", nil, "format-floats"},
 	}
 


### PR DESCRIPTION
## Summary
Fix panic in `format()` function when replacement index is negative (out of bounds access on underlying writer).

## What
- Bounds-check replacement index before write
- Test covers negative index case

## Rebase status
Rebased against current master (4f41128). Zero conflicts. Tests pass.