### PR TITLE
fix: interpolate ${{ }} expressions in job container volumes

### DIFF
--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -124,7 +124,7 @@ func getDockerDaemonSocketMountPath(daemonPath string) string {
 }
 
 // Returns the binds and mounts for the container, resolving paths as appropriate
-func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
+func (rc *RunContext) GetBindsAndMounts(ctx context.Context) ([]string, map[string]string) {
 	name := rc.jobContainerName()
 
 	if rc.Config.ContainerDaemonSocket == "" {
@@ -155,6 +155,7 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 	if job := rc.Run.Job(); job != nil {
 		if container := job.Container(); container != nil {
 			for _, v := range container.Volumes {
+				v = rc.ExprEval.Interpolate(ctx, v)
 				if !strings.Contains(v, ":") || filepath.IsAbs(v) {
 					// Bind anonymous volume or host file.
 					binds = append(binds, v)
@@ -283,7 +284,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 		envList = append(envList, fmt.Sprintf("%s=%s", "LANG", "C.UTF-8")) // Use same locale as GitHub Actions
 
 		ext := container.LinuxContainerEnvironmentExtensions{}
-		binds, mounts := rc.GetBindsAndMounts()
+		binds, mounts := rc.GetBindsAndMounts(ctx)
 
 		// specify the network to which the container will connect when `docker create` stage. (like execute command line: docker create --network <networkName> <image>)
 		// if using service containers, will create a new network for the containers.


### PR DESCRIPTION
## Description

When a workflow job uses a container with volumes that contain `${{ }}` expressions (e.g., `${{ vars.BUILDDOC_WEBDIR || /var/www/html/poubelle }}`), the expressions are not interpolated before validation. This causes the volume to be rejected with an error like:

> `[${{ vars.BUILDDOC_WEBDIR || /var/www/html/poubelle }}] is not a valid volume, will be ignored`

## Root Cause

The `GetBindsAndMounts()` method processes job container volumes directly from the parsed YAML model without running them through the expression evaluator (`rc.ExprEval.Interpolate`). 

In contrast, the **service container** volumes are correctly interpolated at line 310-312 before being passed to `GetServiceBindsAndMounts()`. The job container volumes path was simply missing this interpolation step.

## Fix

1. Added `ctx context.Context` parameter to `GetBindsAndMounts()`
2. Added `rc.ExprEval.Interpolate(ctx, v)` call for each volume path before validation
3. Updated the caller to pass `ctx`

## Testing

- The fix follows the same pattern already used for service container volumes (lines 310-312)
- The `ExprEval.Interpolate()` method handles `${{ }}` expressions that can't be evaluated (non-existent vars, syntax errors) by returning the original string unchanged, so existing workflows without expressions continue to work exactly as before