### PR TITLE
fix: support equals in runner labels

### DIFF
--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -13,9 +13,9 @@ func (i *Input) newPlatforms() map[string]string {
 	}
 
 	for _, p := range i.platforms {
-		pParts := strings.Split(p, "=")
-		if len(pParts) == 2 {
-			platforms[strings.ToLower(pParts[0])] = pParts[1]
+		separator := strings.LastIndex(p, "=")
+		if separator > 0 && separator < len(p)-1 {
+			platforms[strings.ToLower(p[:separator])] = p[separator+1:]
 		}
 	}
 	return platforms

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -36,6 +36,14 @@ func TestListOptions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNewPlatformsSupportsEqualsInRunnerLabels(t *testing.T) {
+	platforms := (&Input{
+		platforms: []string{"runner-size=large=node:16-bullseye-slim"},
+	}).newPlatforms()
+
+	assert.Equal(t, "node:16-bullseye-slim", platforms["runner-size=large"])
+}
+
 func TestRun(t *testing.T) {
 	rootCmd := createRootCommand(context.Background(), &Input{}, "")
 	err := newRunCommand(context.Background(), &Input{


### PR DESCRIPTION
Fixes #4691

The platform mapping parser split at every equals sign, so a valid self-hosted runner label such as runner-size=large was ignored.

This parses the mapping at its final equals sign and adds a regression test for labels containing an equals sign.

Tests:

- go test ./cmd -run '^TestNewPlatformsSupportsEqualsInRunnerLabels$' -count=1 -v