### PR TITLE
Concurrency groups and parallel steps (reference branch — being split, do not review)

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -689,6 +689,9 @@ func (cr *containerReference) waitForCommand(ctx context.Context, isTerminal boo
 	cmdResponse := make(chan error)
 
 	outWriter, errWriter := cr.getLogWriters()
+	if ctxOut, ctxErr, ok := LogWriters(ctx); ok {
+		outWriter, errWriter = ctxOut, ctxErr
+	}
 	go func() {
 		var err error
 		if !isTerminal || os.Getenv("NORAW") != "" {

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"net/netip"
 
@@ -197,6 +198,9 @@ func (cr *containerReference) GetHealth(ctx context.Context) Health {
 }
 
 func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Writer) (io.Writer, io.Writer) {
+	cr.logWriterMutex.Lock()
+	defer cr.logWriterMutex.Unlock()
+
 	out := cr.input.Stdout
 	err := cr.input.Stderr
 
@@ -206,12 +210,30 @@ func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Write
 	return out, err
 }
 
+// getLogWriters returns the current log writers, they are replaced per step
+// and read concurrently by steps running in the background
+func (cr *containerReference) getLogWriters() (io.Writer, io.Writer) {
+	cr.logWriterMutex.Lock()
+	defer cr.logWriterMutex.Unlock()
+
+	outWriter := io.Writer(os.Stdout)
+	if cr.input.Stdout != nil {
+		outWriter = cr.input.Stdout
+	}
+	errWriter := io.Writer(os.Stderr)
+	if cr.input.Stderr != nil {
+		errWriter = cr.input.Stderr
+	}
+	return outWriter, errWriter
+}
+
 type containerReference struct {
-	cli   client.APIClient
-	id    string
-	input *NewContainerInput
-	UID   int
-	GID   int
+	cli            client.APIClient
+	id             string
+	input          *NewContainerInput
+	UID            int
+	GID            int
+	logWriterMutex sync.Mutex
 	LinuxContainerEnvironmentExtensions
 }
 
@@ -666,17 +688,8 @@ func (cr *containerReference) waitForCommand(ctx context.Context, isTerminal boo
 
 	cmdResponse := make(chan error)
 
+	outWriter, errWriter := cr.getLogWriters()
 	go func() {
-		var outWriter io.Writer
-		outWriter = cr.input.Stdout
-		if outWriter == nil {
-			outWriter = os.Stdout
-		}
-		errWriter := cr.input.Stderr
-		if errWriter == nil {
-			errWriter = os.Stderr
-		}
-
 		var err error
 		if !isTerminal || os.Getenv("NORAW") != "" {
 			_, err = stdcopy.StdCopy(outWriter, errWriter, resp.Reader)
@@ -852,15 +865,7 @@ func (cr *containerReference) attach() common.Executor {
 		}
 		isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 
-		var outWriter io.Writer
-		outWriter = cr.input.Stdout
-		if outWriter == nil {
-			outWriter = os.Stdout
-		}
-		errWriter := cr.input.Stderr
-		if errWriter == nil {
-			errWriter = os.Stderr
-		}
+		outWriter, errWriter := cr.getLogWriters()
 		go func() {
 			if !isTerminal || os.Getenv("NORAW") != "" {
 				_, err = stdcopy.StdCopy(outWriter, errWriter, out.Reader)

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -307,6 +307,9 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 		wd = e.Path
 	}
 	stdout := e.getStdOut()
+	if ctxStdout, _, ok := LogWriters(ctx); ok {
+		stdout = ctxStdout
+	}
 	f, err := lookupPathHost(command[0], env, stdout)
 	if err != nil {
 		return err

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-git/go-billy/v5/helper/polyfill"
@@ -33,6 +35,16 @@ type HostEnvironment struct {
 	ActPath   string
 	CleanUp   func()
 	StdOut    io.Writer
+
+	// stdoutMutex guards StdOut, it is replaced per step and read
+	// concurrently by steps running in the background
+	stdoutMutex sync.Mutex
+}
+
+func (e *HostEnvironment) getStdOut() io.Writer {
+	e.stdoutMutex.Lock()
+	defer e.stdoutMutex.Unlock()
+	return e.StdOut
 }
 
 func (e *HostEnvironment) Create(_ []string, _ []string) common.Executor {
@@ -182,12 +194,12 @@ func (e *HostEnvironment) Start(_ bool) common.Executor {
 
 type ptyWriter struct {
 	Out       io.Writer
-	AutoStop  bool
+	AutoStop  atomic.Bool
 	dirtyLine bool
 }
 
 func (w *ptyWriter) Write(buf []byte) (int, error) {
-	if w.AutoStop && len(buf) > 0 && buf[len(buf)-1] == 4 {
+	if w.AutoStop.Load() && len(buf) > 0 && buf[len(buf)-1] == 4 {
 		n, err := w.Out.Write(buf[:len(buf)-1])
 		if err != nil {
 			return n, err
@@ -294,7 +306,8 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 	} else {
 		wd = e.Path
 	}
-	f, err := lookupPathHost(command[0], env, e.StdOut)
+	stdout := e.getStdOut()
+	f, err := lookupPathHost(command[0], env, stdout)
 	if err != nil {
 		return err
 	}
@@ -302,9 +315,9 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 	cmd.Path = f
 	cmd.Args = command
 	cmd.Stdin = nil
-	cmd.Stdout = e.StdOut
+	cmd.Stdout = stdout
 	cmd.Env = envList
-	cmd.Stderr = e.StdOut
+	cmd.Stderr = stdout
 	cmd.Dir = wd
 	cmd.SysProcAttr = getSysProcAttr(cmdline, false)
 	var ppty *os.File
@@ -324,7 +337,7 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 			common.Logger(ctx).Debugf("Failed to setup Pty %v\n", err.Error())
 		}
 	}
-	writer := &ptyWriter{Out: e.StdOut}
+	writer := &ptyWriter{Out: stdout}
 	logctx, finishLog := context.WithCancel(context.Background())
 	if ppty != nil {
 		go copyPtyOutput(writer, ppty, finishLog)
@@ -339,7 +352,7 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 		return err
 	}
 	if tty != nil {
-		writer.AutoStop = true
+		writer.AutoStop.Store(true)
 		if _, err := tty.Write([]byte("\x04")); err != nil {
 			common.Logger(ctx).Debug("Failed to write EOT")
 		}
@@ -460,6 +473,8 @@ func (e *HostEnvironment) GetHealth(_ context.Context) Health {
 }
 
 func (e *HostEnvironment) ReplaceLogWriter(stdout io.Writer, _ io.Writer) (io.Writer, io.Writer) {
+	e.stdoutMutex.Lock()
+	defer e.stdoutMutex.Unlock()
 	org := e.StdOut
 	e.StdOut = stdout
 	return org, org

--- a/pkg/container/log_writer.go
+++ b/pkg/container/log_writer.go
@@ -1,0 +1,29 @@
+package container
+
+import (
+	"context"
+	"io"
+)
+
+type logWriterContextKey struct{}
+
+type logWriters struct {
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// WithLogWriters attaches the log writers for command output to the context.
+// Execution environments prefer these writers over their global log writer,
+// so steps running concurrently each capture their own output instead of
+// racing for the single writer slot of the environment.
+func WithLogWriters(ctx context.Context, stdout io.Writer, stderr io.Writer) context.Context {
+	return context.WithValue(ctx, logWriterContextKey{}, &logWriters{stdout: stdout, stderr: stderr})
+}
+
+// LogWriters returns the log writers attached to the context, if any
+func LogWriters(ctx context.Context) (io.Writer, io.Writer, bool) {
+	if writers, ok := ctx.Value(logWriterContextKey{}).(*logWriters); ok {
+		return writers.stdout, writers.stderr, true
+	}
+	return nil, nil, false
+}

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -580,6 +580,56 @@ type Step struct {
 	With               map[string]string `yaml:"with"`
 	RawContinueOnError string            `yaml:"continue-on-error"`
 	TimeoutMinutes     string            `yaml:"timeout-minutes"`
+	Background         string            `yaml:"background"`
+	RawWait            yaml.Node         `yaml:"wait"`
+	RawWaitAll         yaml.Node         `yaml:"wait-all"`
+	Cancel             string            `yaml:"cancel"`
+	RawParallel        yaml.Node         `yaml:"parallel"`
+}
+
+// IsBackground returns true if the step runs asynchronously while the job
+// continues with the next step
+func (s *Step) IsBackground() bool {
+	background, _ := strconv.ParseBool(s.Background)
+	return background
+}
+
+// Wait returns the ids of the background steps a `wait` step waits for
+func (s *Step) Wait() []string {
+	switch s.RawWait.Kind {
+	case yaml.ScalarNode:
+		var id string
+		if !decodeNode(s.RawWait, &id) || id == "" {
+			return nil
+		}
+		return []string{id}
+	case yaml.SequenceNode:
+		var ids []string
+		if !decodeNode(s.RawWait, &ids) {
+			return nil
+		}
+		return ids
+	}
+	return nil
+}
+
+// IsBackgroundControl returns true for `wait`, `wait-all` and `cancel` steps
+// that synchronize with or stop background steps
+func (s *Step) IsBackgroundControl() bool {
+	stepType := s.Type()
+	return stepType == StepTypeWait || stepType == StepTypeWaitAll || stepType == StepTypeCancel
+}
+
+// ParallelSteps returns the nested steps of a `parallel` step group
+func (s *Step) ParallelSteps() []*Step {
+	if s.RawParallel.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var steps []*Step
+	if !decodeNode(s.RawParallel, &steps) {
+		return nil
+	}
+	return steps
 }
 
 // String gets the name of step
@@ -590,6 +640,14 @@ func (s *Step) String() string {
 		return s.Uses
 	} else if s.Run != "" {
 		return s.Run
+	} else if s.RawWait.Kind != 0 {
+		return fmt.Sprintf("wait: %s", strings.Join(s.Wait(), ", "))
+	} else if s.RawWaitAll.Kind != 0 {
+		return "wait-all"
+	} else if s.Cancel != "" {
+		return fmt.Sprintf("cancel: %s", s.Cancel)
+	} else if s.RawParallel.Kind != 0 {
+		return "parallel"
 	}
 	return s.ID
 }
@@ -665,6 +723,18 @@ const (
 
 	// StepTypeInvalid is for steps that have invalid step action
 	StepTypeInvalid
+
+	// StepTypeWait is a step with a `wait` attribute that waits for one or more background steps
+	StepTypeWait
+
+	// StepTypeWaitAll is a step with a `wait-all` attribute that waits for all active background steps
+	StepTypeWaitAll
+
+	// StepTypeCancel is a step with a `cancel` attribute that gracefully terminates a background step
+	StepTypeCancel
+
+	// StepTypeParallel is a step with a `parallel` attribute containing a group of steps that run concurrently
+	StepTypeParallel
 )
 
 func (s StepType) String() string {
@@ -683,12 +753,33 @@ func (s StepType) String() string {
 		return "local-reusable-workflow"
 	case StepTypeReusableWorkflowRemote:
 		return "remote-reusable-workflow"
+	case StepTypeWait:
+		return "wait"
+	case StepTypeWaitAll:
+		return "wait-all"
+	case StepTypeCancel:
+		return "cancel"
+	case StepTypeParallel:
+		return "parallel"
 	}
 	return "unknown"
 }
 
 // Type returns the type of the step
 func (s *Step) Type() StepType {
+	if s.RawWait.Kind != 0 {
+		return StepTypeWait
+	}
+	if s.RawWaitAll.Kind != 0 {
+		return StepTypeWaitAll
+	}
+	if s.Cancel != "" {
+		return StepTypeCancel
+	}
+	if s.RawParallel.Kind != 0 {
+		return StepTypeParallel
+	}
+
 	if s.Run == "" && s.Uses == "" {
 		return StepTypeInvalid
 	}

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -26,11 +26,12 @@ type Workflow struct {
 	RawConcurrency yaml.Node         `yaml:"concurrency"`
 }
 
-// Concurrency for a workflow or job. Group and CancelInProgress may contain
-// expressions that have to be evaluated before use.
+// Concurrency for a workflow or job. Group, CancelInProgress and Queue may
+// contain expressions that have to be evaluated before use.
 type Concurrency struct {
 	Group            string `yaml:"group"`
 	CancelInProgress string `yaml:"cancel-in-progress"`
+	Queue            string `yaml:"queue"`
 }
 
 // Concurrency returns the workflow level concurrency settings or nil if none are defined
@@ -112,7 +113,43 @@ func (w *Workflow) UnmarshalYAML(node *yaml.Node) error {
 		return errors.Join(err, fmt.Errorf("Actions YAML Schema Validation Error detected:\nFor more information, see: https://nektosact.com/usage/schema.html"))
 	}
 	type WorkflowDefault Workflow
-	return node.Decode((*WorkflowDefault)(w))
+	if err := node.Decode((*WorkflowDefault)(w)); err != nil {
+		return err
+	}
+	return w.validateConcurrency()
+}
+
+// validateConcurrency rejects concurrency blocks GitHub refuses to run before
+// the workflow is planned, so no job runs and produces side effects first.
+// Only literal values can be checked here, expression values are validated
+// once they are evaluated.
+func (w *Workflow) validateConcurrency() error {
+	if err := invalidConcurrencyCombination(w.Concurrency()); err != nil {
+		return fmt.Errorf("invalid workflow level 'concurrency': %w", err)
+	}
+	for id, job := range w.Jobs {
+		if job == nil {
+			continue
+		}
+		if err := invalidConcurrencyCombination(job.Concurrency()); err != nil {
+			return fmt.Errorf("invalid 'concurrency' for job '%s': %w", id, err)
+		}
+	}
+	return nil
+}
+
+func invalidConcurrencyCombination(concurrency *Concurrency) error {
+	if concurrency == nil {
+		return nil
+	}
+	// `${{ }}` values are only known after evaluation
+	if strings.Contains(concurrency.Queue, "${{") || strings.Contains(concurrency.CancelInProgress, "${{") {
+		return nil
+	}
+	if concurrency.Queue == "max" && concurrency.CancelInProgress == "true" {
+		return errors.New("the combination of 'queue: max' and 'cancel-in-progress: true' is not allowed")
+	}
+	return nil
 }
 
 type WorkflowStrict Workflow
@@ -130,7 +167,10 @@ func (w *WorkflowStrict) UnmarshalYAML(node *yaml.Node) error {
 		return errors.Join(err, fmt.Errorf("Actions YAML Strict Schema Validation Error detected:\nFor more information, see: https://nektosact.com/usage/schema.html"))
 	}
 	type WorkflowDefault Workflow
-	return node.Decode((*WorkflowDefault)(w))
+	if err := node.Decode((*WorkflowDefault)(w)); err != nil {
+		return err
+	}
+	return (*Workflow)(w).validateConcurrency()
 }
 
 type WorkflowDispatchInput struct {

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -17,12 +17,43 @@ import (
 
 // Workflow is the structure of the files in .github/workflows
 type Workflow struct {
-	File     string
-	Name     string            `yaml:"name"`
-	RawOn    yaml.Node         `yaml:"on"`
-	Env      map[string]string `yaml:"env"`
-	Jobs     map[string]*Job   `yaml:"jobs"`
-	Defaults Defaults          `yaml:"defaults"`
+	File           string
+	Name           string            `yaml:"name"`
+	RawOn          yaml.Node         `yaml:"on"`
+	Env            map[string]string `yaml:"env"`
+	Jobs           map[string]*Job   `yaml:"jobs"`
+	Defaults       Defaults          `yaml:"defaults"`
+	RawConcurrency yaml.Node         `yaml:"concurrency"`
+}
+
+// Concurrency for a workflow or job. Group and CancelInProgress may contain
+// expressions that have to be evaluated before use.
+type Concurrency struct {
+	Group            string `yaml:"group"`
+	CancelInProgress string `yaml:"cancel-in-progress"`
+}
+
+// Concurrency returns the workflow level concurrency settings or nil if none are defined
+func (w *Workflow) Concurrency() *Concurrency {
+	return parseConcurrency(w.RawConcurrency)
+}
+
+func parseConcurrency(node yaml.Node) *Concurrency {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		var group string
+		if !decodeNode(node, &group) || group == "" {
+			return nil
+		}
+		return &Concurrency{Group: group}
+	case yaml.MappingNode:
+		var concurrency Concurrency
+		if !decodeNode(node, &concurrency) || concurrency.Group == "" {
+			return nil
+		}
+		return &concurrency
+	}
+	return nil
 }
 
 // On events for the workflow
@@ -209,7 +240,13 @@ type Job struct {
 	Uses           string                    `yaml:"uses"`
 	With           map[string]interface{}    `yaml:"with"`
 	RawSecrets     yaml.Node                 `yaml:"secrets"`
+	RawConcurrency yaml.Node                 `yaml:"concurrency"`
 	Result         string
+}
+
+// Concurrency returns the job level concurrency settings or nil if none are defined
+func (j *Job) Concurrency() *Concurrency {
+	return parseConcurrency(j.RawConcurrency)
 }
 
 // Strategy for the job

--- a/pkg/model/workflow_test.go
+++ b/pkg/model/workflow_test.go
@@ -136,6 +136,71 @@ jobs:
 	assert.Contains(t, workflow.Jobs["test2"].Container().Env["foo"], "bar")
 }
 
+func TestReadWorkflow_BackgroundSteps(t *testing.T) {
+	yaml := `
+name: background-steps
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Start server
+      id: server
+      run: npm start
+      background: true
+    - name: A uses step in the background
+      id: action
+      uses: ./actions/docker-url
+      background: true
+    - name: Not a background step
+      run: echo
+    - name: Wait for one step
+      wait: server
+    - wait: [server, action]
+    - wait-all:
+    - cancel: server
+    - parallel:
+        - name: Build frontend
+          run: npm run build:frontend
+        - id: backend
+          uses: ./actions/backend
+`
+
+	workflow, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.NoError(t, err, "read workflow should succeed")
+
+	steps := workflow.GetJob("test").Steps
+	require.Len(t, steps, 8)
+
+	assert.True(t, steps[0].IsBackground())
+	assert.Equal(t, StepTypeRun, steps[0].Type())
+	assert.True(t, steps[1].IsBackground())
+	assert.Equal(t, StepTypeUsesActionLocal, steps[1].Type())
+	assert.False(t, steps[2].IsBackground())
+
+	assert.Equal(t, StepTypeWait, steps[3].Type())
+	assert.Equal(t, []string{"server"}, steps[3].Wait())
+	assert.Equal(t, "Wait for one step", steps[3].String())
+
+	assert.Equal(t, StepTypeWait, steps[4].Type())
+	assert.Equal(t, []string{"server", "action"}, steps[4].Wait())
+	assert.Equal(t, "wait: server, action", steps[4].String())
+
+	assert.Equal(t, StepTypeWaitAll, steps[5].Type())
+	assert.Equal(t, "wait-all", steps[5].String())
+
+	assert.Equal(t, StepTypeCancel, steps[6].Type())
+	assert.Equal(t, "server", steps[6].Cancel)
+	assert.Equal(t, "cancel: server", steps[6].String())
+
+	assert.Equal(t, StepTypeParallel, steps[7].Type())
+	group := steps[7].ParallelSteps()
+	require.Len(t, group, 2)
+	assert.Equal(t, "npm run build:frontend", group[0].Run)
+	assert.Equal(t, "./actions/backend", group[1].Uses)
+}
+
 func TestReadWorkflow_ObjectContainer(t *testing.T) {
 	yaml := `
 name: local-action-docker-url

--- a/pkg/model/workflow_test.go
+++ b/pkg/model/workflow_test.go
@@ -136,6 +136,55 @@ jobs:
 	assert.Contains(t, workflow.Jobs["test2"].Container().Env["foo"], "bar")
 }
 
+func TestReadWorkflow_Concurrency(t *testing.T) {
+	yaml := `
+name: concurrency
+on: push
+
+concurrency:
+  group: workflow-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scalar:
+    runs-on: ubuntu-latest
+    concurrency: job-group
+    steps:
+    - run: echo
+  mapping:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: job-group-${{ github.event_name }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+    - run: echo
+  none:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo
+`
+
+	workflow, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.NoError(t, err, "read workflow should succeed")
+
+	concurrency := workflow.Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "workflow-${{ github.ref }}", concurrency.Group)
+	assert.Equal(t, "true", concurrency.CancelInProgress)
+
+	concurrency = workflow.GetJob("scalar").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "job-group", concurrency.Group)
+	assert.Equal(t, "", concurrency.CancelInProgress)
+
+	concurrency = workflow.GetJob("mapping").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "job-group-${{ github.event_name }}", concurrency.Group)
+	assert.Equal(t, "${{ github.ref != 'refs/heads/main' }}", concurrency.CancelInProgress)
+
+	assert.Nil(t, workflow.GetJob("none").Concurrency())
+}
+
 func TestReadWorkflow_ObjectContainer(t *testing.T) {
 	yaml := `
 name: local-action-docker-url

--- a/pkg/model/workflow_test.go
+++ b/pkg/model/workflow_test.go
@@ -185,6 +185,67 @@ jobs:
 	assert.Nil(t, workflow.GetJob("none").Concurrency())
 }
 
+func TestReadWorkflow_ConcurrencyQueue(t *testing.T) {
+	yaml := `
+name: concurrency-queue
+on: push
+
+concurrency:
+  group: workflow-group
+  queue: max
+
+jobs:
+  queued:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: job-group
+      queue: single
+    steps:
+    - run: echo
+  defaulted:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: other-group
+    steps:
+    - run: echo
+`
+
+	workflow, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.NoError(t, err, "read workflow should succeed")
+
+	concurrency := workflow.Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "max", concurrency.Queue)
+
+	concurrency = workflow.GetJob("queued").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "single", concurrency.Queue)
+
+	concurrency = workflow.GetJob("defaulted").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "", concurrency.Queue, "queue defaults to single and is left empty when not set")
+}
+
+func TestReadWorkflow_ConcurrencyQueueInvalid(t *testing.T) {
+	yaml := `
+name: concurrency-queue-invalid
+on: push
+
+concurrency:
+  group: g
+  queue: enormous
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo
+`
+
+	_, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.ErrorContains(t, err, "Expected one of single,max got enormous")
+}
+
 func TestReadWorkflow_BackgroundSteps(t *testing.T) {
 	yaml := `
 name: background-steps

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -388,7 +388,7 @@ func newStepContainer(ctx context.Context, step step, image string, cmd []string
 	rc := step.getRunContext()
 	stepModel := step.getStepModel()
 	rawLogger := common.Logger(ctx).WithField("raw_output", true)
-	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+	logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, stepModel.ID), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)
 		} else {

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -100,13 +100,26 @@ func execAsComposite(step actionStep) common.Executor {
 
 		// Map outputs from composite RunContext to job RunContext
 		eval := compositeRC.NewExpressionEvaluator(ctx)
+		outputs := make(map[string]string, len(action.Outputs))
 		for outputName, output := range action.Outputs {
-			rc.setOutput(ctx, map[string]string{
-				"name": outputName,
-			}, eval.Interpolate(ctx, output.Value))
+			outputs[outputName] = eval.Interpolate(ctx, output.Value)
 		}
 
-		rc.Masks = append(rc.Masks, compositeRC.Masks...)
+		for _, mask := range compositeRC.Masks {
+			rc.AddMask(mask)
+		}
+
+		stepID := step.getStepModel().ID
+		lock := rc.stepStateLock()
+		lock.Lock()
+		defer lock.Unlock()
+
+		for outputName, value := range outputs {
+			rc.setOutputForStep(ctx, stepID, map[string]string{
+				"name": outputName,
+			}, value)
+		}
+
 		rc.ExtraPath = compositeRC.ExtraPath
 		// compositeRC.Env is dirty, contains INPUT_ and merged step env, only rely on compositeRC.GlobalEnv
 		mergeIntoMap := mergeIntoMapCaseSensitive

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -51,6 +51,13 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 	configCopy := *(parent.Config)
 	configCopy.Secrets = nil
 
+	// snapshot the parent state that may be mutated by steps running
+	// concurrently in the background
+	lock := parent.stepStateLock()
+	lock.Lock()
+	extraPath := append([]string{}, parent.ExtraPath...)
+	lock.Unlock()
+
 	// create a run context for the composite action to run in
 	compositerc := &RunContext{
 		Name:    parent.Name,
@@ -70,9 +77,10 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		ActionPath:       actionPath,
 		Env:              env,
 		GlobalEnv:        parent.GlobalEnv,
-		Masks:            parent.Masks,
-		ExtraPath:        parent.ExtraPath,
+		Masks:            parent.masksSnapshot(),
+		ExtraPath:        extraPath,
 		Parent:           parent,
+		parentStepID:     step.getStepModel().ID,
 		EventJSON:        parent.EventJSON,
 		nodeToolFullPath: parent.nodeToolFullPath,
 	}
@@ -105,7 +113,7 @@ func execAsComposite(step actionStep) common.Executor {
 			outputs[outputName] = eval.Interpolate(ctx, output.Value)
 		}
 
-		for _, mask := range compositeRC.Masks {
+		for _, mask := range compositeRC.masksSnapshot() {
 			rc.AddMask(mask)
 		}
 
@@ -120,7 +128,23 @@ func execAsComposite(step actionStep) common.Executor {
 			}, value)
 		}
 
-		rc.ExtraPath = compositeRC.ExtraPath
+		// merge the PATH additions of the composite action into the current
+		// extra path instead of overwriting it, other steps may have added
+		// entries while the composite action ran
+		mergedPath := append([]string{}, compositeRC.ExtraPath...)
+		for _, entry := range rc.ExtraPath {
+			exists := false
+			for _, merged := range mergedPath {
+				if merged == entry {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				mergedPath = append(mergedPath, entry)
+			}
+		}
+		rc.ExtraPath = mergedPath
 		// compositeRC.Env is dirty, contains INPUT_ and merged step env, only rely on compositeRC.GlobalEnv
 		mergeIntoMap := mergeIntoMapCaseSensitive
 		if rc.JobContainer.IsEnvironmentCaseInsensitive() {

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
 )
 
@@ -249,8 +250,11 @@ func (rc *RunContext) newCompositeCommandExecutor(executor common.Executor) comm
 			return true
 		})
 
-		oldout, olderr := rc.JobContainer.ReplaceLogWriter(logWriter, logWriter)
-		defer rc.JobContainer.ReplaceLogWriter(oldout, olderr)
+		// the handler is published on the context, which the execution
+		// environments prefer over their global writer slot; a step running
+		// this composite action has its own writers on the context and they
+		// must not swallow the commands of the composite's inner steps
+		ctx = container.WithLogWriters(ctx, logWriter, logWriter)
 
 		return executor(ctx)
 	}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -34,6 +34,13 @@ func tryParseRawActionCommand(line string) (command string, kvPairs map[string]s
 }
 
 func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
+	return rc.stepCommandHandler(ctx, "")
+}
+
+// stepCommandHandler returns a line handler routing step scoped commands to
+// stepID. With an empty stepID commands are routed to the current step, which
+// is ambiguous while background steps run concurrently.
+func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) common.LineHandler {
 	logger := common.Logger(ctx)
 	resumeCommand := ""
 	return func(line string) bool {
@@ -48,6 +55,14 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		}
 		arg = unescapeCommandData(arg)
 		kvPairs = unescapeKvPairs(kvPairs)
+
+		lock := rc.stepStateLock()
+		lock.Lock()
+		defer lock.Unlock()
+		if stepID == "" {
+			stepID = rc.currentStep()
+		}
+
 		defCommandLogger := logger.WithFields(logrus.Fields{"command": command, "kvPairs": kvPairs, "arg": arg, "raw": line})
 		switch command {
 		case "set-env":
@@ -57,7 +72,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			}
 			rc.setEnv(ctx, kvPairs, arg)
 		case "set-output":
-			rc.setOutput(ctx, kvPairs, arg)
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
 		case "add-path":
 			if rc.Env["ACTIONS_ALLOW_UNSECURE_COMMANDS"] != "true" {
 				defCommandLogger.Errorf("The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsafe commands by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.")
@@ -81,7 +96,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			defCommandLogger.Infof("  \U00002699  %s", line)
 		case "save-state":
 			defCommandLogger.Infof("  \U0001f4be  %s", line)
-			rc.saveState(ctx, kvPairs, arg)
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
 		case "add-matcher":
 			defCommandLogger.Infof("  \U00002753 add-matcher %s", arg)
 		default:
@@ -111,9 +126,8 @@ func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg
 	mergeIntoMap(rc.Env, newenv)
 	mergeIntoMap(rc.GlobalEnv, newenv)
 }
-func (rc *RunContext) setOutput(ctx context.Context, kvPairs map[string]string, arg string) {
+func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPairs map[string]string, arg string) {
 	logger := common.Logger(ctx)
-	stepID := rc.CurrentStep
 	outputName := kvPairs["name"]
 	if outputMapping, ok := rc.OutputMappings[MappableOutput{StepID: stepID, OutputName: outputName}]; ok {
 		stepID = outputMapping.StepID
@@ -182,8 +196,7 @@ func unescapeKvPairs(kvPairs map[string]string) map[string]string {
 	return kvPairs
 }
 
-func (rc *RunContext) saveState(_ context.Context, kvPairs map[string]string, arg string) {
-	stepID := rc.CurrentStep
+func (rc *RunContext) saveStateForStep(_ context.Context, stepID string, kvPairs map[string]string, arg string) {
 	if stepID != "" {
 		if rc.IntraActionState == nil {
 			rc.IntraActionState = map[string]map[string]string{}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -110,6 +110,9 @@ func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) com
 func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg string) {
 	name := kvPairs["name"]
 	common.Logger(ctx).WithFields(logrus.Fields{"command": "set-env", "name": name, "arg": arg}).Infof("  \U00002699  ::set-env:: %s=%s", name, arg)
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	if rc.Env == nil {
 		rc.Env = make(map[string]string)
 	}
@@ -128,6 +131,9 @@ func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg
 }
 func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPairs map[string]string, arg string) {
 	logger := common.Logger(ctx)
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	outputName := kvPairs["name"]
 	if outputMapping, ok := rc.OutputMappings[MappableOutput{StepID: stepID, OutputName: outputName}]; ok {
 		stepID = outputMapping.StepID
@@ -145,6 +151,9 @@ func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPai
 }
 func (rc *RunContext) addPath(ctx context.Context, arg string) {
 	common.Logger(ctx).WithFields(logrus.Fields{"command": "add-path", "arg": arg}).Infof("  \U00002699  ::add-path:: %s", arg)
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	extraPath := []string{arg}
 	for _, v := range rc.ExtraPath {
 		if v != arg {
@@ -197,6 +206,9 @@ func unescapeKvPairs(kvPairs map[string]string) map[string]string {
 }
 
 func (rc *RunContext) saveStateForStep(_ context.Context, stepID string, kvPairs map[string]string, arg string) {
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	if stepID != "" {
 		if rc.IntraActionState == nil {
 			rc.IntraActionState = map[string]map[string]string{}

--- a/pkg/runner/concurrency.go
+++ b/pkg/runner/concurrency.go
@@ -3,8 +3,6 @@ package runner
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -14,148 +12,127 @@ import (
 	"github.com/nektos/act/pkg/model"
 )
 
-// errCancelledByConcurrencyGroup is returned by acquire when the owner of the
-// request was cancelled by another job entering one of its concurrency groups
-// with cancel-in-progress enabled.
-var errCancelledByConcurrencyGroup = errors.New("cancelled by another job in the same concurrency group")
+// errCancelledByConcurrencyGroup is returned by acquire when the request was
+// cancelled instead of run: either it was superseded by a newer request in
+// the same group (GitHub cancels the previously pending run) or the job/run
+// itself was cancelled while waiting.
+var errCancelledByConcurrencyGroup = errors.New("cancelled by the concurrency group")
 
-// concurrencySpec describes a single concurrency group requirement of a job.
-// Jobs sharing the same owner may hold the group at the same time. This lets
-// all jobs of one workflow run share the workflow level concurrency group,
-// while job level groups use a unique owner per job so they serialize.
+// concurrencySpec is an evaluated `concurrency` configuration
 type concurrencySpec struct {
 	group            string
-	owner            string
 	cancelInProgress bool
 }
 
-type concurrencyGroup struct {
-	owner string
-	// holders maps an id per acquisition to the cancel function of the
-	// holding job, so cancel-in-progress can cancel all current holders
-	holders map[int64]context.CancelFunc
-	// released is closed (and the group dropped) once the last holder
-	// releases the group, waking up all waiting jobs
-	released chan struct{}
+// concurrencyWaiter represents one workflow run or job holding or waiting
+// for a concurrency group
+type concurrencyWaiter struct {
+	// cancelSelf gracefully cancels the holder when a new request arrives
+	// with cancel-in-progress
+	cancelSelf func()
+	// promoted is closed when the waiter becomes the holder of the group
+	promoted chan struct{}
+	// superseded is closed when a newer pending request replaces this one,
+	// the superseded request is cancelled without having run
+	superseded chan struct{}
 }
 
-// concurrencyManager serializes jobs that share a concurrency group. A single
-// instance is shared between a runner and all reusable workflow runners
-// spawned from it, so called workflows take part in the same groups.
+type concurrencyGroup struct {
+	holder  *concurrencyWaiter
+	pending *concurrencyWaiter
+}
+
+// concurrencyManager implements GitHub's concurrency group queueing: one
+// holder runs at a time, at most one request is pending and a newer request
+// supersedes (cancels) the previously pending one. A single instance is
+// shared between a runner and all reusable workflow runners spawned from it.
 type concurrencyManager struct {
-	mu        sync.Mutex
-	holderSeq int64
-	ownerSeq  atomic.Int64
-	groups    map[string]*concurrencyGroup
-	// cancelledOwners records owners that were cancelled via
-	// cancel-in-progress; their remaining jobs are cancelled instead of run,
-	// approximating GitHub cancelling the whole workflow run
-	cancelledOwners map[string]bool
+	mu     sync.Mutex
+	groups map[string]*concurrencyGroup
 }
 
 func newConcurrencyManager() *concurrencyManager {
-	return &concurrencyManager{
-		groups:          map[string]*concurrencyGroup{},
-		cancelledOwners: map[string]bool{},
-	}
+	return &concurrencyManager{groups: map[string]*concurrencyGroup{}}
 }
 
-// newOwner returns a new unique owner identity for a workflow run or a job
-func (m *concurrencyManager) newOwner(kind string) string {
-	return fmt.Sprintf("%s-%d", kind, m.ownerSeq.Add(1))
-}
-
-// acquire blocks until all requested groups are held by the calling job and
-// returns a function releasing them again. cancelSelf is invoked if another
-// job cancels this one via cancel-in-progress.
-func (m *concurrencyManager) acquire(ctx context.Context, cancelSelf context.CancelFunc, specs ...concurrencySpec) (func(), error) {
-	ordered := make([]concurrencySpec, len(specs))
-	copy(ordered, specs)
-	// acquire groups in a stable order to avoid deadlocks between jobs
-	// requesting the same groups in a different order
-	sort.Slice(ordered, func(i, j int) bool { return ordered[i].group < ordered[j].group })
-
-	releases := make([]func(), 0, len(ordered))
-	releaseAll := func() {
-		for i := len(releases) - 1; i >= 0; i-- {
-			releases[i]()
-		}
-	}
-
-	for _, spec := range ordered {
-		release, err := m.acquireGroup(ctx, spec, cancelSelf)
-		if err != nil {
-			releaseAll()
-			return nil, err
-		}
-		releases = append(releases, release)
-	}
-	return releaseAll, nil
-}
-
-func (m *concurrencyManager) acquireGroup(ctx context.Context, spec concurrencySpec, cancelSelf context.CancelFunc) (func(), error) {
+// acquire blocks until the group is free and returns a function releasing it
+// again. cancelSelf is invoked if a later request cancels this one via
+// cancel-in-progress while it holds the group. cancelCtx (optional) aborts
+// waiting when the requester itself is cancelled.
+func (m *concurrencyManager) acquire(ctx context.Context, cancelCtx context.Context, spec concurrencySpec, cancelSelf func()) (func(), error) {
 	logger := common.Logger(ctx)
-	waiting := false
+	me := &concurrencyWaiter{
+		cancelSelf: cancelSelf,
+		promoted:   make(chan struct{}),
+		superseded: make(chan struct{}),
+	}
+
 	m.mu.Lock()
-	for {
-		if m.cancelledOwners[spec.owner] {
-			m.mu.Unlock()
-			return nil, errCancelledByConcurrencyGroup
-		}
-		group := m.groups[spec.group]
-		if group == nil {
-			group = &concurrencyGroup{
-				holders:  map[int64]context.CancelFunc{},
-				released: make(chan struct{}),
-			}
-			m.groups[spec.group] = group
-		}
-		if len(group.holders) == 0 || group.owner == spec.owner {
-			group.owner = spec.owner
-			m.holderSeq++
-			id := m.holderSeq
-			group.holders[id] = cancelSelf
-			m.mu.Unlock()
-			if waiting {
-				logger.Infof("Acquired concurrency group '%s'", spec.group)
-			}
-			return func() { m.release(spec.group, id) }, nil
-		}
-		if spec.cancelInProgress {
-			// mark the current owner as cancelled and cancel all its jobs
-			// holding the group; the group is re-acquired once they release it
-			m.cancelledOwners[group.owner] = true
-			logger.Infof("Cancelling in-progress jobs in concurrency group '%s'", spec.group)
-			for _, cancel := range group.holders {
-				cancel()
-			}
-		}
-		if !waiting {
-			logger.Infof("Waiting for concurrency group '%s'", spec.group)
-			waiting = true
-		}
-		released := group.released
+	group := m.groups[spec.group]
+	if group == nil {
+		group = &concurrencyGroup{}
+		m.groups[spec.group] = group
+	}
+	if group.holder == nil {
+		group.holder = me
 		m.mu.Unlock()
-		select {
-		case <-released:
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-		m.mu.Lock()
+		return func() { m.release(spec.group, me) }, nil
+	}
+	if spec.cancelInProgress && group.holder.cancelSelf != nil {
+		logger.Infof("Cancelling the run in progress in concurrency group '%s'", spec.group)
+		group.holder.cancelSelf()
+	}
+	if group.pending != nil {
+		// GitHub keeps at most one pending run per group: the previously
+		// pending run is cancelled and replaced by the newer request
+		logger.Infof("Superseding the run pending in concurrency group '%s'", spec.group)
+		close(group.pending.superseded)
+	}
+	group.pending = me
+	m.mu.Unlock()
+
+	logger.Infof("Waiting for concurrency group '%s'", spec.group)
+
+	var cancelDone <-chan struct{}
+	if cancelCtx != nil {
+		cancelDone = cancelCtx.Done()
+	}
+	select {
+	case <-me.promoted:
+		logger.Infof("Acquired concurrency group '%s'", spec.group)
+		return func() { m.release(spec.group, me) }, nil
+	case <-me.superseded:
+		return nil, errCancelledByConcurrencyGroup
+	case <-cancelDone:
+		m.removePending(spec.group, me)
+		return nil, errCancelledByConcurrencyGroup
+	case <-ctx.Done():
+		m.removePending(spec.group, me)
+		return nil, ctx.Err()
 	}
 }
 
-func (m *concurrencyManager) release(groupName string, id int64) {
+func (m *concurrencyManager) release(groupName string, me *concurrencyWaiter) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	group := m.groups[groupName]
-	if group == nil {
+	if group == nil || group.holder != me {
 		return
 	}
-	delete(group.holders, id)
-	if len(group.holders) == 0 {
-		delete(m.groups, groupName)
-		close(group.released)
+	if group.pending != nil {
+		group.holder = group.pending
+		group.pending = nil
+		close(group.holder.promoted)
+		return
+	}
+	delete(m.groups, groupName)
+}
+
+func (m *concurrencyManager) removePending(groupName string, me *concurrencyWaiter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if group := m.groups[groupName]; group != nil && group.pending == me {
+		group.pending = nil
 	}
 }
 
@@ -172,26 +149,56 @@ func (config *Config) concurrency() *concurrencyManager {
 
 var concurrencyInitMu sync.Mutex
 
-// concurrencySpecs evaluates the workflow and job level concurrency groups
-// that apply to this job
-func (rc *RunContext) concurrencySpecs(ctx context.Context) []concurrencySpec {
-	specs := make([]concurrencySpec, 0, 2)
-	ee := rc.NewExpressionEvaluator(ctx)
-	if spec, ok := evaluateConcurrency(ctx, ee, rc.Run.Job().Concurrency(), rc.jobConcurrencyOwner); ok {
-		specs = append(specs, spec)
+// heldConcurrencyGroupsKey carries the set of concurrency groups already held
+// by the current workflow run or its callers, so jobs and called reusable
+// workflows do not deadlock waiting for a group their own caller holds
+type heldConcurrencyGroupsKey struct{}
+
+func withHeldConcurrencyGroup(ctx context.Context, group string) context.Context {
+	held := map[string]bool{group: true}
+	for g := range heldConcurrencyGroups(ctx) {
+		held[g] = true
 	}
-	if spec, ok := evaluateConcurrency(ctx, ee, rc.Run.Workflow.Concurrency(), rc.workflowConcurrencyOwner); ok {
-		// if the job level group has the same name the job would wait for a
-		// group it already holds, so only keep the stricter job level spec
-		if len(specs) == 0 || specs[0].group != spec.group {
-			specs = append(specs, spec)
-		}
-	}
-	return specs
+	return context.WithValue(ctx, heldConcurrencyGroupsKey{}, held)
 }
 
-func evaluateConcurrency(ctx context.Context, ee ExpressionEvaluator, concurrency *model.Concurrency, owner string) (concurrencySpec, bool) {
-	if concurrency == nil || owner == "" {
+func heldConcurrencyGroups(ctx context.Context) map[string]bool {
+	if held, ok := ctx.Value(heldConcurrencyGroupsKey{}).(map[string]bool); ok {
+		return held
+	}
+	return nil
+}
+
+// workflowRunState tracks the cancellation of one workflow run, used both for
+// cancel-in-progress of workflow level concurrency groups and to skip jobs of
+// a cancelled run that have not started yet
+type workflowRunState struct {
+	cancelled  atomic.Bool
+	completed  atomic.Bool
+	cancelCh   chan struct{}
+	cancelOnce sync.Once
+}
+
+func newWorkflowRunState() *workflowRunState {
+	return &workflowRunState{cancelCh: make(chan struct{})}
+}
+
+// cancelRun gracefully cancels all jobs of the run, it has no effect once
+// the run completed
+func (s *workflowRunState) cancelRun() {
+	if s.completed.Load() {
+		return
+	}
+	s.cancelled.Store(true)
+	s.cancelOnce.Do(func() { close(s.cancelCh) })
+}
+
+func (s *workflowRunState) complete() {
+	s.completed.Store(true)
+}
+
+func evaluateConcurrency(ctx context.Context, ee ExpressionEvaluator, concurrency *model.Concurrency) (concurrencySpec, bool) {
+	if concurrency == nil {
 		return concurrencySpec{}, false
 	}
 	group := strings.TrimSpace(ee.Interpolate(ctx, concurrency.Group))
@@ -207,60 +214,119 @@ func evaluateConcurrency(ctx context.Context, ee ExpressionEvaluator, concurrenc
 			cancelInProgress = false
 		}
 	}
-	return concurrencySpec{group: group, owner: owner, cancelInProgress: cancelInProgress}, true
+	return concurrencySpec{group: group, cancelInProgress: cancelInProgress}, true
 }
 
-// withConcurrency wraps a job executor so it holds the concurrency groups of
-// the job while running. Jobs cancelled by cancel-in-progress of another job
-// finish with result 'cancelled' without failing the plan.
+// withConcurrency wraps a job executor so it takes part in the cancellation
+// of its workflow run and holds the job level concurrency group of the job
+// while running. Jobs cancelled by their group or their run finish with
+// result 'cancelled' without failing the plan.
 func (rc *RunContext) withConcurrency(executor common.Executor) common.Executor {
 	return func(ctx context.Context) error {
-		specs := rc.concurrencySpecs(ctx)
-		if len(specs) == 0 {
+		logger := common.Logger(ctx)
+		runState := rc.runState
+
+		// jobs of a cancelled run that have not started yet are cancelled
+		if runState != nil && runState.cancelled.Load() && ctx.Err() == nil {
+			logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled because its workflow run was cancelled", rc.Name)
+			rc.cancelledResult()
+			return nil
+		}
+
+		spec, hasSpec := evaluateConcurrency(ctx, rc.NewExpressionEvaluator(ctx), rc.Run.Job().Concurrency())
+		if hasSpec && heldConcurrencyGroups(ctx)[spec.group] {
+			// the group is already held by this run or a calling workflow,
+			// acquiring it again would deadlock on our own caller
+			logger.Debugf("Concurrency group '%s' is already held by this workflow run or its caller", spec.group)
+			hasSpec = false
+		}
+
+		if !hasSpec && runState == nil {
 			return executor(ctx)
 		}
 
-		logger := common.Logger(ctx)
-
-		// gracefully cancel this job when either the surrounding cancel
-		// context (Ctrl+C) or cancel-in-progress of another job fires
-		jobCancelCtx, cancelJob := context.WithCancel(context.Background())
+		jobCancelCtx, cancelJob := rc.newJobCancelContext(ctx, runState)
 		defer cancelJob()
-		if parent := common.JobCancelContext(ctx); parent != nil {
-			go func() {
-				select {
-				case <-parent.Done():
-					cancelJob()
-				case <-jobCancelCtx.Done():
-				}
-			}()
-		}
 
 		var cancelledByGroup atomic.Bool
+		var jobCompleted atomic.Bool
 		cancelSelf := func() {
+			if jobCompleted.Load() {
+				return
+			}
 			cancelledByGroup.Store(true)
 			cancelJob()
 		}
 
-		release, err := rc.Config.concurrency().acquire(ctx, cancelSelf, specs...)
-		if err != nil {
-			if errors.Is(err, errCancelledByConcurrencyGroup) && ctx.Err() == nil {
-				logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by concurrency group before it started", rc.Name)
-				rc.cancelledResult()
-				return nil
+		if hasSpec {
+			release, err := rc.Config.concurrency().acquire(ctx, jobCancelCtx, spec, cancelSelf)
+			if err != nil {
+				if errors.Is(err, errCancelledByConcurrencyGroup) && ctx.Err() == nil {
+					logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by concurrency group '%s' before it started", rc.Name, spec.group)
+					rc.cancelledResult()
+					return nil
+				}
+				return err
 			}
-			return err
+			defer release()
+			ctx = withHeldConcurrencyGroup(ctx, spec.group)
 		}
-		defer release()
 
-		err = executor(common.WithJobCancelContext(ctx, jobCancelCtx))
-		if cancelledByGroup.Load() && ctx.Err() == nil {
-			logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by a concurrency group with cancel-in-progress", rc.Name)
-			rc.cancelledResult()
+		err := executor(common.WithJobCancelContext(ctx, jobCancelCtx))
+		jobCompleted.Store(true)
+		if rc.handleCancelledJob(ctx, cancelledByGroup.Load(), spec.group) {
 			return nil
 		}
 		return err
 	}
+}
+
+// newJobCancelContext returns a context that gracefully cancels this job
+// when the surrounding cancel context (Ctrl+C), the cancellation of its
+// workflow run, or cancel-in-progress of another job fires. It deliberately
+// does not inherit from ctx: cancelling it signals the job to stop
+// gracefully instead of aborting it.
+func (rc *RunContext) newJobCancelContext(ctx context.Context, runState *workflowRunState) (context.Context, context.CancelFunc) {
+	jobCancelCtx, cancelJob := context.WithCancel(context.Background())
+	var parentDone <-chan struct{}
+	if parent := common.JobCancelContext(ctx); parent != nil {
+		parentDone = parent.Done()
+	}
+	var runCancelled <-chan struct{}
+	if runState != nil {
+		runCancelled = runState.cancelCh
+	}
+	go func() {
+		select {
+		case <-parentDone:
+			cancelJob()
+		case <-runCancelled:
+			cancelJob()
+		case <-jobCancelCtx.Done():
+		}
+	}()
+	return jobCancelCtx, cancelJob
+}
+
+// handleCancelledJob marks the job result 'cancelled' if the job was
+// cancelled by its concurrency group or its workflow run (not by the outer
+// context) and reports whether it did so
+func (rc *RunContext) handleCancelledJob(ctx context.Context, cancelledByGroup bool, group string) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	logger := common.Logger(ctx)
+	if cancelledByGroup {
+		logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by concurrency group '%s' with cancel-in-progress", rc.Name, group)
+		rc.cancelledResult()
+		return true
+	}
+	if rc.runState != nil && rc.runState.cancelled.Load() {
+		logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled because its workflow run was cancelled", rc.Name)
+		rc.cancelledResult()
+		return true
+	}
+	return false
 }
 
 func (rc *RunContext) cancelledResult() {

--- a/pkg/runner/concurrency.go
+++ b/pkg/runner/concurrency.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -12,16 +13,48 @@ import (
 	"github.com/nektos/act/pkg/model"
 )
 
-// errCancelledByConcurrencyGroup is returned by acquire when the request was
-// cancelled instead of run: either it was superseded by a newer request in
-// the same group (GitHub cancels the previously pending run) or the job/run
-// itself was cancelled while waiting.
-var errCancelledByConcurrencyGroup = errors.New("cancelled by the concurrency group")
+// errSupersededByConcurrencyGroup is returned by acquire when the concurrency
+// group itself cancelled the request: a newer request superseded it or the
+// queue of the group was full.
+var errSupersededByConcurrencyGroup = errors.New("superseded by a newer request in the concurrency group")
+
+// errConcurrencyWaitCancelled is returned by acquire when the requester was
+// cancelled while waiting for the group, for example by Ctrl+C or by the
+// cancellation of its own workflow run. The group did not cancel it.
+var errConcurrencyWaitCancelled = errors.New("cancelled while waiting for the concurrency group")
+
+// isConcurrencyCancellation reports whether acquire declined the request
+// rather than failing, in which case the job or run is marked 'cancelled'
+func isConcurrencyCancellation(err error) bool {
+	return errors.Is(err, errSupersededByConcurrencyGroup) || errors.Is(err, errConcurrencyWaitCancelled)
+}
+
+// maxPendingRuns is the number of jobs or workflow runs that may be pending
+// in one concurrency group with `queue: max`
+const maxPendingRuns = 100
 
 // concurrencySpec is an evaluated `concurrency` configuration
 type concurrencySpec struct {
+	// group is the group name as written, used for log messages. Groups are
+	// identified by concurrencyGroupKey, never by this field.
 	group            string
 	cancelInProgress bool
+	// queueMax allows up to maxPendingRuns pending requests instead of the
+	// default single pending request (`queue: max`)
+	queueMax bool
+}
+
+// concurrencyGroupKey identifies a concurrency group. GitHub treats group
+// names case insensitively, so `prod` and `Prod` are the same group.
+func concurrencyGroupKey(group string) string {
+	return strings.ToLower(group)
+}
+
+func queuePolicyName(queueMax bool) string {
+	if queueMax {
+		return "max"
+	}
+	return "single"
 }
 
 // concurrencyWaiter represents one workflow run or job holding or waiting
@@ -32,20 +65,31 @@ type concurrencyWaiter struct {
 	cancelSelf func()
 	// promoted is closed when the waiter becomes the holder of the group
 	promoted chan struct{}
-	// superseded is closed when a newer pending request replaces this one,
-	// the superseded request is cancelled without having run
+	// superseded is closed when a pending request is cancelled without
+	// having run, because a newer request replaced it
 	superseded chan struct{}
 }
 
 type concurrencyGroup struct {
-	holder  *concurrencyWaiter
-	pending *concurrencyWaiter
+	holder *concurrencyWaiter
+	// pending holds the waiting requests in first-in-first-out order, the
+	// head is promoted when the holder releases the group
+	pending []*concurrencyWaiter
+	// queueMax is the queue policy of the group, taken from the request that
+	// created it. Workflows sharing a group name are expected to agree on
+	// the policy; the group's policy wins for later arrivals so that a
+	// workflow which omits `queue: max` cannot discard a queue admitted
+	// under it.
+	queueMax bool
 }
 
 // concurrencyManager implements GitHub's concurrency group queueing: one
-// holder runs at a time, at most one request is pending and a newer request
-// supersedes (cancels) the previously pending one. A single instance is
-// shared between a runner and all reusable workflow runners spawned from it.
+// holder runs at a time and requests queue behind it. With the default
+// `queue: single` at most one request is pending and a newer request
+// supersedes (cancels) the previously pending one; with `queue: max` up to
+// maxPendingRuns requests queue in FIFO order and requests arriving once the
+// queue is full are cancelled. A single instance is shared between a runner
+// and all reusable workflow runners spawned from it.
 type concurrencyManager struct {
 	mu     sync.Mutex
 	groups map[string]*concurrencyGroup
@@ -67,31 +111,61 @@ func (m *concurrencyManager) acquire(ctx context.Context, cancelCtx context.Cont
 		superseded: make(chan struct{}),
 	}
 
+	key := concurrencyGroupKey(spec.group)
+
 	m.mu.Lock()
-	group := m.groups[spec.group]
+	group := m.groups[key]
 	if group == nil {
-		group = &concurrencyGroup{}
-		m.groups[spec.group] = group
+		group = &concurrencyGroup{queueMax: spec.queueMax}
+		m.groups[key] = group
+	} else if group.queueMax != spec.queueMax {
+		// workflows sharing a group name are expected to agree on the queue
+		// policy; the policy of the group wins so a workflow that omits
+		// `queue: max` cannot discard a queue admitted under it
+		logger.Warnf("Concurrency group '%s' is used with both 'queue: single' and 'queue: max', keeping '%s' for the whole group",
+			spec.group, queuePolicyName(group.queueMax))
 	}
 	if group.holder == nil {
 		group.holder = me
 		m.mu.Unlock()
-		return func() { m.release(spec.group, me) }, nil
+		return func() { m.release(key, me) }, nil
 	}
 	if spec.cancelInProgress && group.holder.cancelSelf != nil {
 		logger.Infof("Cancelling the run in progress in concurrency group '%s'", spec.group)
 		group.holder.cancelSelf()
 	}
-	if group.pending != nil {
-		// GitHub keeps at most one pending run per group: the previously
-		// pending run is cancelled and replaced by the newer request
-		logger.Infof("Superseding the run pending in concurrency group '%s'", spec.group)
-		close(group.pending.superseded)
+	if group.queueMax {
+		// with `queue: max` the queue is bounded and the *arriving* request
+		// is cancelled once it is full, the queued ones keep their place
+		if len(group.pending) >= maxPendingRuns {
+			m.mu.Unlock()
+			logger.Infof("Concurrency group '%s' already has %d pending runs, cancelling this one", spec.group, maxPendingRuns)
+			return nil, errSupersededByConcurrencyGroup
+		}
+	} else if len(group.pending) > 0 {
+		// with the default `queue: single` GitHub keeps at most one pending
+		// run per group: the previously pending run is cancelled and
+		// replaced by the newer request
+		if len(group.pending) == 1 {
+			logger.Infof("Superseding the run pending in concurrency group '%s'", spec.group)
+		} else {
+			logger.Infof("Superseding the %d runs pending in concurrency group '%s'", len(group.pending), spec.group)
+		}
+		for _, superseded := range group.pending {
+			close(superseded.superseded)
+		}
+		group.pending = nil
 	}
-	group.pending = me
+	group.pending = append(group.pending, me)
+	position := len(group.pending)
+	queueMax := group.queueMax
 	m.mu.Unlock()
 
-	logger.Infof("Waiting for concurrency group '%s'", spec.group)
+	if queueMax {
+		logger.Infof("Waiting for concurrency group '%s' at queue position %d", spec.group, position)
+	} else {
+		logger.Infof("Waiting for concurrency group '%s'", spec.group)
+	}
 
 	var cancelDone <-chan struct{}
 	if cancelCtx != nil {
@@ -100,39 +174,62 @@ func (m *concurrencyManager) acquire(ctx context.Context, cancelCtx context.Cont
 	select {
 	case <-me.promoted:
 		logger.Infof("Acquired concurrency group '%s'", spec.group)
-		return func() { m.release(spec.group, me) }, nil
+		return func() { m.release(key, me) }, nil
 	case <-me.superseded:
-		return nil, errCancelledByConcurrencyGroup
+		return nil, errSupersededByConcurrencyGroup
 	case <-cancelDone:
-		m.removePending(spec.group, me)
-		return nil, errCancelledByConcurrencyGroup
+		m.abandon(key, me)
+		return nil, errConcurrencyWaitCancelled
 	case <-ctx.Done():
-		m.removePending(spec.group, me)
+		m.abandon(key, me)
 		return nil, ctx.Err()
 	}
 }
 
-func (m *concurrencyManager) release(groupName string, me *concurrencyWaiter) {
+func (m *concurrencyManager) release(groupKey string, me *concurrencyWaiter) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	group := m.groups[groupName]
+	group := m.groups[groupKey]
 	if group == nil || group.holder != me {
 		return
 	}
-	if group.pending != nil {
-		group.holder = group.pending
-		group.pending = nil
+	m.releaseLocked(groupKey, group)
+}
+
+// releaseLocked hands the group to the request that has been waiting the
+// longest (FIFO), or drops the group when nothing is waiting
+func (m *concurrencyManager) releaseLocked(groupKey string, group *concurrencyGroup) {
+	if len(group.pending) > 0 {
+		group.holder = group.pending[0]
+		group.pending = group.pending[1:]
 		close(group.holder.promoted)
 		return
 	}
-	delete(m.groups, groupName)
+	delete(m.groups, groupKey)
 }
 
-func (m *concurrencyManager) removePending(groupName string, me *concurrencyWaiter) {
+// abandon drops a waiter that gave up waiting for the group. The waiter can
+// be promoted to holder at the very moment it gives up — its select then may
+// pick either branch — so a waiter that turns out to be the holder releases
+// the group instead of leaving it held by a request that never runs.
+func (m *concurrencyManager) abandon(groupKey string, me *concurrencyWaiter) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if group := m.groups[groupName]; group != nil && group.pending == me {
-		group.pending = nil
+	group := m.groups[groupKey]
+	if group == nil {
+		return
+	}
+	for i, waiter := range group.pending {
+		if waiter == me {
+			group.pending = append(group.pending[:i], group.pending[i+1:]...)
+			if group.holder == nil && len(group.pending) == 0 {
+				delete(m.groups, groupKey)
+			}
+			return
+		}
+	}
+	if group.holder == me {
+		m.releaseLocked(groupKey, group)
 	}
 }
 
@@ -155,7 +252,7 @@ var concurrencyInitMu sync.Mutex
 type heldConcurrencyGroupsKey struct{}
 
 func withHeldConcurrencyGroup(ctx context.Context, group string) context.Context {
-	held := map[string]bool{group: true}
+	held := map[string]bool{concurrencyGroupKey(group): true}
 	for g := range heldConcurrencyGroups(ctx) {
 		held[g] = true
 	}
@@ -167,6 +264,13 @@ func heldConcurrencyGroups(ctx context.Context) map[string]bool {
 		return held
 	}
 	return nil
+}
+
+// isConcurrencyGroupHeld reports whether the group is already held by this
+// workflow run or one of its callers, in which case waiting for it would
+// deadlock on our own caller
+func isConcurrencyGroupHeld(ctx context.Context, group string) bool {
+	return heldConcurrencyGroups(ctx)[concurrencyGroupKey(group)]
 }
 
 // workflowRunState tracks the cancellation of one workflow run, used both for
@@ -197,14 +301,9 @@ func (s *workflowRunState) complete() {
 	s.completed.Store(true)
 }
 
-func evaluateConcurrency(ctx context.Context, ee ExpressionEvaluator, concurrency *model.Concurrency) (concurrencySpec, bool) {
+func evaluateConcurrency(ctx context.Context, ee ExpressionEvaluator, concurrency *model.Concurrency) (concurrencySpec, bool, error) {
 	if concurrency == nil {
-		return concurrencySpec{}, false
-	}
-	group := strings.TrimSpace(ee.Interpolate(ctx, concurrency.Group))
-	if group == "" {
-		common.Logger(ctx).Warnf("Concurrency group evaluated to an empty string, ignoring the concurrency settings")
-		return concurrencySpec{}, false
+		return concurrencySpec{}, false, nil
 	}
 	cancelInProgress := false
 	if val := strings.TrimSpace(ee.Interpolate(ctx, concurrency.CancelInProgress)); val != "" {
@@ -214,7 +313,47 @@ func evaluateConcurrency(ctx context.Context, ee ExpressionEvaluator, concurrenc
 			cancelInProgress = false
 		}
 	}
-	return concurrencySpec{group: group, cancelInProgress: cancelInProgress}, true
+	// the settings are validated before the group is inspected, an invalid
+	// concurrency block is rejected even when its group interpolates empty
+	queueMax, err := parseQueuePolicy(strings.TrimSpace(ee.Interpolate(ctx, concurrency.Queue)))
+	if err != nil {
+		return concurrencySpec{}, false, err
+	}
+	if err := validateQueuePolicy(queueMax, cancelInProgress); err != nil {
+		return concurrencySpec{}, false, err
+	}
+
+	group := strings.TrimSpace(ee.Interpolate(ctx, concurrency.Group))
+	if group == "" {
+		common.Logger(ctx).Warnf("Concurrency group evaluated to an empty string, ignoring the concurrency settings")
+		return concurrencySpec{}, false, nil
+	}
+	return concurrencySpec{
+		group:            group,
+		cancelInProgress: cancelInProgress,
+		queueMax:         queueMax,
+	}, true, nil
+}
+
+// parseQueuePolicy maps the `queue` value to whether the group queues up to
+// maxPendingRuns requests. An empty value is the documented default `single`.
+func parseQueuePolicy(value string) (bool, error) {
+	switch value {
+	case "", "single":
+		return false, nil
+	case "max":
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid value '%s' for 'concurrency.queue', expected 'single' or 'max'", value)
+	}
+}
+
+// validateQueuePolicy rejects the combination GitHub refuses to run
+func validateQueuePolicy(queueMax bool, cancelInProgress bool) error {
+	if queueMax && cancelInProgress {
+		return errors.New("the combination of 'queue: max' and 'cancel-in-progress: true' is not allowed in a concurrency group")
+	}
+	return nil
 }
 
 // withConcurrency wraps a job executor so it takes part in the cancellation
@@ -233,8 +372,11 @@ func (rc *RunContext) withConcurrency(executor common.Executor) common.Executor 
 			return nil
 		}
 
-		spec, hasSpec := evaluateConcurrency(ctx, rc.NewExpressionEvaluator(ctx), rc.Run.Job().Concurrency())
-		if hasSpec && heldConcurrencyGroups(ctx)[spec.group] {
+		spec, hasSpec, err := evaluateConcurrency(ctx, rc.NewExpressionEvaluator(ctx), rc.Run.Job().Concurrency())
+		if err != nil {
+			return err
+		}
+		if hasSpec && isConcurrencyGroupHeld(ctx, spec.group) {
 			// the group is already held by this run or a calling workflow,
 			// acquiring it again would deadlock on our own caller
 			logger.Debugf("Concurrency group '%s' is already held by this workflow run or its caller", spec.group)
@@ -242,7 +384,7 @@ func (rc *RunContext) withConcurrency(executor common.Executor) common.Executor 
 		}
 
 		if !hasSpec && runState == nil {
-			return executor(ctx)
+			return rc.withJobSlot(ctx, executor)
 		}
 
 		jobCancelCtx, cancelJob := rc.newJobCancelContext(ctx, runState)
@@ -261,8 +403,12 @@ func (rc *RunContext) withConcurrency(executor common.Executor) common.Executor 
 		if hasSpec {
 			release, err := rc.Config.concurrency().acquire(ctx, jobCancelCtx, spec, cancelSelf)
 			if err != nil {
-				if errors.Is(err, errCancelledByConcurrencyGroup) && ctx.Err() == nil {
-					logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by concurrency group '%s' before it started", rc.Name, spec.group)
+				if isConcurrencyCancellation(err) && ctx.Err() == nil {
+					if errors.Is(err, errSupersededByConcurrencyGroup) {
+						logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by concurrency group '%s' before it started", rc.Name, spec.group)
+					} else {
+						logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled while waiting for concurrency group '%s'", rc.Name, spec.group)
+					}
 					rc.cancelledResult()
 					return nil
 				}
@@ -272,13 +418,32 @@ func (rc *RunContext) withConcurrency(executor common.Executor) common.Executor 
 			ctx = withHeldConcurrencyGroup(ctx, spec.group)
 		}
 
-		err := executor(common.WithJobCancelContext(ctx, jobCancelCtx))
+		err = rc.withJobSlot(ctx, func(ctx context.Context) error {
+			return executor(common.WithJobCancelContext(ctx, jobCancelCtx))
+		})
 		jobCompleted.Store(true)
 		if rc.handleCancelledJob(ctx, cancelledByGroup.Load(), spec.group) {
 			return nil
 		}
 		return err
 	}
+}
+
+// withJobSlot runs executor while holding one of the slots limiting how many
+// jobs execute at the same time (--concurrent-jobs). The slot is taken only
+// once the job is ready to run, so jobs waiting for a concurrency group do
+// not occupy slots other workflow runs need to make progress.
+func (rc *RunContext) withJobSlot(ctx context.Context, executor common.Executor) error {
+	if rc.jobSlots == nil {
+		return executor(ctx)
+	}
+	select {
+	case rc.jobSlots <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	defer func() { <-rc.jobSlots }()
+	return executor(ctx)
 }
 
 // newJobCancelContext returns a context that gracefully cancels this job

--- a/pkg/runner/concurrency.go
+++ b/pkg/runner/concurrency.go
@@ -1,0 +1,272 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/model"
+)
+
+// errCancelledByConcurrencyGroup is returned by acquire when the owner of the
+// request was cancelled by another job entering one of its concurrency groups
+// with cancel-in-progress enabled.
+var errCancelledByConcurrencyGroup = errors.New("cancelled by another job in the same concurrency group")
+
+// concurrencySpec describes a single concurrency group requirement of a job.
+// Jobs sharing the same owner may hold the group at the same time. This lets
+// all jobs of one workflow run share the workflow level concurrency group,
+// while job level groups use a unique owner per job so they serialize.
+type concurrencySpec struct {
+	group            string
+	owner            string
+	cancelInProgress bool
+}
+
+type concurrencyGroup struct {
+	owner string
+	// holders maps an id per acquisition to the cancel function of the
+	// holding job, so cancel-in-progress can cancel all current holders
+	holders map[int64]context.CancelFunc
+	// released is closed (and the group dropped) once the last holder
+	// releases the group, waking up all waiting jobs
+	released chan struct{}
+}
+
+// concurrencyManager serializes jobs that share a concurrency group. A single
+// instance is shared between a runner and all reusable workflow runners
+// spawned from it, so called workflows take part in the same groups.
+type concurrencyManager struct {
+	mu        sync.Mutex
+	holderSeq int64
+	ownerSeq  atomic.Int64
+	groups    map[string]*concurrencyGroup
+	// cancelledOwners records owners that were cancelled via
+	// cancel-in-progress; their remaining jobs are cancelled instead of run,
+	// approximating GitHub cancelling the whole workflow run
+	cancelledOwners map[string]bool
+}
+
+func newConcurrencyManager() *concurrencyManager {
+	return &concurrencyManager{
+		groups:          map[string]*concurrencyGroup{},
+		cancelledOwners: map[string]bool{},
+	}
+}
+
+// newOwner returns a new unique owner identity for a workflow run or a job
+func (m *concurrencyManager) newOwner(kind string) string {
+	return fmt.Sprintf("%s-%d", kind, m.ownerSeq.Add(1))
+}
+
+// acquire blocks until all requested groups are held by the calling job and
+// returns a function releasing them again. cancelSelf is invoked if another
+// job cancels this one via cancel-in-progress.
+func (m *concurrencyManager) acquire(ctx context.Context, cancelSelf context.CancelFunc, specs ...concurrencySpec) (func(), error) {
+	ordered := make([]concurrencySpec, len(specs))
+	copy(ordered, specs)
+	// acquire groups in a stable order to avoid deadlocks between jobs
+	// requesting the same groups in a different order
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].group < ordered[j].group })
+
+	releases := make([]func(), 0, len(ordered))
+	releaseAll := func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+	}
+
+	for _, spec := range ordered {
+		release, err := m.acquireGroup(ctx, spec, cancelSelf)
+		if err != nil {
+			releaseAll()
+			return nil, err
+		}
+		releases = append(releases, release)
+	}
+	return releaseAll, nil
+}
+
+func (m *concurrencyManager) acquireGroup(ctx context.Context, spec concurrencySpec, cancelSelf context.CancelFunc) (func(), error) {
+	logger := common.Logger(ctx)
+	waiting := false
+	m.mu.Lock()
+	for {
+		if m.cancelledOwners[spec.owner] {
+			m.mu.Unlock()
+			return nil, errCancelledByConcurrencyGroup
+		}
+		group := m.groups[spec.group]
+		if group == nil {
+			group = &concurrencyGroup{
+				holders:  map[int64]context.CancelFunc{},
+				released: make(chan struct{}),
+			}
+			m.groups[spec.group] = group
+		}
+		if len(group.holders) == 0 || group.owner == spec.owner {
+			group.owner = spec.owner
+			m.holderSeq++
+			id := m.holderSeq
+			group.holders[id] = cancelSelf
+			m.mu.Unlock()
+			if waiting {
+				logger.Infof("Acquired concurrency group '%s'", spec.group)
+			}
+			return func() { m.release(spec.group, id) }, nil
+		}
+		if spec.cancelInProgress {
+			// mark the current owner as cancelled and cancel all its jobs
+			// holding the group; the group is re-acquired once they release it
+			m.cancelledOwners[group.owner] = true
+			logger.Infof("Cancelling in-progress jobs in concurrency group '%s'", spec.group)
+			for _, cancel := range group.holders {
+				cancel()
+			}
+		}
+		if !waiting {
+			logger.Infof("Waiting for concurrency group '%s'", spec.group)
+			waiting = true
+		}
+		released := group.released
+		m.mu.Unlock()
+		select {
+		case <-released:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		m.mu.Lock()
+	}
+}
+
+func (m *concurrencyManager) release(groupName string, id int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	group := m.groups[groupName]
+	if group == nil {
+		return
+	}
+	delete(group.holders, id)
+	if len(group.holders) == 0 {
+		delete(m.groups, groupName)
+		close(group.released)
+	}
+}
+
+// concurrency returns the shared concurrency manager for this config,
+// creating it on first use
+func (config *Config) concurrency() *concurrencyManager {
+	concurrencyInitMu.Lock()
+	defer concurrencyInitMu.Unlock()
+	if config.concurrencyManager == nil {
+		config.concurrencyManager = newConcurrencyManager()
+	}
+	return config.concurrencyManager
+}
+
+var concurrencyInitMu sync.Mutex
+
+// concurrencySpecs evaluates the workflow and job level concurrency groups
+// that apply to this job
+func (rc *RunContext) concurrencySpecs(ctx context.Context) []concurrencySpec {
+	specs := make([]concurrencySpec, 0, 2)
+	ee := rc.NewExpressionEvaluator(ctx)
+	if spec, ok := evaluateConcurrency(ctx, ee, rc.Run.Job().Concurrency(), rc.jobConcurrencyOwner); ok {
+		specs = append(specs, spec)
+	}
+	if spec, ok := evaluateConcurrency(ctx, ee, rc.Run.Workflow.Concurrency(), rc.workflowConcurrencyOwner); ok {
+		// if the job level group has the same name the job would wait for a
+		// group it already holds, so only keep the stricter job level spec
+		if len(specs) == 0 || specs[0].group != spec.group {
+			specs = append(specs, spec)
+		}
+	}
+	return specs
+}
+
+func evaluateConcurrency(ctx context.Context, ee ExpressionEvaluator, concurrency *model.Concurrency, owner string) (concurrencySpec, bool) {
+	if concurrency == nil || owner == "" {
+		return concurrencySpec{}, false
+	}
+	group := strings.TrimSpace(ee.Interpolate(ctx, concurrency.Group))
+	if group == "" {
+		common.Logger(ctx).Warnf("Concurrency group evaluated to an empty string, ignoring the concurrency settings")
+		return concurrencySpec{}, false
+	}
+	cancelInProgress := false
+	if val := strings.TrimSpace(ee.Interpolate(ctx, concurrency.CancelInProgress)); val != "" {
+		var err error
+		if cancelInProgress, err = strconv.ParseBool(val); err != nil {
+			common.Logger(ctx).Errorf("Failed to parse 'cancel-in-progress' value '%s': %v", val, err)
+			cancelInProgress = false
+		}
+	}
+	return concurrencySpec{group: group, owner: owner, cancelInProgress: cancelInProgress}, true
+}
+
+// withConcurrency wraps a job executor so it holds the concurrency groups of
+// the job while running. Jobs cancelled by cancel-in-progress of another job
+// finish with result 'cancelled' without failing the plan.
+func (rc *RunContext) withConcurrency(executor common.Executor) common.Executor {
+	return func(ctx context.Context) error {
+		specs := rc.concurrencySpecs(ctx)
+		if len(specs) == 0 {
+			return executor(ctx)
+		}
+
+		logger := common.Logger(ctx)
+
+		// gracefully cancel this job when either the surrounding cancel
+		// context (Ctrl+C) or cancel-in-progress of another job fires
+		jobCancelCtx, cancelJob := context.WithCancel(context.Background())
+		defer cancelJob()
+		if parent := common.JobCancelContext(ctx); parent != nil {
+			go func() {
+				select {
+				case <-parent.Done():
+					cancelJob()
+				case <-jobCancelCtx.Done():
+				}
+			}()
+		}
+
+		var cancelledByGroup atomic.Bool
+		cancelSelf := func() {
+			cancelledByGroup.Store(true)
+			cancelJob()
+		}
+
+		release, err := rc.Config.concurrency().acquire(ctx, cancelSelf, specs...)
+		if err != nil {
+			if errors.Is(err, errCancelledByConcurrencyGroup) && ctx.Err() == nil {
+				logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by concurrency group before it started", rc.Name)
+				rc.cancelledResult()
+				return nil
+			}
+			return err
+		}
+		defer release()
+
+		err = executor(common.WithJobCancelContext(ctx, jobCancelCtx))
+		if cancelledByGroup.Load() && ctx.Err() == nil {
+			logger.WithField("jobResult", "cancelled").Infof("\U0001F6AB  Job '%s' was cancelled by a concurrency group with cancel-in-progress", rc.Name)
+			rc.cancelledResult()
+			return nil
+		}
+		return err
+	}
+}
+
+func (rc *RunContext) cancelledResult() {
+	rc.result("cancelled")
+	if rc.caller != nil {
+		// a cancelled job of a called workflow cancels the calling job
+		rc.caller.runContext.result("cancelled")
+	}
+}

--- a/pkg/runner/concurrency_test.go
+++ b/pkg/runner/concurrency_test.go
@@ -1,0 +1,302 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nektos/act/pkg/model"
+)
+
+func TestConcurrencyManagerSerializesDifferentOwners(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+
+	var mu sync.Mutex
+	active := 0
+	maxActive := 0
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			release, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group", owner: manager.newOwner("job")})
+			assert.NoError(t, err)
+			defer release()
+
+			mu.Lock()
+			active++
+			if active > maxActive {
+				maxActive = active
+			}
+			mu.Unlock()
+
+			time.Sleep(10 * time.Millisecond)
+
+			mu.Lock()
+			active--
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, maxActive, "only one job of a concurrency group may run at a time")
+}
+
+func TestConcurrencyManagerSharedOwnerDoesNotBlock(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	spec := concurrencySpec{group: "group", owner: "workflow-1"}
+
+	releaseFirst, err := manager.acquire(ctx, func() {}, spec)
+	require.NoError(t, err)
+	defer releaseFirst()
+
+	// jobs of the same workflow run share the workflow level group and must
+	// not wait for each other
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		releaseSecond, err := manager.acquire(ctx, func() {}, spec)
+		assert.NoError(t, err)
+		releaseSecond()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("job sharing the owner of the group holder should not wait")
+	}
+}
+
+func TestConcurrencyManagerDifferentGroupsDoNotBlock(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+
+	releaseFirst, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group-1", owner: "job-1"})
+	require.NoError(t, err)
+	defer releaseFirst()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		releaseSecond, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group-2", owner: "job-2"})
+		assert.NoError(t, err)
+		releaseSecond()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("jobs in different concurrency groups should not wait for each other")
+	}
+}
+
+func TestConcurrencyManagerCancelInProgress(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+
+	firstOwner := manager.newOwner("workflow")
+	cancelled := make(chan struct{})
+	releaseFirst, err := manager.acquire(ctx, func() { close(cancelled) }, concurrencySpec{group: "group", owner: firstOwner})
+	require.NoError(t, err)
+
+	// the cancelled job releases the group once it stopped running
+	go func() {
+		<-cancelled
+		releaseFirst()
+	}()
+
+	release, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group", owner: manager.newOwner("workflow"), cancelInProgress: true})
+	assert.NoError(t, err)
+	release()
+
+	select {
+	case <-cancelled:
+	default:
+		t.Fatal("the job holding the group should have been cancelled")
+	}
+
+	// remaining jobs of the cancelled owner are cancelled instead of run
+	_, err = manager.acquire(ctx, func() {}, concurrencySpec{group: "another-group", owner: firstOwner})
+	assert.ErrorIs(t, err, errCancelledByConcurrencyGroup)
+}
+
+func TestConcurrencyManagerContextCancelledWhileWaiting(t *testing.T) {
+	manager := newConcurrencyManager()
+
+	release, err := manager.acquire(context.Background(), func() {}, concurrencySpec{group: "group", owner: "job-1"})
+	require.NoError(t, err)
+	defer release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = manager.acquire(ctx, func() {}, concurrencySpec{group: "group", owner: "job-2"})
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestConcurrencyManagerReleasesAcquiredGroupsOnError(t *testing.T) {
+	manager := newConcurrencyManager()
+
+	release, err := manager.acquire(context.Background(), func() {}, concurrencySpec{group: "group-2", owner: "job-1"})
+	require.NoError(t, err)
+	defer release()
+
+	// requesting group-1 and group-2 acquires group-1 first, then fails on
+	// the held group-2 and must release group-1 again
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = manager.acquire(ctx, func() {},
+		concurrencySpec{group: "group-1", owner: "job-2"},
+		concurrencySpec{group: "group-2", owner: "job-2"})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		releaseAgain, err := manager.acquire(context.Background(), func() {}, concurrencySpec{group: "group-1", owner: "job-3"})
+		assert.NoError(t, err)
+		releaseAgain()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("group-1 should have been released after the failed acquisition")
+	}
+}
+
+func runConcurrencyWorkflow(t *testing.T, workflowPath string, markerDir string) *model.Plan {
+	t.Helper()
+
+	log.SetLevel(logLevel)
+
+	workdir, err := filepath.Abs(workdir)
+	require.NoError(t, err)
+
+	config := &Config{
+		Workdir:        workdir,
+		EventName:      "push",
+		Platforms:      map[string]string{"self-hosted": "-self-hosted"},
+		GitHubInstance: "github.com",
+		Env:            map[string]string{"MARKER_DIR": markerDir},
+		ConcurrentJobs: 4,
+	}
+	runner, err := New(config)
+	require.NoError(t, err)
+
+	planner, err := model.NewWorkflowPlanner(filepath.Join(workdir, workflowPath), true, false)
+	require.NoError(t, err)
+	plan, err := planner.PlanEvent("push")
+	require.NoError(t, err)
+
+	require.NoError(t, runner.NewPlanExecutor(plan)(context.Background()))
+	return plan
+}
+
+type jobInterval struct {
+	name  string
+	start time.Time
+	end   time.Time
+}
+
+func markerInterval(t *testing.T, dir string, name string) jobInterval {
+	t.Helper()
+	start, err := os.Stat(filepath.Join(dir, name+"-start"))
+	require.NoError(t, err)
+	end, err := os.Stat(filepath.Join(dir, name+"-end"))
+	require.NoError(t, err)
+	return jobInterval{name: name, start: start.ModTime(), end: end.ModTime()}
+}
+
+func assertIntervalsDisjoint(t *testing.T, a jobInterval, b jobInterval) {
+	t.Helper()
+	if !a.end.After(b.start) || !b.end.After(a.start) {
+		return
+	}
+	t.Errorf("jobs '%s' (%v - %v) and '%s' (%v - %v) overlapped although they share a concurrency group",
+		a.name, a.start, a.end, b.name, b.start, b.end)
+}
+
+func concurrencyTestWorkflow(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + "-windows"
+	}
+	return name
+}
+
+func TestRunConcurrencyGroupSerializesJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	markerDir := filepath.ToSlash(t.TempDir())
+	plan := runConcurrencyWorkflow(t, concurrencyTestWorkflow("concurrency-serialize"), markerDir)
+
+	first := markerInterval(t, markerDir, "first")
+	second := markerInterval(t, markerDir, "second")
+	assertIntervalsDisjoint(t, first, second)
+
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			assert.Equal(t, "success", run.Job().Result, "job %s should have succeeded", run.String())
+		}
+	}
+}
+
+func TestRunConcurrencyGroupSerializesWorkflows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	markerDir := filepath.ToSlash(t.TempDir())
+	plan := runConcurrencyWorkflow(t, concurrencyTestWorkflow("concurrency-workflow-group"), markerDir)
+
+	// jobs of the same workflow run share the workflow level group and may
+	// run in parallel, but jobs of different workflow runs must not overlap
+	for _, w1 := range []string{"w1-a", "w1-b"} {
+		for _, w2 := range []string{"w2-a", "w2-b"} {
+			assertIntervalsDisjoint(t, markerInterval(t, markerDir, w1), markerInterval(t, markerDir, w2))
+		}
+	}
+
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			assert.Equal(t, "success", run.Job().Result, "job %s should have succeeded", run.String())
+		}
+	}
+}
+
+func TestRunConcurrencyCancelInProgress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	plan := runConcurrencyWorkflow(t, concurrencyTestWorkflow("concurrency-cancel"), "")
+
+	results := map[string]string{}
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			results[run.JobID] = run.Job().Result
+		}
+	}
+	require.Len(t, results, 2)
+
+	successes := 0
+	for jobID, result := range results {
+		assert.Contains(t, []string{"success", "cancelled"}, result, "job %s must either succeed or be cancelled", jobID)
+		if result == "success" {
+			successes++
+		}
+	}
+	assert.GreaterOrEqual(t, successes, 1, "at least one job must have succeeded: %v", results)
+}

--- a/pkg/runner/concurrency_test.go
+++ b/pkg/runner/concurrency_test.go
@@ -1,17 +1,23 @@
 package runner
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
+	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
 )
 
@@ -27,8 +33,9 @@ func TestConcurrencyManagerSerializes(t *testing.T) {
 	go func() {
 		defer close(acquired)
 		releaseSecond, err := manager.acquire(ctx, nil, spec, func() {})
-		assert.NoError(t, err)
-		releaseSecond()
+		if assert.NoError(t, err) && releaseSecond != nil {
+			releaseSecond()
+		}
 	}()
 
 	select {
@@ -64,7 +71,8 @@ func TestConcurrencyManagerSupersedesPending(t *testing.T) {
 	require.Eventually(t, func() bool {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
-		return manager.groups["group"].pending != nil
+		g := manager.groups["group"]
+		return g != nil && len(g.pending) > 0
 	}, 5*time.Second, 10*time.Millisecond)
 
 	third := make(chan error, 1)
@@ -80,7 +88,7 @@ func TestConcurrencyManagerSupersedesPending(t *testing.T) {
 	// the second (previously pending) request is cancelled by the third
 	select {
 	case err := <-superseded:
-		assert.ErrorIs(t, err, errCancelledByConcurrencyGroup)
+		assert.ErrorIs(t, err, errSupersededByConcurrencyGroup)
 	case <-time.After(5 * time.Second):
 		t.Fatal("the pending request must be superseded by a newer request")
 	}
@@ -93,6 +101,471 @@ func TestConcurrencyManagerSupersedesPending(t *testing.T) {
 		(<-releases)()
 	case <-time.After(5 * time.Second):
 		t.Fatal("the newest request must acquire the group after the release")
+	}
+}
+
+func TestConcurrencyManagerCaseInsensitiveGroups(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+
+	// GitHub treats concurrency group names case insensitively, so 'prod'
+	// and 'Prod' are the same group
+	lower, _, err := evaluateConcurrency(ctx, testEvaluator{}, &model.Concurrency{Group: "prod"})
+	require.NoError(t, err)
+	upper, _, err := evaluateConcurrency(ctx, testEvaluator{}, &model.Concurrency{Group: "Prod"})
+	require.NoError(t, err)
+	assert.Equal(t, concurrencyGroupKey(lower.group), concurrencyGroupKey(upper.group))
+	assert.Equal(t, "Prod", upper.group, "the original spelling is kept for log messages")
+
+	releaseFirst, err := manager.acquire(ctx, nil, lower, func() {})
+	require.NoError(t, err)
+
+	acquired := make(chan struct{})
+	go func() {
+		defer close(acquired)
+		release, err := manager.acquire(ctx, nil, upper, func() {})
+		if assert.NoError(t, err) && release != nil {
+			release()
+		}
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("'Prod' must wait for 'prod', they are the same concurrency group")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseFirst()
+
+	select {
+	case <-acquired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("'Prod' must acquire the group after 'prod' released it")
+	}
+}
+
+func TestConcurrencyManagerQueueMaxIsFIFO(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	spec := concurrencySpec{group: "group", queueMax: true}
+
+	releaseFirst, err := manager.acquire(ctx, nil, spec, func() {})
+	require.NoError(t, err)
+
+	// queue three requests in a known order and record the order in which
+	// they acquire the group
+	var mu sync.Mutex
+	order := []int{}
+	done := make(chan struct{}, 3)
+	releases := make(chan func(), 3)
+	for i := 1; i <= 3; i++ {
+		queuePending(ctx, t, manager, spec, i, &mu, &order, done, releases)
+	}
+
+	releaseFirst()
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("all queued requests must eventually acquire the group")
+		}
+		(<-releases)()
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []int{1, 2, 3}, order, "queued runs must be promoted first-in-first-out")
+}
+
+// queuePending starts a request that waits for the group and records its id
+// once it acquires it, returning after the request is registered as pending
+func queuePending(ctx context.Context, t *testing.T, manager *concurrencyManager, spec concurrencySpec, id int, mu *sync.Mutex, order *[]int, done chan struct{}, releases chan func()) {
+	t.Helper()
+	expected := 0
+	manager.mu.Lock()
+	if group := manager.groups[concurrencyGroupKey(spec.group)]; group != nil {
+		expected = len(group.pending) + 1
+	}
+	manager.mu.Unlock()
+
+	go func() {
+		release, err := manager.acquire(ctx, nil, spec, func() {})
+		if !assert.NoError(t, err) || release == nil {
+			done <- struct{}{}
+			return
+		}
+		mu.Lock()
+		*order = append(*order, id)
+		mu.Unlock()
+		releases <- release
+		done <- struct{}{}
+	}()
+
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		group := manager.groups[concurrencyGroupKey(spec.group)]
+		return group != nil && len(group.pending) == expected
+	}, 5*time.Second, 5*time.Millisecond, "request %d should be pending", id)
+}
+
+func TestConcurrencyManagerQueueMaxCancelsOverflow(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	spec := concurrencySpec{group: "group", queueMax: true}
+
+	release, err := manager.acquire(ctx, nil, spec, func() {})
+	require.NoError(t, err)
+	defer release()
+
+	key := concurrencyGroupKey(spec.group)
+	pendingCount := func() int {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		if group := manager.groups[key]; group != nil {
+			return len(group.pending)
+		}
+		return 0
+	}
+
+	// queue every request through acquire, so the cap is exercised on the
+	// real path rather than against hand-built internal state
+	results := make(chan error, maxPendingRuns)
+	for i := 0; i < maxPendingRuns; i++ {
+		go func() {
+			release, err := manager.acquire(ctx, nil, spec, func() {})
+			if release != nil {
+				release()
+			}
+			results <- err
+		}()
+		// queue them one at a time so the boundary is approached exactly and
+		// the FIFO order stays deterministic
+		want := i + 1
+		require.Eventually(t, func() bool { return pendingCount() == want }, 5*time.Second, 5*time.Millisecond,
+			"request %d must be accepted into the queue, not cancelled", want)
+	}
+
+	// the queue now holds exactly the documented limit, which pins the
+	// boundary to maxPendingRuns rather than to any smaller cap
+	require.Equal(t, maxPendingRuns, pendingCount())
+
+	// the next request arrives at a full queue and is cancelled, the queued
+	// ones keep their place
+	_, err = manager.acquire(ctx, nil, spec, func() {})
+	assert.ErrorIs(t, err, errSupersededByConcurrencyGroup)
+	assert.Equal(t, maxPendingRuns, pendingCount(), "a full queue must not grow beyond the limit")
+
+	// drain: releasing the holder lets the whole queue through
+	release()
+	for i := 0; i < maxPendingRuns; i++ {
+		select {
+		case err := <-results:
+			assert.NoError(t, err, "every queued request must eventually acquire the group")
+		case <-time.After(30 * time.Second):
+			t.Fatal("the queue must drain once the holder releases the group")
+		}
+	}
+}
+
+func TestConcurrencyManagerAbandonThroughAcquireReleasesGroup(t *testing.T) {
+	// a waiter can be promoted at the very moment its own cancellation
+	// fires; acquire's select may then take the cancelled branch while the
+	// waiter already holds the group. Drive that race through acquire
+	// repeatedly: if the group is left held, the follow-up acquire blocks.
+	for i := 0; i < 100; i++ {
+		manager := newConcurrencyManager()
+		spec := concurrencySpec{group: "group"}
+		key := concurrencyGroupKey(spec.group)
+
+		releaseFirst, err := manager.acquire(context.Background(), nil, spec, func() {})
+		require.NoError(t, err)
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		waiterDone := make(chan func(), 1)
+		go func() {
+			release, _ := manager.acquire(context.Background(), cancelCtx, spec, func() {})
+			waiterDone <- release
+		}()
+		require.Eventually(t, func() bool {
+			manager.mu.Lock()
+			defer manager.mu.Unlock()
+			group := manager.groups[key]
+			return group != nil && len(group.pending) == 1
+		}, 5*time.Second, time.Millisecond)
+
+		// promote and cancel concurrently so both select branches are live
+		go cancel()
+		releaseFirst()
+
+		if release := <-waiterDone; release != nil {
+			release()
+		}
+
+		// whichever branch won, the group must not stay held
+		acquired := make(chan struct{})
+		go func() {
+			defer close(acquired)
+			release, err := manager.acquire(context.Background(), nil, spec, func() {})
+			if assert.NoError(t, err) && release != nil {
+				release()
+			}
+		}()
+		select {
+		case <-acquired:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: the group stayed held by a waiter that gave up", i)
+		}
+		cancel()
+	}
+}
+
+func TestConcurrencyManagerRemovesPendingFromMiddleOfQueue(t *testing.T) {
+	manager := newConcurrencyManager()
+	spec := concurrencySpec{group: "group", queueMax: true}
+	key := concurrencyGroupKey(spec.group)
+
+	releaseFirst, err := manager.acquire(context.Background(), nil, spec, func() {})
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	order := []int{}
+	done := make(chan struct{}, 3)
+	cancels := make([]context.CancelFunc, 3)
+	for i := 0; i < 3; i++ {
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		cancels[i] = cancel
+		id := i + 1
+		go func() {
+			release, err := manager.acquire(context.Background(), cancelCtx, spec, func() {})
+			if err == nil {
+				mu.Lock()
+				order = append(order, id)
+				mu.Unlock()
+				release()
+			}
+			done <- struct{}{}
+		}()
+		want := i + 1
+		require.Eventually(t, func() bool {
+			manager.mu.Lock()
+			defer manager.mu.Unlock()
+			return len(manager.groups[key].pending) == want
+		}, 5*time.Second, time.Millisecond)
+	}
+
+	// cancel the middle waiter, which is spliced out from between its
+	// neighbours
+	cancels[1]()
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return len(manager.groups[key].pending) == 2
+	}, 5*time.Second, time.Millisecond)
+
+	releaseFirst()
+	for i := 0; i < 3; i++ {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("removing a waiter from the middle must not strand its neighbours")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []int{1, 3}, order, "the neighbours of a cancelled waiter keep their order")
+}
+
+func TestConcurrencyManagerSingleGroupStaysSingle(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	singleSpec := concurrencySpec{group: "group"}
+	maxSpec := concurrencySpec{group: "group", queueMax: true}
+	key := concurrencyGroupKey(singleSpec.group)
+
+	// the group is created by a request using the default queue: single
+	release, err := manager.acquire(ctx, nil, singleSpec, func() {})
+	require.NoError(t, err)
+	defer release()
+
+	superseded := make(chan error, 2)
+	go func() {
+		_, err := manager.acquire(ctx, nil, singleSpec, func() {})
+		superseded <- err
+	}()
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return len(manager.groups[key].pending) == 1
+	}, 5*time.Second, time.Millisecond)
+
+	// a later request asking for `queue: max` must not bypass the supersede
+	// the single-queue group guarantees, otherwise a stale run would still
+	// execute alongside the newest one
+	go func() {
+		r, err := manager.acquire(ctx, nil, maxSpec, func() {})
+		if r != nil {
+			r()
+		}
+		superseded <- err
+	}()
+
+	select {
+	case err := <-superseded:
+		assert.ErrorIs(t, err, errSupersededByConcurrencyGroup, "the stale pending run must be superseded")
+	case <-time.After(5 * time.Second):
+		t.Fatal("a 'queue: max' arrival must still supersede the pending run of a single-queue group")
+	}
+
+	manager.mu.Lock()
+	assert.Equal(t, 1, len(manager.groups[key].pending), "a single-queue group keeps at most one pending request")
+	manager.mu.Unlock()
+}
+
+func TestEvaluateConcurrencyQueueValidation(t *testing.T) {
+	ctx := context.Background()
+
+	spec, ok, err := evaluateConcurrency(ctx, testEvaluator{}, &model.Concurrency{Group: "g", Queue: "max"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.True(t, spec.queueMax)
+
+	spec, ok, err = evaluateConcurrency(ctx, testEvaluator{}, &model.Concurrency{Group: "g", Queue: "single"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.False(t, spec.queueMax)
+
+	// GitHub rejects this combination with a workflow validation error
+	_, _, err = evaluateConcurrency(ctx, testEvaluator{}, &model.Concurrency{Group: "g", Queue: "max", CancelInProgress: "true"})
+	assert.ErrorContains(t, err, "'queue: max' and 'cancel-in-progress: true' is not allowed")
+
+	_, _, err = evaluateConcurrency(ctx, testEvaluator{}, &model.Concurrency{Group: "g", Queue: "bogus"})
+	assert.ErrorContains(t, err, "invalid value 'bogus' for 'concurrency.queue'")
+
+	// queue: max with cancel-in-progress explicitly false is allowed
+	_, _, err = evaluateConcurrency(ctx, testEvaluator{}, &model.Concurrency{Group: "g", Queue: "max", CancelInProgress: "false"})
+	assert.NoError(t, err)
+}
+
+// testEvaluator interpolates the expressions in `values`, mimicking the real
+// evaluator which yields an empty string for expressions it cannot resolve
+type testEvaluator struct {
+	values map[string]string
+}
+
+func (testEvaluator) evaluate(context.Context, string, exprparser.DefaultStatusCheck) (interface{}, error) {
+	return nil, nil
+}
+func (testEvaluator) EvaluateYamlNode(context.Context, *yaml.Node) error { return nil }
+func (e testEvaluator) Interpolate(_ context.Context, s string) string {
+	if !strings.Contains(s, "${{") {
+		return s
+	}
+	return e.values[s]
+}
+
+func TestEvaluateConcurrencyExpressionValues(t *testing.T) {
+	ctx := context.Background()
+	const queueExpr = "${{ vars.QUEUE_MODE }}"
+
+	ee := testEvaluator{values: map[string]string{queueExpr: "max"}}
+	spec, ok, err := evaluateConcurrency(ctx, ee, &model.Concurrency{Group: "g", Queue: queueExpr})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.True(t, spec.queueMax, "an expression evaluating to 'max' must enable the bounded queue")
+
+	// an expression the evaluator cannot resolve yields "", which is the
+	// documented default rather than an error
+	ee = testEvaluator{values: map[string]string{}}
+	spec, ok, err = evaluateConcurrency(ctx, ee, &model.Concurrency{Group: "g", Queue: queueExpr})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.False(t, spec.queueMax, "an unresolved queue expression falls back to the default 'single'")
+
+	// an expression resolving to something else is still rejected
+	ee = testEvaluator{values: map[string]string{queueExpr: "bogus"}}
+	_, _, err = evaluateConcurrency(ctx, ee, &model.Concurrency{Group: "g", Queue: queueExpr})
+	assert.ErrorContains(t, err, "invalid value 'bogus' for 'concurrency.queue'")
+
+	// the invalid combination is rejected even when it only becomes visible
+	// after evaluation
+	ee = testEvaluator{values: map[string]string{queueExpr: "max", "${{ true }}": "true"}}
+	_, _, err = evaluateConcurrency(ctx, ee, &model.Concurrency{Group: "g", Queue: queueExpr, CancelInProgress: "${{ true }}"})
+	assert.ErrorContains(t, err, "'queue: max' and 'cancel-in-progress: true' is not allowed")
+}
+
+func TestEvaluateConcurrencyValidatesEmptyGroup(t *testing.T) {
+	ctx := context.Background()
+	ee := testEvaluator{values: map[string]string{"${{ inputs.env }}": ""}}
+
+	// an invalid concurrency block is rejected even when its group
+	// interpolates to an empty string, which GitHub refuses to run
+	_, _, err := evaluateConcurrency(ctx, ee, &model.Concurrency{
+		Group:            "${{ inputs.env }}",
+		Queue:            "max",
+		CancelInProgress: "true",
+	})
+	assert.ErrorContains(t, err, "'queue: max' and 'cancel-in-progress: true' is not allowed")
+
+	_, _, err = evaluateConcurrency(ctx, ee, &model.Concurrency{Group: "${{ inputs.env }}", Queue: "bogus"})
+	assert.ErrorContains(t, err, "invalid value 'bogus' for 'concurrency.queue'")
+
+	// a valid block with an empty group is still just ignored
+	_, ok, err := evaluateConcurrency(ctx, ee, &model.Concurrency{Group: "${{ inputs.env }}", Queue: "max"})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestConcurrencyManagerGroupPolicyWins(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	maxSpec := concurrencySpec{group: "group", queueMax: true}
+	singleSpec := concurrencySpec{group: "group"}
+	key := concurrencyGroupKey(maxSpec.group)
+
+	release, err := manager.acquire(ctx, nil, maxSpec, func() {})
+	require.NoError(t, err)
+	defer release()
+
+	// three runs queue under the group's `queue: max` policy
+	results := make(chan error, 3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			r, err := manager.acquire(ctx, nil, maxSpec, func() {})
+			if r != nil {
+				r()
+			}
+			results <- err
+		}()
+		want := i + 1
+		require.Eventually(t, func() bool {
+			manager.mu.Lock()
+			defer manager.mu.Unlock()
+			return len(manager.groups[key].pending) == want
+		}, 5*time.Second, time.Millisecond)
+	}
+
+	// a request that omits `queue: max` must not discard the queue the group
+	// admitted under it
+	go func() {
+		r, err := manager.acquire(ctx, nil, singleSpec, func() {})
+		if r != nil {
+			r()
+		}
+		results <- err
+	}()
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return len(manager.groups[key].pending) == 4
+	}, 5*time.Second, time.Millisecond)
+
+	select {
+	case err := <-results:
+		t.Fatalf("no queued run may be cancelled by an arrival that omits 'queue: max', got %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -142,14 +615,15 @@ func TestConcurrencyManagerCancelCtxAbortsWaiting(t *testing.T) {
 	require.Eventually(t, func() bool {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
-		return manager.groups["group"].pending != nil
+		g := manager.groups["group"]
+		return g != nil && len(g.pending) > 0
 	}, 5*time.Second, 10*time.Millisecond)
 
 	cancel()
 
 	select {
 	case err := <-waited:
-		assert.ErrorIs(t, err, errCancelledByConcurrencyGroup)
+		assert.ErrorIs(t, err, errConcurrencyWaitCancelled)
 	case <-time.After(5 * time.Second):
 		t.Fatal("a cancelled waiter must stop waiting for the group")
 	}
@@ -158,8 +632,77 @@ func TestConcurrencyManagerCancelCtxAbortsWaiting(t *testing.T) {
 	require.Eventually(t, func() bool {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
-		return manager.groups["group"].pending == nil
+		g := manager.groups["group"]
+		return g == nil || len(g.pending) == 0
 	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestConcurrencyManagerAbandonedHolderReleasesGroup(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	spec := concurrencySpec{group: "group"}
+
+	releaseFirst, err := manager.acquire(ctx, nil, spec, func() {})
+	require.NoError(t, err)
+
+	// a waiter can be promoted at the very moment it gives up waiting; its
+	// select may then take the cancelled branch even though it now holds the
+	// group. Reproduce that ordering deterministically: queue a waiter,
+	// promote it by releasing, then abandon it.
+	key := concurrencyGroupKey(spec.group)
+	waiter := &concurrencyWaiter{promoted: make(chan struct{}), superseded: make(chan struct{})}
+	manager.mu.Lock()
+	manager.groups[key].pending = append(manager.groups[key].pending, waiter)
+	manager.mu.Unlock()
+
+	releaseFirst()
+
+	manager.mu.Lock()
+	require.Equal(t, waiter, manager.groups[key].holder, "the queued waiter must have been promoted")
+	manager.mu.Unlock()
+
+	manager.abandon(key, waiter)
+
+	// the group must not stay held by the request that gave up
+	acquired := make(chan struct{})
+	go func() {
+		defer close(acquired)
+		release, err := manager.acquire(ctx, nil, spec, func() {})
+		assert.NoError(t, err)
+		release()
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a promoted waiter that gave up must release the group instead of holding it forever")
+	}
+}
+
+func TestConcurrencyManagerAbandonedHolderPromotesNextWaiter(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	spec := concurrencySpec{group: "group", queueMax: true}
+
+	releaseFirst, err := manager.acquire(ctx, nil, spec, func() {})
+	require.NoError(t, err)
+
+	key := concurrencyGroupKey(spec.group)
+	abandoned := &concurrencyWaiter{promoted: make(chan struct{}), superseded: make(chan struct{})}
+	next := &concurrencyWaiter{promoted: make(chan struct{}), superseded: make(chan struct{})}
+	manager.mu.Lock()
+	manager.groups[key].pending = append(manager.groups[key].pending, abandoned, next)
+	manager.mu.Unlock()
+
+	releaseFirst()
+	manager.abandon(key, abandoned)
+
+	// the queue keeps moving: the request behind the abandoned one is promoted
+	select {
+	case <-next.promoted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the next queued request must be promoted when a promoted waiter gives up")
+	}
 }
 
 func TestConcurrencyManagerContextCancelledWhileWaiting(t *testing.T) {
@@ -338,6 +881,86 @@ func TestRunConcurrencySupersedesPending(t *testing.T) {
 			assertIntervalsDisjoint(t, ran[i], ran[j])
 		}
 	}
+}
+
+func TestRunConcurrencyQueueMaxRunsEveryQueuedRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	logs := captureRunnerLogs(t)
+	markerDir := filepath.ToSlash(t.TempDir())
+	plan := runConcurrencyWorkflow(t, concurrencyTestWorkflow("concurrency-queue-max"), markerDir)
+
+	// with `queue: max` no run is superseded, all of them queue up and run
+	// one after another. The third workflow spells the group in upper case,
+	// which GitHub treats as the same group.
+	ran := make([]jobInterval, 0, 3)
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			assert.Equal(t, "success", run.Job().Result, "job %s should have succeeded", run.String())
+			ran = append(ran, markerInterval(t, markerDir, run.Workflow.Name))
+		}
+	}
+	require.Len(t, ran, 3, "every queued run must execute with queue: max")
+
+	for i := 0; i < len(ran); i++ {
+		for j := i + 1; j < len(ran); j++ {
+			assertIntervalsDisjoint(t, ran[i], ran[j])
+		}
+	}
+
+	// the group must actually have been contended, otherwise three runs that
+	// happened to arrive one after another would satisfy the assertions
+	// above even if `queue: max` were ignored entirely. The runner logs when
+	// a run queues, which proves contention without depending on timing.
+	assert.Contains(t, logs.String(), "Waiting for concurrency group",
+		"the runs must have queued on the group rather than arriving one after another")
+}
+
+// threadSafeBuffer collects log output written from the goroutines of
+// concurrently executing workflow runs
+type threadSafeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *threadSafeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *threadSafeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// captureRunnerLogs redirects the standard logger, which the plan executor
+// uses for concurrency group messages, into a buffer for the test
+func captureRunnerLogs(t *testing.T) *threadSafeBuffer {
+	t.Helper()
+	buf := &threadSafeBuffer{}
+	original := log.StandardLogger().Out
+	log.SetOutput(io.MultiWriter(original, buf))
+	t.Cleanup(func() { log.SetOutput(original) })
+	return buf
+}
+
+func TestRunConcurrencyQueueMaxWithCancelInProgressIsRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	log.SetLevel(logLevel)
+	absWorkdir, err := filepath.Abs(workdir)
+	require.NoError(t, err)
+
+	// GitHub rejects this workflow before anything runs, so act must fail
+	// while reading it rather than after earlier jobs produced side effects
+	_, err = model.NewWorkflowPlanner(filepath.Join(absWorkdir, "concurrency-queue-invalid"), true, false)
+	assert.ErrorContains(t, err, "'queue: max' and 'cancel-in-progress: true' is not allowed")
 }
 
 func TestRunConcurrencyReusableWorkflowSharedGroup(t *testing.T) {

--- a/pkg/runner/concurrency_test.go
+++ b/pkg/runner/concurrency_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"testing"
 	"time"
 
@@ -16,88 +15,84 @@ import (
 	"github.com/nektos/act/pkg/model"
 )
 
-func TestConcurrencyManagerSerializesDifferentOwners(t *testing.T) {
+func TestConcurrencyManagerSerializes(t *testing.T) {
 	manager := newConcurrencyManager()
 	ctx := context.Background()
+	spec := concurrencySpec{group: "group"}
 
-	var mu sync.Mutex
-	active := 0
-	maxActive := 0
-
-	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			release, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group", owner: manager.newOwner("job")})
-			assert.NoError(t, err)
-			defer release()
-
-			mu.Lock()
-			active++
-			if active > maxActive {
-				maxActive = active
-			}
-			mu.Unlock()
-
-			time.Sleep(10 * time.Millisecond)
-
-			mu.Lock()
-			active--
-			mu.Unlock()
-		}()
-	}
-	wg.Wait()
-
-	assert.Equal(t, 1, maxActive, "only one job of a concurrency group may run at a time")
-}
-
-func TestConcurrencyManagerSharedOwnerDoesNotBlock(t *testing.T) {
-	manager := newConcurrencyManager()
-	ctx := context.Background()
-	spec := concurrencySpec{group: "group", owner: "workflow-1"}
-
-	releaseFirst, err := manager.acquire(ctx, func() {}, spec)
+	releaseFirst, err := manager.acquire(ctx, nil, spec, func() {})
 	require.NoError(t, err)
-	defer releaseFirst()
 
-	// jobs of the same workflow run share the workflow level group and must
-	// not wait for each other
-	done := make(chan struct{})
+	acquired := make(chan struct{})
 	go func() {
-		defer close(done)
-		releaseSecond, err := manager.acquire(ctx, func() {}, spec)
+		defer close(acquired)
+		releaseSecond, err := manager.acquire(ctx, nil, spec, func() {})
 		assert.NoError(t, err)
 		releaseSecond()
 	}()
 
 	select {
-	case <-done:
+	case <-acquired:
+		t.Fatal("the second request must wait until the group is released")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseFirst()
+
+	select {
+	case <-acquired:
 	case <-time.After(5 * time.Second):
-		t.Fatal("job sharing the owner of the group holder should not wait")
+		t.Fatal("the pending request must be promoted when the group is released")
 	}
 }
 
-func TestConcurrencyManagerDifferentGroupsDoNotBlock(t *testing.T) {
+func TestConcurrencyManagerSupersedesPending(t *testing.T) {
 	manager := newConcurrencyManager()
 	ctx := context.Background()
+	spec := concurrencySpec{group: "group"}
 
-	releaseFirst, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group-1", owner: "job-1"})
+	releaseFirst, err := manager.acquire(ctx, nil, spec, func() {})
 	require.NoError(t, err)
-	defer releaseFirst()
 
-	done := make(chan struct{})
+	superseded := make(chan error, 1)
 	go func() {
-		defer close(done)
-		releaseSecond, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group-2", owner: "job-2"})
-		assert.NoError(t, err)
-		releaseSecond()
+		_, err := manager.acquire(ctx, nil, spec, func() {})
+		superseded <- err
 	}()
 
+	// make sure the second request is pending before the third arrives
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.groups["group"].pending != nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	third := make(chan error, 1)
+	releases := make(chan func(), 1)
+	go func() {
+		release, err := manager.acquire(ctx, nil, spec, func() {})
+		if release != nil {
+			releases <- release
+		}
+		third <- err
+	}()
+
+	// the second (previously pending) request is cancelled by the third
 	select {
-	case <-done:
+	case err := <-superseded:
+		assert.ErrorIs(t, err, errCancelledByConcurrencyGroup)
 	case <-time.After(5 * time.Second):
-		t.Fatal("jobs in different concurrency groups should not wait for each other")
+		t.Fatal("the pending request must be superseded by a newer request")
+	}
+
+	releaseFirst()
+
+	select {
+	case err := <-third:
+		assert.NoError(t, err, "the newest request must acquire the group")
+		(<-releases)()
+	case <-time.After(5 * time.Second):
+		t.Fatal("the newest request must acquire the group after the release")
 	}
 }
 
@@ -105,74 +100,80 @@ func TestConcurrencyManagerCancelInProgress(t *testing.T) {
 	manager := newConcurrencyManager()
 	ctx := context.Background()
 
-	firstOwner := manager.newOwner("workflow")
 	cancelled := make(chan struct{})
-	releaseFirst, err := manager.acquire(ctx, func() { close(cancelled) }, concurrencySpec{group: "group", owner: firstOwner})
+	releaseFirst, err := manager.acquire(ctx, nil, concurrencySpec{group: "group"}, func() { close(cancelled) })
 	require.NoError(t, err)
 
-	// the cancelled job releases the group once it stopped running
+	// the cancelled holder releases the group once it stopped running
 	go func() {
 		<-cancelled
 		releaseFirst()
 	}()
 
-	release, err := manager.acquire(ctx, func() {}, concurrencySpec{group: "group", owner: manager.newOwner("workflow"), cancelInProgress: true})
+	release, err := manager.acquire(ctx, nil, concurrencySpec{group: "group", cancelInProgress: true}, func() {})
 	assert.NoError(t, err)
 	release()
 
 	select {
 	case <-cancelled:
 	default:
-		t.Fatal("the job holding the group should have been cancelled")
+		t.Fatal("the holder must have been cancelled by cancel-in-progress")
+	}
+}
+
+func TestConcurrencyManagerCancelCtxAbortsWaiting(t *testing.T) {
+	manager := newConcurrencyManager()
+	ctx := context.Background()
+	spec := concurrencySpec{group: "group"}
+
+	release, err := manager.acquire(ctx, nil, spec, func() {})
+	require.NoError(t, err)
+	defer release()
+
+	// the waiting request is cancelled itself (e.g. by cancel-in-progress
+	// of the job while it waits) and must stop waiting
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	waited := make(chan error, 1)
+	go func() {
+		_, err := manager.acquire(ctx, cancelCtx, spec, func() {})
+		waited <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.groups["group"].pending != nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	select {
+	case err := <-waited:
+		assert.ErrorIs(t, err, errCancelledByConcurrencyGroup)
+	case <-time.After(5 * time.Second):
+		t.Fatal("a cancelled waiter must stop waiting for the group")
 	}
 
-	// remaining jobs of the cancelled owner are cancelled instead of run
-	_, err = manager.acquire(ctx, func() {}, concurrencySpec{group: "another-group", owner: firstOwner})
-	assert.ErrorIs(t, err, errCancelledByConcurrencyGroup)
+	// the aborted waiter is no longer pending
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return manager.groups["group"].pending == nil
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestConcurrencyManagerContextCancelledWhileWaiting(t *testing.T) {
 	manager := newConcurrencyManager()
+	spec := concurrencySpec{group: "group"}
 
-	release, err := manager.acquire(context.Background(), func() {}, concurrencySpec{group: "group", owner: "job-1"})
+	release, err := manager.acquire(context.Background(), nil, spec, func() {})
 	require.NoError(t, err)
 	defer release()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	_, err = manager.acquire(ctx, func() {}, concurrencySpec{group: "group", owner: "job-2"})
+	_, err = manager.acquire(ctx, nil, spec, func() {})
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-}
-
-func TestConcurrencyManagerReleasesAcquiredGroupsOnError(t *testing.T) {
-	manager := newConcurrencyManager()
-
-	release, err := manager.acquire(context.Background(), func() {}, concurrencySpec{group: "group-2", owner: "job-1"})
-	require.NoError(t, err)
-	defer release()
-
-	// requesting group-1 and group-2 acquires group-1 first, then fails on
-	// the held group-2 and must release group-1 again
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	_, err = manager.acquire(ctx, func() {},
-		concurrencySpec{group: "group-1", owner: "job-2"},
-		concurrencySpec{group: "group-2", owner: "job-2"})
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		releaseAgain, err := manager.acquire(context.Background(), func() {}, concurrencySpec{group: "group-1", owner: "job-3"})
-		assert.NoError(t, err)
-		releaseAgain()
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("group-1 should have been released after the failed acquisition")
-	}
 }
 
 func runConcurrencyWorkflow(t *testing.T, workflowPath string, markerDir string) *model.Plan {
@@ -261,8 +262,9 @@ func TestRunConcurrencyGroupSerializesWorkflows(t *testing.T) {
 	markerDir := filepath.ToSlash(t.TempDir())
 	plan := runConcurrencyWorkflow(t, concurrencyTestWorkflow("concurrency-workflow-group"), markerDir)
 
-	// jobs of the same workflow run share the workflow level group and may
-	// run in parallel, but jobs of different workflow runs must not overlap
+	// jobs of the same workflow run may run in parallel (the run holds the
+	// group, not the individual jobs), but jobs of different workflow runs
+	// sharing the group must not overlap
 	for _, w1 := range []string{"w1-a", "w1-b"} {
 		for _, w2 := range []string{"w2-a", "w2-b"} {
 			assertIntervalsDisjoint(t, markerInterval(t, markerDir, w1), markerInterval(t, markerDir, w2))
@@ -299,4 +301,67 @@ func TestRunConcurrencyCancelInProgress(t *testing.T) {
 		}
 	}
 	assert.GreaterOrEqual(t, successes, 1, "at least one job must have succeeded: %v", results)
+}
+
+func TestRunConcurrencySupersedesPending(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	markerDir := filepath.ToSlash(t.TempDir())
+	plan := runConcurrencyWorkflow(t, concurrencyTestWorkflow("concurrency-supersede"), markerDir)
+
+	ran := make([]jobInterval, 0, 3)
+	cancelled := 0
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			result := run.Job().Result
+			assert.Contains(t, []string{"success", "cancelled"}, result, "job %s must either succeed or be cancelled", run.String())
+			switch result {
+			case "success":
+				ran = append(ran, markerInterval(t, markerDir, run.Workflow.Name))
+			case "cancelled":
+				cancelled++
+				assert.NoFileExists(t, filepath.Join(markerDir, run.Workflow.Name+"-start"), "a superseded run must not have executed")
+			}
+		}
+	}
+
+	// GitHub keeps at most one pending run per group: with three runs
+	// entering the group at once, at most one is superseded (a run may
+	// arrive only after another one already finished, so all three running
+	// is possible, but at least two always run)
+	assert.GreaterOrEqual(t, len(ran), 2, "at least two runs must have executed")
+	assert.LessOrEqual(t, cancelled, 1, "at most one run can be superseded")
+	for i := 0; i < len(ran); i++ {
+		for j := i + 1; j < len(ran); j++ {
+			assertIntervalsDisjoint(t, ran[i], ran[j])
+		}
+	}
+}
+
+func TestRunConcurrencyReusableWorkflowSharedGroup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// the caller holds the group while the called workflow declares the same
+	// group: the called workflow must run instead of deadlocking on its own
+	// caller
+	type result struct{ plan *model.Plan }
+	done := make(chan result, 1)
+	go func() {
+		done <- result{runConcurrencyWorkflow(t, concurrencyTestWorkflow("concurrency-reusable"), "")}
+	}()
+
+	select {
+	case res := <-done:
+		for _, stage := range res.plan.Stages {
+			for _, run := range stage.Runs {
+				assert.Equal(t, "success", run.Job().Result, "job %s should have succeeded", run.String())
+			}
+		}
+	case <-time.After(120 * time.Second):
+		t.Fatal("the run deadlocked: the called workflow waits for the concurrency group its caller holds")
+	}
 }

--- a/pkg/runner/container_mock_test.go
+++ b/pkg/runner/container_mock_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
@@ -13,6 +14,14 @@ type containerMock struct {
 	mock.Mock
 	container.Container
 	container.LinuxContainerEnvironmentExtensions
+}
+
+// matchCmdFile matches a runner file command path regardless of the unique
+// per step directory it is placed in
+func matchCmdFile(name string) interface{} {
+	return mock.MatchedBy(func(path string) bool {
+		return strings.HasPrefix(path, "/var/run/act/workflow/") && strings.HasSuffix(path, "/"+name)
+	})
 }
 
 func (cm *containerMock) Create(capAdd []string, capDrop []string) common.Executor {

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -26,9 +26,11 @@ type ExpressionEvaluator interface {
 	Interpolate(context.Context, string) string
 }
 
-// NewExpressionEvaluator creates a new evaluator
+// NewExpressionEvaluator creates a new evaluator. The evaluator operates on
+// a snapshot of the job env and step results taken at creation time, so it
+// can be used while steps running concurrently in the background mutate them.
 func (rc *RunContext) NewExpressionEvaluator(ctx context.Context) ExpressionEvaluator {
-	return rc.NewExpressionEvaluatorWithEnv(ctx, rc.GetEnv())
+	return rc.NewExpressionEvaluatorWithEnv(ctx, rc.envSnapshot())
 }
 
 func (rc *RunContext) NewExpressionEvaluatorWithEnv(ctx context.Context, env map[string]string) ExpressionEvaluator {
@@ -82,7 +84,7 @@ func (rc *RunContext) NewExpressionEvaluatorWithEnv(ctx context.Context, env map
 		Jobs:   &workflowCallResult,
 		// todo: should be unavailable
 		// but required to interpolate/evaluate the step outputs on the job
-		Steps:     rc.getStepsContext(),
+		Steps:     rc.stepsSnapshot(),
 		Secrets:   getWorkflowSecrets(ctx, rc),
 		Vars:      getWorkflowVars(ctx, rc),
 		Strategy:  strategy,
@@ -144,7 +146,7 @@ func (rc *RunContext) newStepExpressionEvaluator(ctx context.Context, step step,
 		Github:   step.getGithubContext(ctx),
 		Env:      *step.getEnv(),
 		Job:      rc.getJobContext(),
-		Steps:    rc.getStepsContext(),
+		Steps:    rc.stepsSnapshot(),
 		Secrets:  getWorkflowSecrets(ctx, rc),
 		Vars:     getWorkflowVars(ctx, rc),
 		Strategy: strategy,

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -202,18 +202,15 @@ func getHashFilesFunction(ctx context.Context, rc *RunContext) func(v []reflect.
 				env["followSymbolicLinks"] = "true"
 			}
 
-			stdout, stderr := rc.JobContainer.ReplaceLogWriter(hout, herr)
+			// capture the output of the helper on the context, which the
+			// execution environments prefer over their global writer slot
 			_ = rc.JobContainer.Copy(rc.JobContainer.GetActPath(), &container.FileEntry{
 				Name: name,
 				Mode: 0o644,
 				Body: hashfiles,
 			}).
 				Then(rc.execJobContainer([]string{rc.GetNodeToolFullPath(ctx), path.Join(rc.JobContainer.GetActPath(), name)},
-					env, "", "")).
-				Finally(func(context.Context) error {
-					rc.JobContainer.ReplaceLogWriter(stdout, stderr)
-					return nil
-				})(timeed)
+					env, "", ""))(container.WithLogWriters(timeed, hout, herr))
 			output := hout.String() + "\n" + herr.String()
 			guard := "__OUTPUT__"
 			outstart := strings.Index(output, guard)

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -33,11 +33,16 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		return nil
 	})
 
-	infoSteps := info.steps()
+	infoSteps, expandErr := expandParallelStepGroups(info.steps())
+	if expandErr != nil {
+		return common.NewErrorExecutor(expandErr)
+	}
 
 	if len(infoSteps) == 0 {
 		return common.NewDebugExecutor("No steps found")
 	}
+
+	backgroundSteps := newBackgroundStepRegistry()
 
 	preSteps = append(preSteps, func(ctx context.Context) error {
 		// Have to be skipped for some Tests
@@ -73,6 +78,13 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			stepModel.ID = fmt.Sprintf("%d", i)
 		}
 
+		if stepModel.IsBackgroundControl() {
+			// wait, wait-all and cancel steps always run, they are not
+			// skipped when a previous step failed and have no pre/post stage
+			steps = append(steps, newControlStepExecutor(rc, backgroundSteps, stepModel, setJobError))
+			continue
+		}
+
 		step, err := sf.newStep(stepModel, rc)
 
 		if err != nil {
@@ -81,16 +93,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 
 		preSteps = append(preSteps, useStepLogger(rc, stepModel, stepStagePre, step.pre().ThenError(setJobError)))
 
-		stepExec := step.main()
-		steps = append(steps, useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
-			err := stepExec(ctx)
-			if err != nil {
-				_ = setJobError(ctx, err)
-			} else if ctx.Err() != nil {
-				_ = setJobError(ctx, ctx.Err())
-			}
-			return nil
-		}))
+		steps = append(steps, newMainStepExecutor(rc, backgroundSteps, stepModel, step.main(), setJobError))
 
 		postExec := useStepLogger(rc, stepModel, stepStagePost, step.post().ThenError(setJobError))
 		if postExecutor != nil {
@@ -135,6 +138,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 				Then(common.NewFieldExecutor("stepResult", model.StepStatusSuccess, common.NewInfoExecutor("  \u2705  Success - Set up job"))).
 				ThenError(setJobError).OnError(common.NewFieldExecutor("stepResult", model.StepStatusFailure, common.NewInfoExecutor("  \u274C  Failure - Set up job"))))),
 		common.NewPipelineExecutor(pipeline...).
+			Finally(backgroundSteps.cancelRemaining()).
 			Finally(func(ctx context.Context) error { //nolint:contextcheck
 				var cancel context.CancelFunc
 				if ctx.Err() == context.Canceled {
@@ -202,7 +206,7 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 		ctx = withStepLogger(ctx, stepModel.ID, rc.ExprEval.Interpolate(ctx, stepModel.String()), stage.String())
 
 		rawLogger := common.Logger(ctx).WithField("raw_output", true)
-		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+		logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, stepModel.ID), func(s string) bool {
 			if rc.Config.LogOutput {
 				rawLogger.Infof("%s", s)
 			} else {

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
 )
 
@@ -102,6 +103,12 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		} else {
 			postExecutor = postExec
 		}
+	}
+
+	if postExecutor == nil {
+		// a job may consist only of wait/wait-all/cancel steps, which have
+		// no post stage
+		postExecutor = common.NewPipelineExecutor()
 	}
 
 	var stopContainerExecutor common.Executor = func(ctx context.Context) error {
@@ -215,8 +222,10 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 			return true
 		})
 
-		oldout, olderr := rc.JobContainer.ReplaceLogWriter(logWriter, logWriter)
-		defer rc.JobContainer.ReplaceLogWriter(oldout, olderr)
+		// the writers travel with the context instead of being swapped in
+		// the execution environment's single global writer slot, so steps
+		// running concurrently each capture their own output
+		ctx = container.WithLogWriters(ctx, logWriter, logWriter)
 
 		return executor(ctx)
 	}

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -41,6 +41,11 @@ type masksContextKey string
 
 const masksContextKeyVal = masksContextKey("logrus.FieldLogger")
 
+// masksMutex guards the masks slices of all jobs, they are appended to by
+// running steps and read whenever a log line is formatted. With background
+// steps both can happen concurrently.
+var masksMutex sync.RWMutex
+
 // Logger returns the appropriate logger for current context
 func Masks(ctx context.Context) *[]string {
 	val := ctx.Value(masksContextKeyVal)
@@ -153,7 +158,9 @@ func valueMasker(insecureSecrets bool, secrets map[string]string) entryProcessor
 			return entry
 		}
 
-		masks := Masks(entry.Context)
+		masksMutex.RLock()
+		masks := append([]string{}, *Masks(entry.Context)...)
+		masksMutex.RUnlock()
 
 		for _, v := range ssecrets {
 			if v != "" {
@@ -161,7 +168,7 @@ func valueMasker(insecureSecrets bool, secrets map[string]string) entryProcessor
 			}
 		}
 
-		for _, v := range *masks {
+		for _, v := range masks {
 			if v != "" {
 				entry.Message = strings.ReplaceAll(entry.Message, v, "***")
 			}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -583,13 +583,10 @@ func (rc *RunContext) GetNodeToolFullPath(ctx context.Context) string {
 		cenv[path] = cpath
 		hout := &bytes.Buffer{}
 		herr := &bytes.Buffer{}
-		stdout, stderr := rc.JobContainer.ReplaceLogWriter(hout, herr)
+		// capture the output on the context, which the execution
+		// environments prefer over their global writer slot
 		err := rc.execJobContainer([]string{"node", "--no-warnings", "-e", "console.log(process.execPath)"},
-			cenv, "", "").
-			Finally(func(context.Context) error {
-				rc.JobContainer.ReplaceLogWriter(stdout, stderr)
-				return nil
-			})(timeed)
+			cenv, "", "")(container.WithLogWriters(timeed, hout, herr))
 		rawStr := strings.Trim(hout.String(), "\r\n")
 		if err == nil && !strings.ContainsAny(rawStr, "\r\n") {
 			rc.nodeToolFullPath = rawStr

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -55,10 +55,13 @@ type RunContext struct {
 	Cancelled           bool
 	nodeToolFullPath    string
 
-	// owner identities used for the workflow and job level `concurrency`
-	// groups, assigned by the plan executor
-	workflowConcurrencyOwner string
-	jobConcurrencyOwner      string
+	// runState tracks the cancellation of the workflow run this job belongs
+	// to, assigned by the plan executor
+	runState *workflowRunState
+
+	// parentStepID is the id of the action step a composite RunContext was
+	// created for, it is stable while the mutable CurrentStep is not
+	parentStepID string
 
 	// stepStateMu serializes mutations of the shared job state (StepResults,
 	// Env, ExtraPath, ...) between steps running concurrently because of
@@ -68,6 +71,55 @@ type RunContext struct {
 	// currentStepMu guards CurrentStep, which is also read while steps run
 	// concurrently in the background
 	currentStepMu sync.RWMutex
+
+	// stateDataMu guards the shared maps and slices themselves (Env,
+	// StepResults, ExtraPath, IntraActionState): expression evaluators
+	// snapshot them under a read lock while running steps mutate them under
+	// the write lock, so a step executing concurrently in the background
+	// never observes a map mid-write
+	stateDataMu sync.RWMutex
+}
+
+// stateDataLock returns the mutex guarding the shared data structures.
+// Composite action steps share the lock of their root RunContext.
+func (rc *RunContext) stateDataLock() *sync.RWMutex {
+	root := rc
+	for root.Parent != nil {
+		root = root.Parent
+	}
+	return &root.stateDataMu
+}
+
+// envSnapshot returns a copy of the job env for expression evaluation, safe
+// to read while other steps concurrently change the env
+func (rc *RunContext) envSnapshot() map[string]string {
+	lock := rc.stateDataLock()
+	lock.Lock()
+	defer lock.Unlock()
+	env := rc.getEnvLocked()
+	snapshot := make(map[string]string, len(env))
+	for k, v := range env {
+		snapshot[k] = v
+	}
+	return snapshot
+}
+
+// stepsSnapshot returns a copy of the step results for expression
+// evaluation, safe to read while other steps concurrently record results
+func (rc *RunContext) stepsSnapshot() map[string]*model.StepResult {
+	lock := rc.stateDataLock()
+	lock.RLock()
+	defer lock.RUnlock()
+	snapshot := make(map[string]*model.StepResult, len(rc.StepResults))
+	for id, result := range rc.StepResults {
+		copied := *result
+		copied.Outputs = make(map[string]string, len(result.Outputs))
+		for k, v := range result.Outputs {
+			copied.Outputs[k] = v
+		}
+		snapshot[id] = &copied
+	}
+	return snapshot
 }
 
 func (rc *RunContext) setCurrentStep(stepID string) {
@@ -99,6 +151,14 @@ func (rc *RunContext) AddMask(mask string) {
 	rc.Masks = append(rc.Masks, mask)
 }
 
+// masksSnapshot returns a copy of the current masks, the slice is appended
+// to by running steps and must not be read without the mutex
+func (rc *RunContext) masksSnapshot() []string {
+	masksMutex.RLock()
+	defer masksMutex.RUnlock()
+	return append([]string{}, rc.Masks...)
+}
+
 type MappableOutput struct {
 	StepID     string
 	OutputName string
@@ -116,6 +176,13 @@ func (rc *RunContext) String() string {
 
 // GetEnv returns the env for the context
 func (rc *RunContext) GetEnv() map[string]string {
+	lock := rc.stateDataLock()
+	lock.Lock()
+	defer lock.Unlock()
+	return rc.getEnvLocked()
+}
+
+func (rc *RunContext) getEnvLocked() map[string]string {
 	if rc.Env == nil {
 		rc.Env = map[string]string{}
 		if rc.Run != nil && rc.Run.Workflow != nil && rc.Config != nil {
@@ -529,7 +596,15 @@ func (rc *RunContext) GetNodeToolFullPath(ctx context.Context) string {
 }
 
 func (rc *RunContext) ApplyExtraPath(ctx context.Context, env *map[string]string) {
-	if len(rc.ExtraPath) > 0 {
+	lock := rc.stateDataLock()
+	lock.RLock()
+	extraPath := append([]string{}, rc.ExtraPath...)
+	lock.RUnlock()
+	rc.applyExtraPathSnapshot(ctx, extraPath, env)
+}
+
+func (rc *RunContext) applyExtraPathSnapshot(ctx context.Context, extraPath []string, env *map[string]string) {
+	if len(extraPath) > 0 {
 		path := rc.JobContainer.GetPathVariableName()
 		if rc.JobContainer.IsEnvironmentCaseInsensitive() {
 			// On windows system Path and PATH could also be in the map
@@ -553,7 +628,7 @@ func (rc *RunContext) ApplyExtraPath(ctx context.Context, env *map[string]string
 			}
 			(*env)[path] = cpath
 		}
-		(*env)[path] = rc.JobContainer.JoinPathVariable(append(rc.ExtraPath, (*env)[path])...)
+		(*env)[path] = rc.JobContainer.JoinPathVariable(append(extraPath, (*env)[path])...)
 	}
 }
 
@@ -902,6 +977,9 @@ func trimToLen(s string, l int) string {
 }
 
 func (rc *RunContext) getJobContext() *model.JobContext {
+	lock := rc.stateDataLock()
+	lock.RLock()
+	defer lock.RUnlock()
 	jobStatus := "success"
 	if rc.Cancelled {
 		jobStatus = "cancelled"
@@ -924,6 +1002,11 @@ func (rc *RunContext) getStepsContext() map[string]*model.StepResult {
 
 func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext {
 	logger := common.Logger(ctx)
+	lock := rc.stateDataLock()
+	lock.RLock()
+	actionRepository := rc.Env["GITHUB_ACTION_REPOSITORY"]
+	actionRef := rc.Env["GITHUB_ACTION_REF"]
+	lock.RUnlock()
 	ghc := &model.GithubContext{
 		Event:            make(map[string]interface{}),
 		Workflow:         rc.Run.Workflow.Name,
@@ -936,8 +1019,8 @@ func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext
 		Token:            rc.Config.Token,
 		Job:              rc.Run.JobID,
 		ActionPath:       rc.ActionPath,
-		ActionRepository: rc.Env["GITHUB_ACTION_REPOSITORY"],
-		ActionRef:        rc.Env["GITHUB_ACTION_REF"],
+		ActionRepository: actionRepository,
+		ActionRef:        actionRef,
 		RepositoryOwner:  rc.Config.Env["GITHUB_REPOSITORY_OWNER"],
 		RetentionDays:    rc.Config.Env["GITHUB_RETENTION_DAYS"],
 		RunnerPerflog:    rc.Config.Env["RUNNER_PERFLOG"],

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -59,6 +59,11 @@ type RunContext struct {
 	// to, assigned by the plan executor
 	runState *workflowRunState
 
+	// jobSlots limits how many jobs execute at the same time across all
+	// workflow runs (--concurrent-jobs). A slot is only held while the job
+	// actually runs, never while it waits for a concurrency group.
+	jobSlots chan struct{}
+
 	// parentStepID is the id of the action step a composite RunContext was
 	// created for, it is stable while the mutable CurrentStep is not
 	parentStepID string

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -53,6 +53,11 @@ type RunContext struct {
 	caller              *caller // job calling this RunContext (reusable workflows)
 	Cancelled           bool
 	nodeToolFullPath    string
+
+	// owner identities used for the workflow and job level `concurrency`
+	// groups, assigned by the plan executor
+	workflowConcurrencyOwner string
+	jobConcurrencyOwner      string
 }
 
 func (rc *RunContext) AddMask(mask string) {
@@ -725,7 +730,9 @@ func (rc *RunContext) Executor() (common.Executor, error) {
 			return err
 		}
 		if res {
-			return executor(ctx)
+			// only jobs that actually run take part in concurrency groups,
+			// skipped jobs must not cancel or delay running jobs
+			return rc.withConcurrency(executor)(ctx)
 		}
 		return nil
 	}, nil

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/go-connections/nat"
@@ -53,9 +54,43 @@ type RunContext struct {
 	caller              *caller // job calling this RunContext (reusable workflows)
 	Cancelled           bool
 	nodeToolFullPath    string
+
+	// stepStateMu serializes mutations of the shared job state (StepResults,
+	// Env, ExtraPath, ...) between steps running concurrently because of
+	// `background: true`
+	stepStateMu sync.Mutex
+
+	// currentStepMu guards CurrentStep, which is also read while steps run
+	// concurrently in the background
+	currentStepMu sync.RWMutex
+}
+
+func (rc *RunContext) setCurrentStep(stepID string) {
+	rc.currentStepMu.Lock()
+	defer rc.currentStepMu.Unlock()
+	rc.CurrentStep = stepID
+}
+
+func (rc *RunContext) currentStep() string {
+	rc.currentStepMu.RLock()
+	defer rc.currentStepMu.RUnlock()
+	return rc.CurrentStep
+}
+
+// stepStateLock returns the mutex guarding the shared job state. Composite
+// action steps share the lock of their root RunContext since they mutate
+// state of their parents.
+func (rc *RunContext) stepStateLock() *sync.Mutex {
+	root := rc
+	for root.Parent != nil {
+		root = root.Parent
+	}
+	return &root.stepStateMu
 }
 
 func (rc *RunContext) AddMask(mask string) {
+	masksMutex.Lock()
+	defer masksMutex.Unlock()
 	rc.Masks = append(rc.Masks, mask)
 }
 
@@ -85,7 +120,9 @@ func (rc *RunContext) GetEnv() map[string]string {
 			}
 		}
 	}
-	rc.Env["ACT"] = "true"
+	if rc.Env["ACT"] != "true" {
+		rc.Env["ACT"] = "true"
+	}
 	return rc.Env
 }
 
@@ -888,7 +925,7 @@ func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext
 		RunNumber:        rc.Config.Env["GITHUB_RUN_NUMBER"],
 		Actor:            rc.Config.Actor,
 		EventName:        rc.Config.EventName,
-		Action:           rc.CurrentStep,
+		Action:           rc.currentStep(),
 		Token:            rc.Config.Token,
 		Job:              rc.Run.JobID,
 		ActionPath:       rc.ActionPath,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -120,118 +121,219 @@ func (runner *runnerImpl) configure() (Runner, error) {
 	return runner, nil
 }
 
-// NewPlanExecutor ...
+// NewPlanExecutor executes a plan as one independent "workflow run" per
+// workflow: every workflow runs its own stages serially while different
+// workflows run in parallel, so a workflow run can hold its workflow level
+// `concurrency` group from its first to its last job and jobs of other
+// workflows are not stage barriers for each other. The total number of
+// concurrently executing jobs is limited by GetConcurrentJobs.
 func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
-	maxJobNameLen := 0
+	maxJobNameLen := new(int)
 
-	// every workflow in the plan is one workflow run sharing a single owner
-	// identity for its workflow level `concurrency` group, so its own jobs
-	// can run in parallel while jobs of other runs in the same group cannot
-	concurrency := runner.config.concurrency()
-	workflowConcurrencyOwners := make(map[*model.Workflow]string)
-	workflowConcurrencyOwner := func(w *model.Workflow) string {
-		if _, ok := workflowConcurrencyOwners[w]; !ok {
-			workflowConcurrencyOwners[w] = concurrency.newOwner("workflow")
-		}
-		return workflowConcurrencyOwners[w]
-	}
-
-	stagePipeline := make([]common.Executor, 0)
 	log.Debugf("Plan Stages: %v", plan.Stages)
 
+	// the global stage index is the dependency depth; `needs` only references
+	// jobs of the same workflow, so per workflow the non-empty depths in
+	// order preserve the dependency order
+	workflowStages := make(map[*model.Workflow][][]*model.Run)
+	lastStageIndex := make(map[*model.Workflow]int)
+	workflows := make([]*model.Workflow, 0)
 	for i := range plan.Stages {
-		stage := plan.Stages[i]
-		stagePipeline = append(stagePipeline, func(ctx context.Context) error {
-			pipeline := make([]common.Executor, 0)
-			for _, run := range stage.Runs {
-				log.Debugf("Stages Runs: %v", stage.Runs)
-				stageExecutor := make([]common.Executor, 0)
-				job := run.Job()
-				log.Debugf("Job.Name: %v", job.Name)
-				log.Debugf("Job.RawNeeds: %v", job.RawNeeds)
-				log.Debugf("Job.RawRunsOn: %v", job.RawRunsOn)
-				log.Debugf("Job.Env: %v", job.Env)
-				log.Debugf("Job.If: %v", job.If)
-				for step := range job.Steps {
-					if nil != job.Steps[step] {
-						log.Debugf("Job.Steps: %v", job.Steps[step].String())
-					}
-				}
-				log.Debugf("Job.TimeoutMinutes: %v", job.TimeoutMinutes)
-				log.Debugf("Job.Services: %v", job.Services)
-				log.Debugf("Job.Strategy: %v", job.Strategy)
-				log.Debugf("Job.RawContainer: %v", job.RawContainer)
-				log.Debugf("Job.Defaults.Run.Shell: %v", job.Defaults.Run.Shell)
-				log.Debugf("Job.Defaults.Run.WorkingDirectory: %v", job.Defaults.Run.WorkingDirectory)
-				log.Debugf("Job.Outputs: %v", job.Outputs)
-				log.Debugf("Job.Uses: %v", job.Uses)
-				log.Debugf("Job.With: %v", job.With)
-				// log.Debugf("Job.RawSecrets: %v", job.RawSecrets)
-				log.Debugf("Job.Result: %v", job.Result)
-
-				if job.Strategy != nil {
-					log.Debugf("Job.Strategy.FailFast: %v", job.Strategy.FailFast)
-					log.Debugf("Job.Strategy.MaxParallel: %v", job.Strategy.MaxParallel)
-					log.Debugf("Job.Strategy.FailFastString: %v", job.Strategy.FailFastString)
-					log.Debugf("Job.Strategy.MaxParallelString: %v", job.Strategy.MaxParallelString)
-					log.Debugf("Job.Strategy.RawMatrix: %v", job.Strategy.RawMatrix)
-
-					strategyRc := runner.newRunContext(ctx, run, nil)
-					if err := strategyRc.NewExpressionEvaluator(ctx).EvaluateYamlNode(ctx, &job.Strategy.RawMatrix); err != nil {
-						log.Errorf("Error while evaluating matrix: %v", err)
-					}
-				}
-
-				var matrixes []map[string]interface{}
-				if m, err := job.GetMatrixes(); err != nil {
-					log.Errorf("Error while get job's matrix: %v", err)
-				} else {
-					log.Debugf("Job Matrices: %v", m)
-					log.Debugf("Runner Matrices: %v", runner.config.Matrix)
-					matrixes = selectMatrixes(m, runner.config.Matrix)
-				}
-				log.Debugf("Final matrix after applying user inclusions '%v'", matrixes)
-
-				maxParallel := 4
-				if job.Strategy != nil {
-					maxParallel = job.Strategy.MaxParallel
-				}
-
-				if len(matrixes) < maxParallel {
-					maxParallel = len(matrixes)
-				}
-
-				for i, matrix := range matrixes {
-					rc := runner.newRunContext(ctx, run, matrix)
-					rc.JobName = rc.Name
-					rc.workflowConcurrencyOwner = workflowConcurrencyOwner(run.Workflow)
-					rc.jobConcurrencyOwner = concurrency.newOwner("job")
-					if len(matrixes) > 1 {
-						rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
-					}
-					if len(rc.String()) > maxJobNameLen {
-						maxJobNameLen = len(rc.String())
-					}
-					stageExecutor = append(stageExecutor, func(ctx context.Context) error {
-						jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
-						executor, err := rc.Executor()
-
-						if err != nil {
-							return err
-						}
-
-						return executor(common.WithJobErrorContainer(WithJobLogger(ctx, rc.Run.JobID, jobName, rc.Config, &rc.Masks, matrix)))
-					})
-				}
-				pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))
+		for _, run := range plan.Stages[i].Runs {
+			workflow := run.Workflow
+			stages, seen := workflowStages[workflow]
+			if !seen {
+				workflows = append(workflows, workflow)
 			}
-
-			log.Debugf("PlanExecutor concurrency: %d", runner.config.GetConcurrentJobs())
-			return common.NewParallelExecutor(runner.config.GetConcurrentJobs(), pipeline...)(ctx)
-		})
+			if !seen || lastStageIndex[workflow] != i {
+				stages = append(stages, []*model.Run{})
+				lastStageIndex[workflow] = i
+			}
+			stages[len(stages)-1] = append(stages[len(stages)-1], run)
+			workflowStages[workflow] = stages
+		}
 	}
 
-	return common.NewPipelineExecutor(stagePipeline...).Then(handleFailure(plan))
+	jobSlots := make(chan struct{}, runner.config.GetConcurrentJobs())
+	log.Debugf("PlanExecutor concurrency: %d", runner.config.GetConcurrentJobs())
+
+	runExecutors := make([]common.Executor, 0, len(workflows))
+	for _, workflow := range workflows {
+		runExecutors = append(runExecutors, runner.newWorkflowRunExecutor(workflow, workflowStages[workflow], jobSlots, maxJobNameLen))
+	}
+
+	return common.NewParallelExecutor(len(runExecutors), runExecutors...).Then(handleFailure(plan))
+}
+
+// newWorkflowRunExecutor runs the stages of one workflow serially. If the
+// workflow declares a `concurrency` group, the whole run holds the group
+// from its first to its last job; a run superseded while pending, or
+// cancelled by another run's cancel-in-progress, finishes with all its jobs
+// marked 'cancelled' without failing the plan.
+func (runner *runnerImpl) newWorkflowRunExecutor(workflow *model.Workflow, stages [][]*model.Run, jobSlots chan struct{}, maxJobNameLen *int) common.Executor {
+	return func(ctx context.Context) error {
+		logger := common.Logger(ctx)
+		runState := newWorkflowRunState()
+		defer runState.complete()
+
+		if spec, ok := runner.workflowConcurrencySpec(ctx, stages); ok {
+			if heldConcurrencyGroups(ctx)[spec.group] {
+				// a calling workflow already holds this group, acquiring it
+				// again would deadlock on our own caller
+				logger.Debugf("Concurrency group '%s' is already held by a calling workflow", spec.group)
+			} else {
+				release, err := runner.config.concurrency().acquire(ctx, nil, spec, runState.cancelRun)
+				if err != nil {
+					if errors.Is(err, errCancelledByConcurrencyGroup) && ctx.Err() == nil {
+						logger.Infof("\U0001F6AB  Workflow run '%s' was superseded in concurrency group '%s' and is cancelled", workflow.Name, spec.group)
+						markRunCancelled(stages)
+						return nil
+					}
+					return err
+				}
+				defer release()
+				ctx = withHeldConcurrencyGroup(ctx, spec.group)
+			}
+		}
+
+		var firstErr error
+		for _, stageRuns := range stages {
+			if err := runner.newStageExecutor(stageRuns, runState, jobSlots, maxJobNameLen)(ctx); err != nil {
+				firstErr = err
+				break
+			}
+		}
+		runState.complete()
+		if runState.cancelled.Load() && ctx.Err() == nil {
+			// a run cancelled by cancel-in-progress of another run does not
+			// fail the plan, its jobs carry the result 'cancelled'
+			return nil
+		}
+		return firstErr
+	}
+}
+
+// workflowConcurrencySpec evaluates the workflow level `concurrency`
+// settings; only the github, inputs and vars contexts are available
+func (runner *runnerImpl) workflowConcurrencySpec(ctx context.Context, stages [][]*model.Run) (concurrencySpec, bool) {
+	var firstRun *model.Run
+	for _, stageRuns := range stages {
+		if len(stageRuns) > 0 {
+			firstRun = stageRuns[0]
+			break
+		}
+	}
+	if firstRun == nil || firstRun.Workflow.Concurrency() == nil {
+		return concurrencySpec{}, false
+	}
+	rc := runner.newRunContext(ctx, firstRun, nil)
+	return evaluateConcurrency(ctx, rc.NewExpressionEvaluator(ctx), firstRun.Workflow.Concurrency())
+}
+
+func markRunCancelled(stages [][]*model.Run) {
+	for _, stageRuns := range stages {
+		for _, run := range stageRuns {
+			run.Job().Result = "cancelled"
+		}
+	}
+}
+
+func (runner *runnerImpl) newStageExecutor(stageRuns []*model.Run, runState *workflowRunState, jobSlots chan struct{}, maxJobNameLen *int) common.Executor {
+	return func(ctx context.Context) error {
+		pipeline := make([]common.Executor, 0)
+		for _, run := range stageRuns {
+			log.Debugf("Stages Runs: %v", stageRuns)
+			stageExecutor := make([]common.Executor, 0)
+			job := run.Job()
+			log.Debugf("Job.Name: %v", job.Name)
+			log.Debugf("Job.RawNeeds: %v", job.RawNeeds)
+			log.Debugf("Job.RawRunsOn: %v", job.RawRunsOn)
+			log.Debugf("Job.Env: %v", job.Env)
+			log.Debugf("Job.If: %v", job.If)
+			for step := range job.Steps {
+				if nil != job.Steps[step] {
+					log.Debugf("Job.Steps: %v", job.Steps[step].String())
+				}
+			}
+			log.Debugf("Job.TimeoutMinutes: %v", job.TimeoutMinutes)
+			log.Debugf("Job.Services: %v", job.Services)
+			log.Debugf("Job.Strategy: %v", job.Strategy)
+			log.Debugf("Job.RawContainer: %v", job.RawContainer)
+			log.Debugf("Job.Defaults.Run.Shell: %v", job.Defaults.Run.Shell)
+			log.Debugf("Job.Defaults.Run.WorkingDirectory: %v", job.Defaults.Run.WorkingDirectory)
+			log.Debugf("Job.Outputs: %v", job.Outputs)
+			log.Debugf("Job.Uses: %v", job.Uses)
+			log.Debugf("Job.With: %v", job.With)
+			// log.Debugf("Job.RawSecrets: %v", job.RawSecrets)
+			log.Debugf("Job.Result: %v", job.Result)
+
+			if job.Strategy != nil {
+				log.Debugf("Job.Strategy.FailFast: %v", job.Strategy.FailFast)
+				log.Debugf("Job.Strategy.MaxParallel: %v", job.Strategy.MaxParallel)
+				log.Debugf("Job.Strategy.FailFastString: %v", job.Strategy.FailFastString)
+				log.Debugf("Job.Strategy.MaxParallelString: %v", job.Strategy.MaxParallelString)
+				log.Debugf("Job.Strategy.RawMatrix: %v", job.Strategy.RawMatrix)
+
+				strategyRc := runner.newRunContext(ctx, run, nil)
+				if err := strategyRc.NewExpressionEvaluator(ctx).EvaluateYamlNode(ctx, &job.Strategy.RawMatrix); err != nil {
+					log.Errorf("Error while evaluating matrix: %v", err)
+				}
+			}
+
+			var matrixes []map[string]interface{}
+			if m, err := job.GetMatrixes(); err != nil {
+				log.Errorf("Error while get job's matrix: %v", err)
+			} else {
+				log.Debugf("Job Matrices: %v", m)
+				log.Debugf("Runner Matrices: %v", runner.config.Matrix)
+				matrixes = selectMatrixes(m, runner.config.Matrix)
+			}
+			log.Debugf("Final matrix after applying user inclusions '%v'", matrixes)
+
+			maxParallel := 4
+			if job.Strategy != nil {
+				maxParallel = job.Strategy.MaxParallel
+			}
+
+			if len(matrixes) < maxParallel {
+				maxParallel = len(matrixes)
+			}
+
+			for i, matrix := range matrixes {
+				rc := runner.newRunContext(ctx, run, matrix)
+				rc.JobName = rc.Name
+				rc.runState = runState
+				if len(matrixes) > 1 {
+					rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
+				}
+				if len(rc.String()) > *maxJobNameLen {
+					*maxJobNameLen = len(rc.String())
+				}
+				stageExecutor = append(stageExecutor, func(ctx context.Context) error {
+					jobName := fmt.Sprintf("%-*s", *maxJobNameLen, rc.String())
+					executor, err := rc.Executor()
+
+					if err != nil {
+						return err
+					}
+
+					// limit the number of concurrently executing jobs
+					// across all workflow runs
+					select {
+					case jobSlots <- struct{}{}:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+					defer func() { <-jobSlots }()
+
+					return executor(common.WithJobErrorContainer(WithJobLogger(ctx, rc.Run.JobID, jobName, rc.Config, &rc.Masks, matrix)))
+				})
+			}
+			pipeline = append(pipeline, common.NewParallelExecutor(maxParallel, stageExecutor...))
+		}
+
+		return common.NewParallelExecutor(len(pipeline), pipeline...)(ctx)
+	}
 }
 
 func handleFailure(plan *model.Plan) common.Executor {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -176,16 +175,20 @@ func (runner *runnerImpl) newWorkflowRunExecutor(workflow *model.Workflow, stage
 		runState := newWorkflowRunState()
 		defer runState.complete()
 
-		if spec, ok := runner.workflowConcurrencySpec(ctx, stages); ok {
-			if heldConcurrencyGroups(ctx)[spec.group] {
+		spec, ok, err := runner.workflowConcurrencySpec(ctx, stages)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if isConcurrencyGroupHeld(ctx, spec.group) {
 				// a calling workflow already holds this group, acquiring it
 				// again would deadlock on our own caller
 				logger.Debugf("Concurrency group '%s' is already held by a calling workflow", spec.group)
 			} else {
 				release, err := runner.config.concurrency().acquire(ctx, nil, spec, runState.cancelRun)
 				if err != nil {
-					if errors.Is(err, errCancelledByConcurrencyGroup) && ctx.Err() == nil {
-						logger.Infof("\U0001F6AB  Workflow run '%s' was superseded in concurrency group '%s' and is cancelled", workflow.Name, spec.group)
+					if isConcurrencyCancellation(err) && ctx.Err() == nil {
+						logger.Infof("\U0001F6AB  Workflow run '%s' was cancelled by concurrency group '%s' before it started", workflow.Name, spec.group)
 						markRunCancelled(stages)
 						return nil
 					}
@@ -215,7 +218,7 @@ func (runner *runnerImpl) newWorkflowRunExecutor(workflow *model.Workflow, stage
 
 // workflowConcurrencySpec evaluates the workflow level `concurrency`
 // settings; only the github, inputs and vars contexts are available
-func (runner *runnerImpl) workflowConcurrencySpec(ctx context.Context, stages [][]*model.Run) (concurrencySpec, bool) {
+func (runner *runnerImpl) workflowConcurrencySpec(ctx context.Context, stages [][]*model.Run) (concurrencySpec, bool, error) {
 	var firstRun *model.Run
 	for _, stageRuns := range stages {
 		if len(stageRuns) > 0 {
@@ -224,7 +227,7 @@ func (runner *runnerImpl) workflowConcurrencySpec(ctx context.Context, stages []
 		}
 	}
 	if firstRun == nil || firstRun.Workflow.Concurrency() == nil {
-		return concurrencySpec{}, false
+		return concurrencySpec{}, false, nil
 	}
 	rc := runner.newRunContext(ctx, firstRun, nil)
 	return evaluateConcurrency(ctx, rc.NewExpressionEvaluator(ctx), firstRun.Workflow.Concurrency())
@@ -303,6 +306,7 @@ func (runner *runnerImpl) newStageExecutor(stageRuns []*model.Run, runState *wor
 				rc := runner.newRunContext(ctx, run, matrix)
 				rc.JobName = rc.Name
 				rc.runState = runState
+				rc.jobSlots = jobSlots
 				if len(matrixes) > 1 {
 					rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
 				}
@@ -317,15 +321,9 @@ func (runner *runnerImpl) newStageExecutor(stageRuns []*model.Run, runState *wor
 						return err
 					}
 
-					// limit the number of concurrently executing jobs
-					// across all workflow runs
-					select {
-					case jobSlots <- struct{}{}:
-					case <-ctx.Done():
-						return ctx.Err()
-					}
-					defer func() { <-jobSlots }()
-
+					// the job slot limiting how many jobs run at once is
+					// taken inside the executor, after the job acquired its
+					// concurrency group, so queued jobs do not occupy slots
 					return executor(common.WithJobErrorContainer(WithJobLogger(ctx, rc.Run.JobID, jobName, rc.Config, &rc.Masks, matrix)))
 				})
 			}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -62,6 +62,8 @@ type Config struct {
 	ContainerNetworkMode               docker_container.NetworkMode // the network mode of job containers (the value of --network)
 	ActionCache                        ActionCache                  // Use a custom ActionCache Implementation
 	ConcurrentJobs                     int                          // Number of max concurrent jobs
+
+	concurrencyManager *concurrencyManager // serializes jobs sharing a `concurrency` group, shared with reusable workflow runners
 }
 
 func (config *Config) GetConcurrentJobs() int {
@@ -121,6 +123,18 @@ func (runner *runnerImpl) configure() (Runner, error) {
 // NewPlanExecutor ...
 func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 	maxJobNameLen := 0
+
+	// every workflow in the plan is one workflow run sharing a single owner
+	// identity for its workflow level `concurrency` group, so its own jobs
+	// can run in parallel while jobs of other runs in the same group cannot
+	concurrency := runner.config.concurrency()
+	workflowConcurrencyOwners := make(map[*model.Workflow]string)
+	workflowConcurrencyOwner := func(w *model.Workflow) string {
+		if _, ok := workflowConcurrencyOwners[w]; !ok {
+			workflowConcurrencyOwners[w] = concurrency.newOwner("workflow")
+		}
+		return workflowConcurrencyOwners[w]
+	}
 
 	stagePipeline := make([]common.Executor, 0)
 	log.Debugf("Plan Stages: %v", plan.Stages)
@@ -190,6 +204,8 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 				for i, matrix := range matrixes {
 					rc := runner.newRunContext(ctx, run, matrix)
 					rc.JobName = rc.Name
+					rc.workflowConcurrencyOwner = workflowConcurrencyOwner(run.Workflow)
+					rc.jobConcurrencyOwner = concurrency.newOwner("job")
 					if len(matrixes) > 1 {
 						rc.Name = fmt.Sprintf("%s-%d", rc.Name, i+1)
 					}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -281,6 +281,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "matrix", "push", "", platforms, secrets},
 		{workdir, "matrix-include-exclude", "push", "", platforms, secrets},
 		{workdir, "matrix-exitcode", "push", "Job 'test' failed", platforms, secrets},
+		{workdir, "background-steps-container", "push", "", platforms, secrets},
 		{workdir, "commands", "push", "", platforms, secrets},
 		{workdir, "workdir", "push", "", platforms, secrets},
 		{workdir, "defaults-run", "push", "", platforms, secrets},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -281,6 +281,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "matrix", "push", "", platforms, secrets},
 		{workdir, "matrix-include-exclude", "push", "", platforms, secrets},
 		{workdir, "matrix-exitcode", "push", "Job 'test' failed", platforms, secrets},
+		{workdir, "concurrency", "push", "", platforms, secrets},
 		{workdir, "commands", "push", "", platforms, secrets},
 		{workdir, "workdir", "push", "", platforms, secrets},
 		{workdir, "defaults-run", "push", "", platforms, secrets},

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nektos/act/pkg/common"
@@ -91,14 +92,25 @@ func processRunnerEnvFileCommand(ctx context.Context, fileName string, rc *RunCo
 	return nil
 }
 
+// stepFileCommandSeq makes the runner file command paths unique per step
+// execution, so steps running concurrently because of `background: true` do
+// not read each other's commands
+var stepFileCommandSeq atomic.Int64
+
 func runStepExecutor(step step, stage stepStage, executor common.Executor) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
 		rc := step.getRunContext()
 		stepModel := step.getStepModel()
 
+		// the shared job state is locked during the setup and the result
+		// processing of the step, but not while the step itself runs, so
+		// background steps run concurrently with other steps
+		lock := rc.stepStateLock()
+		lock.Lock()
+
 		ifExpression := step.getIfExpression(ctx, stage)
-		rc.CurrentStep = stepModel.ID
+		rc.setCurrentStep(stepModel.ID)
 
 		stepResult := &model.StepResult{
 			Outcome:    model.StepStatusSuccess,
@@ -106,11 +118,12 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			Outputs:    make(map[string]string),
 		}
 		if stage == stepStageMain {
-			rc.StepResults[rc.CurrentStep] = stepResult
+			rc.StepResults[stepModel.ID] = stepResult
 		}
 
 		err := setupEnv(ctx, step)
 		if err != nil {
+			lock.Unlock()
 			return err
 		}
 
@@ -121,6 +134,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		if err != nil {
 			stepResult.Conclusion = model.StepStatusFailure
 			stepResult.Outcome = model.StepStatusFailure
+			lock.Unlock()
 			return err
 		}
 
@@ -128,6 +142,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			stepResult.Conclusion = model.StepStatusSkipped
 			stepResult.Outcome = model.StepStatusSkipped
 			logger.WithField("stepResult", stepResult.Outcome).Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
+			lock.Unlock()
 			return nil
 		}
 
@@ -139,20 +154,21 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 
 		// Prepare and clean Runner File Commands
 		actPath := rc.JobContainer.GetActPath()
+		cmdDir := path.Join("workflow", fmt.Sprintf("cmds-%d-%s", stepFileCommandSeq.Add(1), stage.String()))
 
-		outputFileCommand := path.Join("workflow", "outputcmd.txt")
+		outputFileCommand := path.Join(cmdDir, "outputcmd.txt")
 		(*step.getEnv())["GITHUB_OUTPUT"] = path.Join(actPath, outputFileCommand)
 
-		stateFileCommand := path.Join("workflow", "statecmd.txt")
+		stateFileCommand := path.Join(cmdDir, "statecmd.txt")
 		(*step.getEnv())["GITHUB_STATE"] = path.Join(actPath, stateFileCommand)
 
-		pathFileCommand := path.Join("workflow", "pathcmd.txt")
+		pathFileCommand := path.Join(cmdDir, "pathcmd.txt")
 		(*step.getEnv())["GITHUB_PATH"] = path.Join(actPath, pathFileCommand)
 
-		envFileCommand := path.Join("workflow", "envs.txt")
+		envFileCommand := path.Join(cmdDir, "envs.txt")
 		(*step.getEnv())["GITHUB_ENV"] = path.Join(actPath, envFileCommand)
 
-		summaryFileCommand := path.Join("workflow", "SUMMARY.md")
+		summaryFileCommand := path.Join(cmdDir, "SUMMARY.md")
 		(*step.getEnv())["GITHUB_STEP_SUMMARY"] = path.Join(actPath, summaryFileCommand)
 
 		_ = rc.JobContainer.Copy(actPath, &container.FileEntry{
@@ -172,15 +188,22 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			Mode: 0o666,
 		})(ctx)
 
+		timeout := rc.ExprEval.Interpolate(ctx, stepModel.TimeoutMinutes)
+		lock.Unlock()
+
 		stepCtx, cancelStepCtx := context.WithCancel(ctx)
 		defer cancelStepCtx()
 		var cancelTimeOut context.CancelFunc
-		stepCtx, cancelTimeOut = evaluateStepTimeout(stepCtx, rc.ExprEval, stepModel)
+		stepCtx, cancelTimeOut = evaluateStepTimeout(stepCtx, timeout)
 		defer cancelTimeOut()
 		monitorJobCancellation(ctx, stepCtx, cctx, rc, logger, ifExpression, step, stage, cancelStepCtx)
 		startTime := time.Now()
 		err = executor(stepCtx)
 		executionTime := time.Since(startTime)
+
+		lock.Lock()
+		defer lock.Unlock()
+		rc.setCurrentStep(stepModel.ID)
 
 		if err == nil {
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u2705  Success - %s %s [%s]", stage, stepString, executionTime)
@@ -204,10 +227,15 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u274C  Failure - %s %s [%s]", stage, stepString, executionTime)
 		}
 		// Process Runner File Commands
+		stepID := stepModel.ID
 		ferrors := []error{err}
 		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, envFileCommand, rc, rc.setEnv))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, rc.saveState))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, rc.setOutput))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
+		}))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
+		}))
 		ferrors = append(ferrors, processRunnerSummaryCommand(ctx, summaryFileCommand, rc))
 		ferrors = append(ferrors, rc.UpdateExtraPath(ctx, path.Join(actPath, pathFileCommand)))
 		return errors.Join(ferrors...)
@@ -219,9 +247,12 @@ func monitorJobCancellation(ctx context.Context, stepCtx context.Context, jobCan
 		go func() {
 			select {
 			case <-jobCancellationCtx.Done():
+				lock := rc.stepStateLock()
+				lock.Lock()
 				rc.Cancelled = true
 				logger.Infof("Reevaluate condition %v due to cancellation", ifExpression)
 				keepStepRunning, err := isStepEnabled(ctx, ifExpression, step, stage)
+				lock.Unlock()
 				logger.Infof("Result condition keepStepRunning=%v", keepStepRunning)
 				if !keepStepRunning || err != nil {
 					cancelStepCtx()
@@ -232,8 +263,7 @@ func monitorJobCancellation(ctx context.Context, stepCtx context.Context, jobCan
 	}
 }
 
-func evaluateStepTimeout(ctx context.Context, exprEval ExpressionEvaluator, stepModel *model.Step) (context.Context, context.CancelFunc) {
-	timeout := exprEval.Interpolate(ctx, stepModel.TimeoutMinutes)
+func evaluateStepTimeout(ctx context.Context, timeout string) (context.Context, context.CancelFunc) {
 	if timeout != "" {
 		if timeOutMinutes, err := strconv.ParseInt(timeout, 10, 64); err == nil {
 			return context.WithTimeout(ctx, time.Duration(timeOutMinutes)*time.Minute)

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -112,13 +112,17 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		ifExpression := step.getIfExpression(ctx, stage)
 		rc.setCurrentStep(stepModel.ID)
 
+		dataLock := rc.stateDataLock()
+
 		stepResult := &model.StepResult{
 			Outcome:    model.StepStatusSuccess,
 			Conclusion: model.StepStatusSuccess,
 			Outputs:    make(map[string]string),
 		}
 		if stage == stepStageMain {
+			dataLock.Lock()
 			rc.StepResults[stepModel.ID] = stepResult
+			dataLock.Unlock()
 		}
 
 		err := setupEnv(ctx, step)
@@ -128,19 +132,25 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		}
 
 		cctx := common.JobCancelContext(ctx)
+		dataLock.Lock()
 		rc.Cancelled = cctx != nil && cctx.Err() != nil
+		dataLock.Unlock()
 
 		runStep, err := isStepEnabled(ctx, ifExpression, step, stage)
 		if err != nil {
+			dataLock.Lock()
 			stepResult.Conclusion = model.StepStatusFailure
 			stepResult.Outcome = model.StepStatusFailure
+			dataLock.Unlock()
 			lock.Unlock()
 			return err
 		}
 
 		if !runStep {
+			dataLock.Lock()
 			stepResult.Conclusion = model.StepStatusSkipped
 			stepResult.Outcome = model.StepStatusSkipped
+			dataLock.Unlock()
 			logger.WithField("stepResult", stepResult.Outcome).Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
 			lock.Unlock()
 			return nil
@@ -208,14 +218,19 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		if err == nil {
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u2705  Success - %s %s [%s]", stage, stepString, executionTime)
 		} else {
+			dataLock.Lock()
 			stepResult.Outcome = model.StepStatusFailure
+			dataLock.Unlock()
 
 			continueOnError, parseErr := isContinueOnError(ctx, stepModel.RawContinueOnError, step, stage)
 			if parseErr != nil {
+				dataLock.Lock()
 				stepResult.Conclusion = model.StepStatusFailure
+				dataLock.Unlock()
 				return parseErr
 			}
 
+			dataLock.Lock()
 			if continueOnError {
 				logger.Infof("Failed but continue next step")
 				err = nil
@@ -223,6 +238,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			} else {
 				stepResult.Conclusion = model.StepStatusFailure
 			}
+			dataLock.Unlock()
 
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u274C  Failure - %s %s [%s]", stage, stepString, executionTime)
 		}
@@ -249,7 +265,10 @@ func monitorJobCancellation(ctx context.Context, stepCtx context.Context, jobCan
 			case <-jobCancellationCtx.Done():
 				lock := rc.stepStateLock()
 				lock.Lock()
+				dataLock := rc.stateDataLock()
+				dataLock.Lock()
 				rc.Cancelled = true
+				dataLock.Unlock()
 				logger.Infof("Reevaluate condition %v due to cancellation", ifExpression)
 				keepStepRunning, err := isStepEnabled(ctx, ifExpression, step, stage)
 				lock.Unlock()

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -73,20 +73,20 @@ func TestStepActionLocalTest(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	salm.On("runAction", sal, filepath.Clean("/tmp/path/to/action"), (*remoteAction)(nil)).Return(func(_ context.Context) error {
 		return nil
@@ -270,20 +270,20 @@ func TestStepActionLocalPost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sal.post()(ctx)

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -175,20 +175,20 @@ func TestStepActionRemote(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.pre()(ctx)
@@ -588,20 +588,20 @@ func TestStepActionRemotePost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.post()(ctx)

--- a/pkg/runner/step_background.go
+++ b/pkg/runner/step_background.go
@@ -1,0 +1,343 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/exprparser"
+	"github.com/nektos/act/pkg/model"
+)
+
+// maxConcurrentBackgroundSteps limits how many background steps of a job run
+// at the same time, additional background steps queue until a slot is free
+const maxConcurrentBackgroundSteps = 10
+
+// backgroundStep tracks one running background step of a job
+type backgroundStep struct {
+	id     string
+	done   chan struct{}
+	cancel context.CancelFunc
+
+	mu        sync.Mutex
+	err       error
+	cancelled bool
+	collected bool
+}
+
+// markCancelled gracefully terminates the step, a deliberately cancelled
+// step does not fail the job
+func (bs *backgroundStep) markCancelled() {
+	bs.mu.Lock()
+	bs.cancelled = true
+	bs.mu.Unlock()
+	bs.cancel()
+}
+
+func (bs *backgroundStep) setError(err error) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if !bs.cancelled {
+		bs.err = err
+	}
+}
+
+// takeError returns the failure of the step the first time it is called, so
+// a background step fails the job only at the first `wait` that includes it
+func (bs *backgroundStep) takeError() error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if bs.cancelled || bs.collected {
+		return nil
+	}
+	bs.collected = true
+	return bs.err
+}
+
+func (bs *backgroundStep) running() bool {
+	select {
+	case <-bs.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// backgroundStepRegistry tracks the background steps of one job execution
+type backgroundStepRegistry struct {
+	mu    sync.Mutex
+	slots chan struct{}
+	steps map[string]*backgroundStep
+	order []*backgroundStep
+}
+
+func newBackgroundStepRegistry() *backgroundStepRegistry {
+	return &backgroundStepRegistry{
+		slots: make(chan struct{}, maxConcurrentBackgroundSteps),
+		steps: map[string]*backgroundStep{},
+	}
+}
+
+func (r *backgroundStepRegistry) get(id string) *backgroundStep {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.steps[id]
+}
+
+func (r *backgroundStepRegistry) all() []*backgroundStep {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*backgroundStep{}, r.order...)
+}
+
+// launch starts executor asynchronously as a background step and returns as
+// soon as it is registered, the step waits for one of the limited background
+// slots before it runs
+func (r *backgroundStepRegistry) launch(ctx context.Context, id string, executor common.Executor) {
+	stepCtx, cancel := context.WithCancel(ctx)
+	bs := &backgroundStep{id: id, done: make(chan struct{}), cancel: cancel}
+
+	r.mu.Lock()
+	r.steps[id] = bs
+	r.order = append(r.order, bs)
+	r.mu.Unlock()
+
+	go func() {
+		defer close(bs.done)
+		defer cancel()
+		select {
+		case r.slots <- struct{}{}:
+		case <-stepCtx.Done():
+			bs.setError(stepCtx.Err())
+			return
+		}
+		defer func() { <-r.slots }()
+		bs.setError(executor(stepCtx))
+	}()
+}
+
+func (r *backgroundStepRegistry) waitFor(ctx context.Context, bs *backgroundStep) error {
+	select {
+	case <-bs.done:
+		return bs.takeError()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// cancelRemaining stops background steps that are still running when the job
+// ends, like services started with `background: true` that were never waited
+// for, their results do not affect the job result
+func (r *backgroundStepRegistry) cancelRemaining() common.Executor {
+	return func(ctx context.Context) error {
+		logger := common.Logger(ctx)
+		for _, bs := range r.all() {
+			if bs.running() {
+				logger.Infof("\U0001F6D1  Stopping background step '%s' still running at the end of the job", bs.id)
+				bs.markCancelled()
+			}
+		}
+		for _, bs := range r.all() {
+			select {
+			case <-bs.done:
+			case <-time.After(time.Minute):
+				logger.Errorf("Background step '%s' did not stop in time", bs.id)
+			}
+		}
+		return nil
+	}
+}
+
+// expandParallelStepGroups desugars every `parallel` step group into
+// background steps followed by an implicit `wait` for the whole group
+func expandParallelStepGroups(steps []*model.Step) ([]*model.Step, error) {
+	expanded := make([]*model.Step, 0, len(steps))
+	for _, stepModel := range steps {
+		if stepModel == nil || stepModel.Type() != model.StepTypeParallel {
+			expanded = append(expanded, stepModel)
+			continue
+		}
+		group := stepModel.ParallelSteps()
+		if len(group) == 0 {
+			return nil, fmt.Errorf("parallel step group '%s' contains no steps", stepModel.String())
+		}
+		ids := make([]string, 0, len(group))
+		for i, child := range group {
+			if child == nil {
+				return nil, fmt.Errorf("invalid step %d in parallel step group '%s': missing run or uses key", i, stepModel.String())
+			}
+			if child.ID == "" {
+				child.ID = fmt.Sprintf("%d", len(expanded))
+			}
+			child.Background = "true"
+			ids = append(ids, child.ID)
+			expanded = append(expanded, child)
+		}
+		wait := &model.Step{
+			ID:   stepModel.ID,
+			Name: fmt.Sprintf("Wait for parallel steps (%s)", strings.Join(ids, ", ")),
+		}
+		wait.RawWait.Kind = yaml.SequenceNode
+		wait.RawWait.Tag = "!!seq"
+		for _, id := range ids {
+			wait.RawWait.Content = append(wait.RawWait.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: id})
+		}
+		expanded = append(expanded, wait)
+	}
+	return expanded, nil
+}
+
+// newMainStepExecutor returns the main stage executor of a regular step.
+// Steps with `background: true` are only started and the job continues with
+// the next step right away, their failures surface at the next `wait` or
+// `wait-all` step that includes them.
+func newMainStepExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step, stepExec common.Executor, setJobError func(context.Context, error) error) common.Executor {
+	if stepModel.IsBackground() {
+		backgroundExec := useStepLogger(rc, stepModel, stepStageMain, stepExec)
+		stepID := stepModel.ID
+		stepName := stepModel.String()
+		return func(ctx context.Context) error {
+			common.Logger(ctx).Infof("⏩ Starting background step '%s'", stepName)
+			registry.launch(ctx, stepID, backgroundExec)
+			return nil
+		}
+	}
+	return useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
+		err := stepExec(ctx)
+		if err != nil {
+			_ = setJobError(ctx, err)
+		} else if ctx.Err() != nil {
+			_ = setJobError(ctx, ctx.Err())
+		}
+		return nil
+	})
+}
+
+// newControlStepExecutor runs a `wait`, `wait-all` or `cancel` step. These
+// steps always run, even when a previous step failed, and do not support the
+// `if` conditional.
+func newControlStepExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step, setJobError func(context.Context, error) error) common.Executor {
+	controlExec := newBackgroundControlExecutor(rc, registry, stepModel)
+	return useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
+		err := controlExec(ctx)
+		if err != nil {
+			_ = setJobError(ctx, err)
+		} else if ctx.Err() != nil {
+			_ = setJobError(ctx, ctx.Err())
+		}
+		return nil
+	})
+}
+
+func newBackgroundControlExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step) common.Executor {
+	return func(ctx context.Context) error {
+		logger := common.Logger(ctx)
+
+		stepResult := &model.StepResult{
+			Outcome:    model.StepStatusSuccess,
+			Conclusion: model.StepStatusSuccess,
+			Outputs:    make(map[string]string),
+		}
+		lock := rc.stepStateLock()
+		lock.Lock()
+		rc.StepResults[stepModel.ID] = stepResult
+		lock.Unlock()
+
+		logger.Infof("⭐ Run %s", stepModel.String())
+
+		var err error
+		switch stepModel.Type() {
+		case model.StepTypeWait:
+			err = runWaitStep(ctx, registry, stepModel)
+		case model.StepTypeWaitAll:
+			err = runWaitAllStep(ctx, registry)
+		case model.StepTypeCancel:
+			err = runCancelStep(ctx, registry, stepModel)
+		default:
+			err = fmt.Errorf("step '%s' is not a background control step", stepModel.ID)
+		}
+
+		if err == nil {
+			logger.WithField("stepResult", stepResult.Outcome).Infof("  ✅  Success - %s", stepModel.String())
+			return nil
+		}
+
+		stepResult.Outcome = model.StepStatusFailure
+		continueOnError, parseErr := evalStepContinueOnError(ctx, rc, stepModel)
+		if parseErr != nil {
+			stepResult.Conclusion = model.StepStatusFailure
+			return parseErr
+		}
+		if continueOnError {
+			logger.Infof("Failed but continue next step")
+			logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
+			return nil
+		}
+		stepResult.Conclusion = model.StepStatusFailure
+		logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
+		return err
+	}
+}
+
+func runWaitStep(ctx context.Context, registry *backgroundStepRegistry, stepModel *model.Step) error {
+	ids := stepModel.Wait()
+	if len(ids) == 0 {
+		return fmt.Errorf("wait step '%s' does not reference any background step", stepModel.ID)
+	}
+	var errs []error
+	for _, id := range ids {
+		bs := registry.get(id)
+		if bs == nil {
+			errs = append(errs, fmt.Errorf("'%s' is not a background step", id))
+			continue
+		}
+		common.Logger(ctx).Infof("⏸  Waiting for background step '%s'", id)
+		if err := registry.waitFor(ctx, bs); err != nil {
+			errs = append(errs, fmt.Errorf("background step '%s' failed: %w", id, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func runWaitAllStep(ctx context.Context, registry *backgroundStepRegistry) error {
+	var errs []error
+	for _, bs := range registry.all() {
+		common.Logger(ctx).Infof("⏸  Waiting for background step '%s'", bs.id)
+		if err := registry.waitFor(ctx, bs); err != nil {
+			errs = append(errs, fmt.Errorf("background step '%s' failed: %w", bs.id, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func runCancelStep(ctx context.Context, registry *backgroundStepRegistry, stepModel *model.Step) error {
+	bs := registry.get(stepModel.Cancel)
+	if bs == nil {
+		return fmt.Errorf("'%s' is not a background step", stepModel.Cancel)
+	}
+	common.Logger(ctx).Infof("\U0001F6D1  Cancelling background step '%s'", bs.id)
+	bs.markCancelled()
+	select {
+	case <-bs.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func evalStepContinueOnError(ctx context.Context, rc *RunContext, stepModel *model.Step) (bool, error) {
+	if stepModel.RawContinueOnError == "" {
+		return false, nil
+	}
+	continueOnError, err := EvalBool(ctx, rc.NewExpressionEvaluator(ctx), stepModel.RawContinueOnError, exprparser.DefaultStatusCheckNone)
+	if err != nil {
+		return false, fmt.Errorf("  ❌  Error in continue-on-error-expression: \"continue-on-error: %s\" (%s)", stepModel.RawContinueOnError, err)
+	}
+	return continueOnError, nil
+}

--- a/pkg/runner/step_background.go
+++ b/pkg/runner/step_background.go
@@ -21,14 +21,24 @@ const maxConcurrentBackgroundSteps = 10
 
 // backgroundStep tracks one running background step of a job
 type backgroundStep struct {
-	id     string
-	done   chan struct{}
-	cancel context.CancelFunc
+	id      string
+	started chan struct{}
+	done    chan struct{}
+	cancel  context.CancelFunc
 
 	mu        sync.Mutex
 	err       error
 	cancelled bool
 	collected bool
+}
+
+func (bs *backgroundStep) queued() bool {
+	select {
+	case <-bs.started:
+		return false
+	default:
+		return true
+	}
 }
 
 // markCancelled gracefully terminates the step, a deliberately cancelled
@@ -99,11 +109,16 @@ func (r *backgroundStepRegistry) all() []*backgroundStep {
 // launch starts executor asynchronously as a background step and returns as
 // soon as it is registered, the step waits for one of the limited background
 // slots before it runs
-func (r *backgroundStepRegistry) launch(ctx context.Context, id string, executor common.Executor) {
+func (r *backgroundStepRegistry) launch(ctx context.Context, id string, executor common.Executor) error {
 	stepCtx, cancel := context.WithCancel(ctx)
-	bs := &backgroundStep{id: id, done: make(chan struct{}), cancel: cancel}
+	bs := &backgroundStep{id: id, started: make(chan struct{}), done: make(chan struct{}), cancel: cancel}
 
 	r.mu.Lock()
+	if _, exists := r.steps[id]; exists {
+		r.mu.Unlock()
+		cancel()
+		return fmt.Errorf("background step id '%s' is not unique, wait and cancel steps could not tell the steps apart", id)
+	}
 	r.steps[id] = bs
 	r.order = append(r.order, bs)
 	r.mu.Unlock()
@@ -113,13 +128,20 @@ func (r *backgroundStepRegistry) launch(ctx context.Context, id string, executor
 		defer cancel()
 		select {
 		case r.slots <- struct{}{}:
-		case <-stepCtx.Done():
-			bs.setError(stepCtx.Err())
-			return
+		default:
+			common.Logger(ctx).Infof("Background step '%s' is queued, at most %d background steps run concurrently", id, maxConcurrentBackgroundSteps)
+			select {
+			case r.slots <- struct{}{}:
+			case <-stepCtx.Done():
+				bs.setError(stepCtx.Err())
+				return
+			}
 		}
+		close(bs.started)
 		defer func() { <-r.slots }()
 		bs.setError(executor(stepCtx))
 	}()
+	return nil
 }
 
 func (r *backgroundStepRegistry) waitFor(ctx context.Context, bs *backgroundStep) error {
@@ -204,7 +226,9 @@ func newMainStepExecutor(rc *RunContext, registry *backgroundStepRegistry, stepM
 		stepName := stepModel.String()
 		return func(ctx context.Context) error {
 			common.Logger(ctx).Infof("⏩ Starting background step '%s'", stepName)
-			registry.launch(ctx, stepID, backgroundExec)
+			if err := registry.launch(ctx, stepID, backgroundExec); err != nil {
+				_ = setJobError(ctx, err)
+			}
 			return nil
 		}
 	}
@@ -245,8 +269,11 @@ func newBackgroundControlExecutor(rc *RunContext, registry *backgroundStepRegist
 			Outputs:    make(map[string]string),
 		}
 		lock := rc.stepStateLock()
+		dataLock := rc.stateDataLock()
 		lock.Lock()
+		dataLock.Lock()
 		rc.StepResults[stepModel.ID] = stepResult
+		dataLock.Unlock()
 		lock.Unlock()
 
 		logger.Infof("⭐ Run %s", stepModel.String())
@@ -268,10 +295,14 @@ func newBackgroundControlExecutor(rc *RunContext, registry *backgroundStepRegist
 			return nil
 		}
 
+		dataLock.Lock()
 		stepResult.Outcome = model.StepStatusFailure
+		dataLock.Unlock()
 		continueOnError, parseErr := evalStepContinueOnError(ctx, rc, stepModel)
 		if parseErr != nil {
+			dataLock.Lock()
 			stepResult.Conclusion = model.StepStatusFailure
+			dataLock.Unlock()
 			return parseErr
 		}
 		if continueOnError {
@@ -279,7 +310,9 @@ func newBackgroundControlExecutor(rc *RunContext, registry *backgroundStepRegist
 			logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
 			return nil
 		}
+		dataLock.Lock()
 		stepResult.Conclusion = model.StepStatusFailure
+		dataLock.Unlock()
 		logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
 		return err
 	}
@@ -296,6 +329,9 @@ func runWaitStep(ctx context.Context, registry *backgroundStepRegistry, stepMode
 		if bs == nil {
 			errs = append(errs, fmt.Errorf("'%s' is not a background step", id))
 			continue
+		}
+		if bs.queued() {
+			common.Logger(ctx).Warnf("Background step '%s' has not started yet, it is queued until one of the %d background slots is free", id, maxConcurrentBackgroundSteps)
 		}
 		common.Logger(ctx).Infof("⏸  Waiting for background step '%s'", id)
 		if err := registry.waitFor(ctx, bs); err != nil {
@@ -320,6 +356,12 @@ func runCancelStep(ctx context.Context, registry *backgroundStepRegistry, stepMo
 	bs := registry.get(stepModel.Cancel)
 	if bs == nil {
 		return fmt.Errorf("'%s' is not a background step", stepModel.Cancel)
+	}
+	if !bs.running() {
+		// cancelling a step that already finished must not suppress a
+		// failure it recorded, a later wait still reports it
+		common.Logger(ctx).Infof("Background step '%s' already finished, nothing to cancel", bs.id)
+		return nil
 	}
 	common.Logger(ctx).Infof("\U0001F6D1  Cancelling background step '%s'", bs.id)
 	bs.markCancelled()

--- a/pkg/runner/step_background_test.go
+++ b/pkg/runner/step_background_test.go
@@ -138,7 +138,7 @@ func TestRunBackgroundStepFailure(t *testing.T) {
 	}
 
 	plan, err := runBackgroundStepsWorkflow(t, backgroundStepsWorkflowName("background-steps-fail"), filepath.ToSlash(t.TempDir()))
-	assert.ErrorContains(t, err, "Job 'fail-at-wait' failed")
+	assert.ErrorContains(t, err, "' failed")
 
 	results := map[string]string{}
 	for _, stage := range plan.Stages {
@@ -148,4 +148,6 @@ func TestRunBackgroundStepFailure(t *testing.T) {
 	}
 	assert.Equal(t, "failure", results["fail-at-wait"], "a failing background step must fail the job at the wait step")
 	assert.Equal(t, "success", results["continue-on-error"], "continue-on-error on a background step must swallow its failure")
+	assert.Equal(t, "failure", results["duplicate-id"], "duplicate background step ids must fail the job instead of hiding a step")
+	assert.Equal(t, "failure", results["cancel-after-failure"], "cancelling an already failed background step must not hide its failure from a later wait")
 }

--- a/pkg/runner/step_background_test.go
+++ b/pkg/runner/step_background_test.go
@@ -1,0 +1,151 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nektos/act/pkg/model"
+)
+
+func TestExpandParallelStepGroups(t *testing.T) {
+	workflow, err := model.ReadWorkflow(strings.NewReader(`
+name: parallel
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo before
+      - parallel:
+          - name: Build a
+            run: echo a
+          - name: Build b
+            id: build-b
+            run: echo b
+      - run: echo after
+`), false)
+	require.NoError(t, err)
+
+	steps, err := expandParallelStepGroups(workflow.GetJob("test").Steps)
+	require.NoError(t, err)
+	require.Len(t, steps, 5)
+
+	assert.Equal(t, "echo before", steps[0].Run)
+
+	assert.Equal(t, "echo a", steps[1].Run)
+	assert.True(t, steps[1].IsBackground())
+	assert.Equal(t, "1", steps[1].ID)
+
+	assert.Equal(t, "echo b", steps[2].Run)
+	assert.True(t, steps[2].IsBackground())
+	assert.Equal(t, "build-b", steps[2].ID)
+
+	assert.Equal(t, model.StepTypeWait, steps[3].Type())
+	assert.Equal(t, []string{"1", "build-b"}, steps[3].Wait())
+
+	assert.Equal(t, "echo after", steps[4].Run)
+}
+
+func runBackgroundStepsWorkflow(t *testing.T, workflowPath string, markerDir string) (*model.Plan, error) {
+	t.Helper()
+
+	log.SetLevel(logLevel)
+
+	absWorkdir, err := filepath.Abs(workdir)
+	require.NoError(t, err)
+
+	config := &Config{
+		Workdir:        absWorkdir,
+		EventName:      "push",
+		Platforms:      map[string]string{"self-hosted": "-self-hosted"},
+		GitHubInstance: "github.com",
+		Env:            map[string]string{"MARKER_DIR": markerDir},
+	}
+	runner, err := New(config)
+	require.NoError(t, err)
+
+	planner, err := model.NewWorkflowPlanner(filepath.Join(absWorkdir, workflowPath), true, false)
+	require.NoError(t, err)
+	plan, err := planner.PlanEvent("push")
+	require.NoError(t, err)
+
+	return plan, runner.NewPlanExecutor(plan)(context.Background())
+}
+
+func backgroundStepsWorkflowName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + "-windows"
+	}
+	return name
+}
+
+func markerModTime(t *testing.T, dir string, name string) time.Time {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(dir, name))
+	require.NoError(t, err, "marker file %s should exist", name)
+	return info.ModTime()
+}
+
+func TestRunBackgroundSteps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	markerDir := filepath.ToSlash(t.TempDir())
+	plan, err := runBackgroundStepsWorkflow(t, backgroundStepsWorkflowName("background-steps"), markerDir)
+	assert.NoError(t, err)
+
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			assert.Equal(t, "success", run.Job().Result, "job %s should have succeeded", run.String())
+		}
+	}
+
+	// the next step ran while the background step was still sleeping
+	workStart := markerModTime(t, markerDir, "work-start")
+	serviceEnd := markerModTime(t, markerDir, "service-end")
+	assert.True(t, workStart.Before(serviceEnd),
+		"the step after a background step must not wait for it (work started %v, service ended %v)", workStart, serviceEnd)
+
+	// both steps of the parallel group overlapped and the following step ran
+	// after the implicit wait for the whole group
+	aStart := markerModTime(t, markerDir, "a-start")
+	aEnd := markerModTime(t, markerDir, "a-end")
+	bStart := markerModTime(t, markerDir, "b-start")
+	bEnd := markerModTime(t, markerDir, "b-end")
+	assert.True(t, aStart.Before(bEnd) && bStart.Before(aEnd),
+		"steps of a parallel group must run concurrently (a: %v - %v, b: %v - %v)", aStart, aEnd, bStart, bEnd)
+	afterParallel := markerModTime(t, markerDir, "after-parallel")
+	assert.False(t, afterParallel.Before(aEnd), "the step after a parallel group must run after all steps of the group")
+	assert.False(t, afterParallel.Before(bEnd), "the step after a parallel group must run after all steps of the group")
+
+	// the quick background step completed even though the monitor was cancelled
+	assert.FileExists(t, filepath.Join(markerDir, "quick-done"))
+}
+
+func TestRunBackgroundStepFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	plan, err := runBackgroundStepsWorkflow(t, backgroundStepsWorkflowName("background-steps-fail"), filepath.ToSlash(t.TempDir()))
+	assert.ErrorContains(t, err, "Job 'fail-at-wait' failed")
+
+	results := map[string]string{}
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			results[run.JobID] = run.Job().Result
+		}
+	}
+	assert.Equal(t, "failure", results["fail-at-wait"], "a failing background step must fail the job at the wait step")
+	assert.Equal(t, "success", results["continue-on-error"], "continue-on-error on a background step must swallow its failure")
+}

--- a/pkg/runner/step_background_test.go
+++ b/pkg/runner/step_background_test.go
@@ -122,7 +122,10 @@ func TestRunBackgroundSteps(t *testing.T) {
 	aEnd := markerModTime(t, markerDir, "a-end")
 	bStart := markerModTime(t, markerDir, "b-start")
 	bEnd := markerModTime(t, markerDir, "b-end")
-	assert.True(t, aStart.Before(bEnd) && bStart.Before(aEnd),
+	// the fixtures rendezvous on each other's start marker, so overlap is
+	// guaranteed by construction; the timestamps only have to be consistent
+	// with it, which allows equality at coarse filesystem granularity
+	assert.True(t, !aStart.After(bEnd) && !bStart.After(aEnd),
 		"steps of a parallel group must run concurrently (a: %v - %v, b: %v - %v)", aStart, aEnd, bStart, bEnd)
 	afterParallel := markerModTime(t, markerDir, "after-parallel")
 	assert.False(t, afterParallel.Before(aEnd), "the step after a parallel group must run after all steps of the group")

--- a/pkg/runner/step_docker.go
+++ b/pkg/runner/step_docker.go
@@ -94,7 +94,7 @@ func (sd *stepDocker) newStepContainer(ctx context.Context, image string, cmd []
 	step := sd.Step
 
 	rawLogger := common.Logger(ctx).WithField("raw_output", true)
-	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+	logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, step.ID), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)
 		} else {

--- a/pkg/runner/step_docker_test.go
+++ b/pkg/runner/step_docker_test.go
@@ -81,20 +81,20 @@ func TestStepDockerMain(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sd.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/step_run.go
+++ b/pkg/runner/step_run.go
@@ -88,7 +88,7 @@ func (sr *stepRun) setupShellCommandExecutor() common.Executor {
 func getScriptName(rc *RunContext, step *model.Step) string {
 	scriptName := step.ID
 	for rcs := rc; rcs.Parent != nil; rcs = rcs.Parent {
-		scriptName = fmt.Sprintf("%s-composite-%s", rcs.Parent.currentStep(), scriptName)
+		scriptName = fmt.Sprintf("%s-composite-%s", rcs.parentStepID, scriptName)
 	}
 	return fmt.Sprintf("workflow/%s", scriptName)
 }

--- a/pkg/runner/step_run.go
+++ b/pkg/runner/step_run.go
@@ -88,7 +88,7 @@ func (sr *stepRun) setupShellCommandExecutor() common.Executor {
 func getScriptName(rc *RunContext, step *model.Step) string {
 	scriptName := step.ID
 	for rcs := rc; rcs.Parent != nil; rcs = rcs.Parent {
-		scriptName = fmt.Sprintf("%s-composite-%s", rcs.Parent.CurrentStep, scriptName)
+		scriptName = fmt.Sprintf("%s-composite-%s", rcs.Parent.currentStep(), scriptName)
 	}
 	return fmt.Sprintf("workflow/%s", scriptName)
 }

--- a/pkg/runner/step_run_test.go
+++ b/pkg/runner/step_run_test.go
@@ -60,22 +60,22 @@ func TestStepRun(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
 	ctx := context.Background()
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sr.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/testdata/.github/workflows/local-reusable-concurrency-windows.yml
+++ b/pkg/runner/testdata/.github/workflows/local-reusable-concurrency-windows.yml
@@ -1,0 +1,12 @@
+name: reusable-concurrency
+on: workflow_call
+concurrency:
+  group: act-test-reusable-group
+defaults:
+  run:
+    shell: powershell
+jobs:
+  called:
+    runs-on: self-hosted
+    steps:
+      - run: echo called

--- a/pkg/runner/testdata/.github/workflows/local-reusable-concurrency.yml
+++ b/pkg/runner/testdata/.github/workflows/local-reusable-concurrency.yml
@@ -1,0 +1,12 @@
+name: reusable-concurrency
+on: workflow_call
+concurrency:
+  group: act-test-reusable-group
+defaults:
+  run:
+    shell: bash
+jobs:
+  called:
+    runs-on: self-hosted
+    steps:
+      - run: echo called

--- a/pkg/runner/testdata/background-steps-container/push.yml
+++ b/pkg/runner/testdata/background-steps-container/push.yml
@@ -1,0 +1,28 @@
+name: background-steps-container
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Background step
+        id: bg
+        run: |
+          echo "value=from-background" >> "$GITHUB_OUTPUT"
+          sleep 1
+          touch /tmp/bg-done
+        background: true
+      - run: echo main work
+      - wait: bg
+      - name: Outputs are available after the wait
+        run: |
+          [ "${{ steps.bg.outputs.value }}" = "from-background" ]
+          [ -f /tmp/bg-done ]
+      - parallel:
+          - run: sleep 1 && echo a
+          - run: sleep 1 && echo b
+      - name: Long running monitor
+        id: monitor
+        run: sleep 60
+        background: true
+      - cancel: monitor
+      - wait-all:

--- a/pkg/runner/testdata/background-steps-fail-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-fail-windows/push.yml
@@ -1,0 +1,27 @@
+name: background-steps-fail
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  fail-at-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step
+        id: failing
+        run: exit 1
+        background: true
+      - name: Still runs before the failure surfaces
+        run: echo ok
+      - name: The job fails here
+        wait: failing
+  continue-on-error:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step with continue-on-error
+        id: failing
+        run: exit 1
+        background: true
+        continue-on-error: true
+      - name: Does not fail the job
+        wait: failing

--- a/pkg/runner/testdata/background-steps-fail-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-fail-windows/push.yml
@@ -25,3 +25,30 @@ jobs:
         continue-on-error: true
       - name: Does not fail the job
         wait: failing
+  duplicate-id:
+    runs-on: self-hosted
+    steps:
+      - id: dup
+        run: echo one
+        background: true
+      - id: dup
+        run: echo two
+        background: true
+      - wait: dup
+  cancel-after-failure:
+    runs-on: self-hosted
+    steps:
+      - name: Fails in the background
+        id: failing
+        run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/cancel-after-failure-done" | Out-Null
+          exit 1
+        background: true
+      - name: Wait until the background step has finished
+        run: |
+          while (-not (Test-Path "$env:MARKER_DIR/cancel-after-failure-done")) { Start-Sleep -Milliseconds 200 }
+          Start-Sleep -Seconds 1
+      - name: Cancelling a finished step must not hide its failure
+        cancel: failing
+      - name: The job fails here
+        wait: failing

--- a/pkg/runner/testdata/background-steps-fail/push.yml
+++ b/pkg/runner/testdata/background-steps-fail/push.yml
@@ -25,3 +25,30 @@ jobs:
         continue-on-error: true
       - name: Does not fail the job
         wait: failing
+  duplicate-id:
+    runs-on: self-hosted
+    steps:
+      - id: dup
+        run: echo one
+        background: true
+      - id: dup
+        run: echo two
+        background: true
+      - wait: dup
+  cancel-after-failure:
+    runs-on: self-hosted
+    steps:
+      - name: Fails in the background
+        id: failing
+        run: |
+          touch "$MARKER_DIR/cancel-after-failure-done"
+          exit 1
+        background: true
+      - name: Wait until the background step has finished
+        run: |
+          until [ -f "$MARKER_DIR/cancel-after-failure-done" ]; do sleep 0.2; done
+          sleep 1
+      - name: Cancelling a finished step must not hide its failure
+        cancel: failing
+      - name: The job fails here
+        wait: failing

--- a/pkg/runner/testdata/background-steps-fail/push.yml
+++ b/pkg/runner/testdata/background-steps-fail/push.yml
@@ -1,0 +1,27 @@
+name: background-steps-fail
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  fail-at-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step
+        id: failing
+        run: exit 1
+        background: true
+      - name: Still runs before the failure surfaces
+        run: echo ok
+      - name: The job fails here
+        wait: failing
+  continue-on-error:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step with continue-on-error
+        id: failing
+        run: exit 1
+        background: true
+        continue-on-error: true
+      - name: Does not fail the job
+        wait: failing

--- a/pkg/runner/testdata/background-steps-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-windows/push.yml
@@ -12,7 +12,8 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_OUTPUT -Value "value=from-background"
           New-Item -ItemType File -Path "$env:MARKER_DIR/service-start" | Out-Null
-          Start-Sleep -Seconds 2
+          $deadline = (Get-Date).AddSeconds(60)
+          while (-not (Test-Path "$env:MARKER_DIR/work-start")) { if ((Get-Date) -gt $deadline) { exit 1 }; Start-Sleep -Milliseconds 200 }
           New-Item -ItemType File -Path "$env:MARKER_DIR/service-end" | Out-Null
         background: true
       - name: Work while the service runs
@@ -31,13 +32,15 @@ jobs:
             id: build-a
             run: |
               New-Item -ItemType File -Path "$env:MARKER_DIR/a-start" | Out-Null
-              Start-Sleep -Seconds 2
+              $deadline = (Get-Date).AddSeconds(60)
+              while (-not (Test-Path "$env:MARKER_DIR/b-start")) { if ((Get-Date) -gt $deadline) { exit 1 }; Start-Sleep -Milliseconds 200 }
               New-Item -ItemType File -Path "$env:MARKER_DIR/a-end" | Out-Null
           - name: Build b
             id: build-b
             run: |
               New-Item -ItemType File -Path "$env:MARKER_DIR/b-start" | Out-Null
-              Start-Sleep -Seconds 2
+              $deadline = (Get-Date).AddSeconds(60)
+              while (-not (Test-Path "$env:MARKER_DIR/a-start")) { if ((Get-Date) -gt $deadline) { exit 1 }; Start-Sleep -Milliseconds 200 }
               New-Item -ItemType File -Path "$env:MARKER_DIR/b-end" | Out-Null
       - name: Runs after the whole group
         run: New-Item -ItemType File -Path "$env:MARKER_DIR/after-parallel" | Out-Null
@@ -56,3 +59,7 @@ jobs:
         cancel: monitor
       - name: Wait for the rest
         wait-all:
+  only-control:
+    runs-on: self-hosted
+    steps:
+      - wait-all:

--- a/pkg/runner/testdata/background-steps-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-windows/push.yml
@@ -1,0 +1,58 @@
+name: background-steps
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  background-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Start background service
+        id: service
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "value=from-background"
+          New-Item -ItemType File -Path "$env:MARKER_DIR/service-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/service-end" | Out-Null
+        background: true
+      - name: Work while the service runs
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/work-start" | Out-Null
+      - name: Wait for the service
+        wait: service
+      - name: Outputs of the service are available after the wait
+        run: |
+          if ("${{ steps.service.outputs.value }}" -ne "from-background") { exit 1 }
+          if (-not (Test-Path "$env:MARKER_DIR/service-end")) { exit 1 }
+  parallel-group:
+    runs-on: self-hosted
+    steps:
+      - parallel:
+          - name: Build a
+            id: build-a
+            run: |
+              New-Item -ItemType File -Path "$env:MARKER_DIR/a-start" | Out-Null
+              Start-Sleep -Seconds 2
+              New-Item -ItemType File -Path "$env:MARKER_DIR/a-end" | Out-Null
+          - name: Build b
+            id: build-b
+            run: |
+              New-Item -ItemType File -Path "$env:MARKER_DIR/b-start" | Out-Null
+              Start-Sleep -Seconds 2
+              New-Item -ItemType File -Path "$env:MARKER_DIR/b-end" | Out-Null
+      - name: Runs after the whole group
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/after-parallel" | Out-Null
+  cancel-and-wait-all:
+    runs-on: self-hosted
+    steps:
+      - name: Long running monitor
+        id: monitor
+        run: Start-Sleep -Seconds 60
+        background: true
+      - name: Quick background work
+        id: quick
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/quick-done" | Out-Null
+        background: true
+      - name: Stop the monitor
+        cancel: monitor
+      - name: Wait for the rest
+        wait-all:

--- a/pkg/runner/testdata/background-steps/push.yml
+++ b/pkg/runner/testdata/background-steps/push.yml
@@ -1,0 +1,58 @@
+name: background-steps
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  background-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Start background service
+        id: service
+        run: |
+          echo "value=from-background" >> "$GITHUB_OUTPUT"
+          touch "$MARKER_DIR/service-start"
+          sleep 2
+          touch "$MARKER_DIR/service-end"
+        background: true
+      - name: Work while the service runs
+        run: touch "$MARKER_DIR/work-start"
+      - name: Wait for the service
+        wait: service
+      - name: Outputs of the service are available after the wait
+        run: |
+          [ "${{ steps.service.outputs.value }}" = "from-background" ]
+          [ -f "$MARKER_DIR/service-end" ]
+  parallel-group:
+    runs-on: self-hosted
+    steps:
+      - parallel:
+          - name: Build a
+            id: build-a
+            run: |
+              touch "$MARKER_DIR/a-start"
+              sleep 2
+              touch "$MARKER_DIR/a-end"
+          - name: Build b
+            id: build-b
+            run: |
+              touch "$MARKER_DIR/b-start"
+              sleep 2
+              touch "$MARKER_DIR/b-end"
+      - name: Runs after the whole group
+        run: touch "$MARKER_DIR/after-parallel"
+  cancel-and-wait-all:
+    runs-on: self-hosted
+    steps:
+      - name: Long running monitor
+        id: monitor
+        run: sleep 60
+        background: true
+      - name: Quick background work
+        id: quick
+        run: touch "$MARKER_DIR/quick-done"
+        background: true
+      - name: Stop the monitor
+        cancel: monitor
+      - name: Wait for the rest
+        wait-all:

--- a/pkg/runner/testdata/background-steps/push.yml
+++ b/pkg/runner/testdata/background-steps/push.yml
@@ -12,7 +12,8 @@ jobs:
         run: |
           echo "value=from-background" >> "$GITHUB_OUTPUT"
           touch "$MARKER_DIR/service-start"
-          sleep 2
+          for i in $(seq 1 300); do [ -f "$MARKER_DIR/work-start" ] && break; sleep 0.2; done
+          [ -f "$MARKER_DIR/work-start" ]
           touch "$MARKER_DIR/service-end"
         background: true
       - name: Work while the service runs
@@ -31,13 +32,15 @@ jobs:
             id: build-a
             run: |
               touch "$MARKER_DIR/a-start"
-              sleep 2
+              for i in $(seq 1 300); do [ -f "$MARKER_DIR/b-start" ] && break; sleep 0.2; done
+              [ -f "$MARKER_DIR/b-start" ]
               touch "$MARKER_DIR/a-end"
           - name: Build b
             id: build-b
             run: |
               touch "$MARKER_DIR/b-start"
-              sleep 2
+              for i in $(seq 1 300); do [ -f "$MARKER_DIR/a-start" ] && break; sleep 0.2; done
+              [ -f "$MARKER_DIR/a-start" ]
               touch "$MARKER_DIR/b-end"
       - name: Runs after the whole group
         run: touch "$MARKER_DIR/after-parallel"
@@ -56,3 +59,7 @@ jobs:
         cancel: monitor
       - name: Wait for the rest
         wait-all:
+  only-control:
+    runs-on: self-hosted
+    steps:
+      - wait-all:

--- a/pkg/runner/testdata/concurrency-cancel-windows/push.yml
+++ b/pkg/runner/testdata/concurrency-cancel-windows/push.yml
@@ -1,0 +1,20 @@
+name: concurrency-cancel
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  first:
+    runs-on: self-hosted
+    concurrency:
+      group: act-test-cancel
+      cancel-in-progress: true
+    steps:
+      - run: Start-Sleep -Seconds 5
+  second:
+    runs-on: self-hosted
+    concurrency:
+      group: act-test-cancel
+      cancel-in-progress: ${{ true }}
+    steps:
+      - run: Start-Sleep -Seconds 5

--- a/pkg/runner/testdata/concurrency-cancel/push.yml
+++ b/pkg/runner/testdata/concurrency-cancel/push.yml
@@ -1,0 +1,20 @@
+name: concurrency-cancel
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  first:
+    runs-on: self-hosted
+    concurrency:
+      group: act-test-cancel
+      cancel-in-progress: true
+    steps:
+      - run: sleep 5
+  second:
+    runs-on: self-hosted
+    concurrency:
+      group: act-test-cancel
+      cancel-in-progress: ${{ true }}
+    steps:
+      - run: sleep 5

--- a/pkg/runner/testdata/concurrency-queue-invalid/push.yml
+++ b/pkg/runner/testdata/concurrency-queue-invalid/push.yml
@@ -1,0 +1,11 @@
+name: concurrency-queue-invalid
+on: push
+concurrency:
+  group: act-test-queue-invalid
+  queue: max
+  cancel-in-progress: true
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: echo unreachable

--- a/pkg/runner/testdata/concurrency-queue-max-windows/w1.yml
+++ b/pkg/runner/testdata/concurrency-queue-max-windows/w1.yml
@@ -1,0 +1,16 @@
+name: qw1
+on: push
+concurrency:
+  group: act-test-queue-max
+  queue: max
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/qw1-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/qw1-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-queue-max-windows/w2.yml
+++ b/pkg/runner/testdata/concurrency-queue-max-windows/w2.yml
@@ -1,0 +1,16 @@
+name: qw2
+on: push
+concurrency:
+  group: act-test-queue-max
+  queue: max
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/qw2-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/qw2-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-queue-max-windows/w3.yml
+++ b/pkg/runner/testdata/concurrency-queue-max-windows/w3.yml
@@ -1,0 +1,16 @@
+name: qw3
+on: push
+concurrency:
+  group: ACT-TEST-QUEUE-MAX
+  queue: max
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/qw3-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/qw3-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-queue-max/w1.yml
+++ b/pkg/runner/testdata/concurrency-queue-max/w1.yml
@@ -1,0 +1,16 @@
+name: qw1
+on: push
+concurrency:
+  group: act-test-queue-max
+  queue: max
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/qw1-start"
+          sleep 2
+          touch "$MARKER_DIR/qw1-end"

--- a/pkg/runner/testdata/concurrency-queue-max/w2.yml
+++ b/pkg/runner/testdata/concurrency-queue-max/w2.yml
@@ -1,0 +1,16 @@
+name: qw2
+on: push
+concurrency:
+  group: act-test-queue-max
+  queue: max
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/qw2-start"
+          sleep 2
+          touch "$MARKER_DIR/qw2-end"

--- a/pkg/runner/testdata/concurrency-queue-max/w3.yml
+++ b/pkg/runner/testdata/concurrency-queue-max/w3.yml
@@ -1,0 +1,16 @@
+name: qw3
+on: push
+concurrency:
+  group: ACT-TEST-QUEUE-MAX
+  queue: max
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/qw3-start"
+          sleep 2
+          touch "$MARKER_DIR/qw3-end"

--- a/pkg/runner/testdata/concurrency-reusable-windows/push.yml
+++ b/pkg/runner/testdata/concurrency-reusable-windows/push.yml
@@ -1,0 +1,7 @@
+name: concurrency-reusable
+on: push
+concurrency:
+  group: act-test-reusable-group
+jobs:
+  caller:
+    uses: ./.github/workflows/local-reusable-concurrency-windows.yml

--- a/pkg/runner/testdata/concurrency-reusable/push.yml
+++ b/pkg/runner/testdata/concurrency-reusable/push.yml
@@ -1,0 +1,7 @@
+name: concurrency-reusable
+on: push
+concurrency:
+  group: act-test-reusable-group
+jobs:
+  caller:
+    uses: ./.github/workflows/local-reusable-concurrency.yml

--- a/pkg/runner/testdata/concurrency-serialize-windows/push.yml
+++ b/pkg/runner/testdata/concurrency-serialize-windows/push.yml
@@ -1,0 +1,23 @@
+name: concurrency-serialize
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  first:
+    runs-on: self-hosted
+    concurrency:
+      group: act-test-serialize-${{ github.event_name }}
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/first-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/first-end" | Out-Null
+  second:
+    runs-on: self-hosted
+    concurrency: act-test-serialize-push
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/second-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/second-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-serialize/push.yml
+++ b/pkg/runner/testdata/concurrency-serialize/push.yml
@@ -1,0 +1,23 @@
+name: concurrency-serialize
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  first:
+    runs-on: self-hosted
+    concurrency:
+      group: act-test-serialize-${{ github.event_name }}
+    steps:
+      - run: |
+          touch "$MARKER_DIR/first-start"
+          sleep 2
+          touch "$MARKER_DIR/first-end"
+  second:
+    runs-on: self-hosted
+    concurrency: act-test-serialize-push
+    steps:
+      - run: |
+          touch "$MARKER_DIR/second-start"
+          sleep 2
+          touch "$MARKER_DIR/second-end"

--- a/pkg/runner/testdata/concurrency-supersede-windows/w1.yml
+++ b/pkg/runner/testdata/concurrency-supersede-windows/w1.yml
@@ -1,0 +1,15 @@
+name: sw1
+on: push
+concurrency:
+  group: act-test-supersede
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/sw1-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/sw1-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-supersede-windows/w2.yml
+++ b/pkg/runner/testdata/concurrency-supersede-windows/w2.yml
@@ -1,0 +1,15 @@
+name: sw2
+on: push
+concurrency:
+  group: act-test-supersede
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/sw2-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/sw2-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-supersede-windows/w3.yml
+++ b/pkg/runner/testdata/concurrency-supersede-windows/w3.yml
@@ -1,0 +1,15 @@
+name: sw3
+on: push
+concurrency:
+  group: act-test-supersede
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/sw3-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/sw3-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-supersede/w1.yml
+++ b/pkg/runner/testdata/concurrency-supersede/w1.yml
@@ -1,0 +1,15 @@
+name: sw1
+on: push
+concurrency:
+  group: act-test-supersede
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/sw1-start"
+          sleep 2
+          touch "$MARKER_DIR/sw1-end"

--- a/pkg/runner/testdata/concurrency-supersede/w2.yml
+++ b/pkg/runner/testdata/concurrency-supersede/w2.yml
@@ -1,0 +1,15 @@
+name: sw2
+on: push
+concurrency:
+  group: act-test-supersede
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/sw2-start"
+          sleep 2
+          touch "$MARKER_DIR/sw2-end"

--- a/pkg/runner/testdata/concurrency-supersede/w3.yml
+++ b/pkg/runner/testdata/concurrency-supersede/w3.yml
@@ -1,0 +1,15 @@
+name: sw3
+on: push
+concurrency:
+  group: act-test-supersede
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/sw3-start"
+          sleep 2
+          touch "$MARKER_DIR/sw3-end"

--- a/pkg/runner/testdata/concurrency-workflow-group-windows/w1.yml
+++ b/pkg/runner/testdata/concurrency-workflow-group-windows/w1.yml
@@ -1,0 +1,22 @@
+name: wf1
+on: push
+concurrency:
+  group: act-test-workflow-group
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w1-a-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w1-a-end" | Out-Null
+  b:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w1-b-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w1-b-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-workflow-group-windows/w2.yml
+++ b/pkg/runner/testdata/concurrency-workflow-group-windows/w2.yml
@@ -1,0 +1,22 @@
+name: wf2
+on: push
+concurrency:
+  group: act-test-workflow-group
+defaults:
+  run:
+    shell: powershell
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w2-a-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w2-a-end" | Out-Null
+  b:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w2-b-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/w2-b-end" | Out-Null

--- a/pkg/runner/testdata/concurrency-workflow-group/w1.yml
+++ b/pkg/runner/testdata/concurrency-workflow-group/w1.yml
@@ -1,0 +1,22 @@
+name: wf1
+on: push
+concurrency:
+  group: act-test-workflow-group
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/w1-a-start"
+          sleep 2
+          touch "$MARKER_DIR/w1-a-end"
+  b:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/w1-b-start"
+          sleep 2
+          touch "$MARKER_DIR/w1-b-end"

--- a/pkg/runner/testdata/concurrency-workflow-group/w2.yml
+++ b/pkg/runner/testdata/concurrency-workflow-group/w2.yml
@@ -1,0 +1,22 @@
+name: wf2
+on: push
+concurrency:
+  group: act-test-workflow-group
+defaults:
+  run:
+    shell: bash
+jobs:
+  a:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/w2-a-start"
+          sleep 2
+          touch "$MARKER_DIR/w2-a-end"
+  b:
+    runs-on: self-hosted
+    steps:
+      - run: |
+          touch "$MARKER_DIR/w2-b-start"
+          sleep 2
+          touch "$MARKER_DIR/w2-b-end"

--- a/pkg/runner/testdata/concurrency/push.yml
+++ b/pkg/runner/testdata/concurrency/push.yml
@@ -1,0 +1,17 @@
+name: concurrency
+on: push
+concurrency:
+  group: act-test-docker-workflow-${{ github.event_name }}
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: act-test-docker-job
+      cancel-in-progress: false
+    steps:
+      - run: sleep 1 && echo first
+  second:
+    runs-on: ubuntu-latest
+    concurrency: act-test-docker-job
+    steps:
+      - run: sleep 1 && echo second

--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1643,9 +1643,17 @@
           "cancel-in-progress": {
             "type": "boolean",
             "description": "To cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true."
+          },
+          "queue": {
+            "type": "concurrency-queue",
+            "description": "Controls how many jobs or workflow runs can be `pending` in the concurrency group. The combination of `queue: max` and `cancel-in-progress: true` is not allowed."
           }
         }
       }
+    },
+    "concurrency-queue": {
+      "description": "To allow more than one `pending` job or workflow run to wait in the same concurrency group, use the optional `queue` property.\n\n* `single` (default): At most one job or workflow run can be `pending` in the concurrency group. When a new job or workflow run is queued, any existing `pending` job or workflow run in the same group is canceled and replaced.\n* `max`: Up to 100 jobs or workflow runs can be `pending` in the concurrency group. When the queue is full, any additional jobs or workflow runs are canceled.",
+      "allowed-values": ["single", "max"]
     },
     "job-environment": {
       "description": "The environment that the job references. All environment protection rules must pass before a job referencing the environment is sent to a runner.",

--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1710,7 +1710,7 @@
       }
     },
     "steps-item": {
-      "one-of": ["run-step", "regular-step"]
+      "one-of": ["run-step", "regular-step", "wait-step", "wait-all-step", "cancel-step", "parallel-step"]
     },
     "run-step": {
       "mapping": {
@@ -1727,7 +1727,8 @@
           "continue-on-error": "step-continue-on-error",
           "env": "step-env",
           "working-directory": "string-steps-context",
-          "shell": "shell"
+          "shell": "shell",
+          "background": "step-background"
         }
       }
     },
@@ -1744,9 +1745,87 @@
             "required": true
           },
           "with": "step-with",
-          "env": "step-env"
+          "env": "step-env",
+          "background": "step-background"
         }
       }
+    },
+    "step-background": {
+      "description": "Runs the step asynchronously so the job continues to the next step without waiting for it to finish. Use `wait`, `wait-all` or `cancel` steps to synchronize with or stop background steps. A maximum of 10 background steps run concurrently, additional background steps queue until a slot becomes available.",
+      "boolean": {}
+    },
+    "wait-step": {
+      "description": "Pauses the job until one or more background steps complete. Provide a single step id as a string or multiple ids as an array. After a `wait` step completes, the outputs of the referenced background steps become available to subsequent steps. A `wait` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait": {
+            "type": "wait-targets",
+            "required": true
+          }
+        }
+      }
+    },
+    "wait-targets": {
+      "one-of": ["non-empty-string", "wait-targets-sequence"]
+    },
+    "wait-targets-sequence": {
+      "sequence": {
+        "item-type": "non-empty-string"
+      }
+    },
+    "wait-all-step": {
+      "description": "Pauses the job until all active background steps complete. A `wait-all` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait-all": {
+            "type": "wait-all-value",
+            "required": true
+          }
+        }
+      }
+    },
+    "wait-all-value": {
+      "one-of": ["null", "boolean"]
+    },
+    "cancel-step": {
+      "description": "Gracefully terminates a running background step referenced by its id. A `cancel` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "cancel": {
+            "type": "non-empty-string",
+            "required": true
+          }
+        }
+      }
+    },
+    "parallel-step": {
+      "description": "Runs a group of steps in parallel: every step in the group runs as a background step, with an implicit `wait` at the end. Each step in the group is subject to the same 10-step concurrency limit as other background steps. You cannot use `parallel` inside a composite action.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "parallel": {
+            "type": "parallel-steps",
+            "required": true
+          }
+        }
+      }
+    },
+    "parallel-steps": {
+      "sequence": {
+        "item-type": "parallel-steps-item"
+      }
+    },
+    "parallel-steps-item": {
+      "one-of": ["run-step", "regular-step"]
     },
     "step-uses": {
       "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, or in a published Docker container image.",


### PR DESCRIPTION
> **Not for review — being split into smaller PRs.** This branch is kept as the reference implementation so the individual PRs have something to point at. Please review those instead.

This started as one branch implementing GitHub Actions `concurrency` groups and the new parallel step syntax. At +3800 / −205 across 58 files it is far too large to ask anyone to review, and it mixes two unrelated features with a change to how every workflow is scheduled. Splitting it.

## The stack

| | PR | closes |
|---|-----|--------|
| 1 | Guard the shared log writers and mask list against concurrent access — #6153 | — |
| 2 | Give each step execution its own runner file command directory — #6154 | refs #2184 #2697 #2553 |
| 3 | The `pkg/model` side of `concurrency.queue` — #6152, building on @xenjke's #6096 | — |
| 4 | Execute each workflow as an independent run instead of one global stage pipeline | — |
| 5 | Workflow and job level `concurrency` groups with cancel-in-progress and queue | — |
| 6 | Parallel steps: `background`, `wait`, `wait-all`, `cancel`, `parallel` — #6161 (draft, stacked on #6153 + #6154) | #6124 |

PRs 1–3 are independent and are up now. PR 6 is up as a draft in #6161: it closes a filed issue and does not depend on PR 4, so it went ahead of it. PR 4 changes job scheduling for everyone even if they use none of these features, so it gets its own PR with its own justification rather than being smuggled in with a feature — it stays parked until there is a signal that it is wanted. PR 5 does not need it either: job level `concurrency` works on the existing stage executor, and only workflow level groups require PR 4.

## Trying it out before it lands

This branch is usable today if you need `concurrency` or parallel steps now:

```sh
git clone --branch feat/concurrency-groups https://github.com/McNultyyy/act.git && cd act && go build -o act-fork .
```

Needs Go 1.25+; no CGO, so it cross-compiles anywhere. Note `go install github.com/McNultyyy/act@...` does **not** work — `go.mod` correctly declares the module as `github.com/nektos/act`, so it has to be cloned and built. Bug reports for these features belong here, not on the upstream issue tracker.

## Questions before I push the rest

Rather than drop three more large PRs on you:

1. **Do you want `concurrency` implemented at all, and in this shape?** Your docs list it as planned, so you may already have a design in mind. PR 5 holds a group for the whole workflow run, implements `queue: single` / `max` with a FIFO queue, and treats group names case-insensitively as GitHub does.

2. **Is PR 4 acceptable?** It removes the barrier that makes one workflow's stage wait on an unrelated workflow's jobs, and turns `--concurrent-jobs` into a plan-wide semaphore. Workflow-level concurrency groups genuinely need it. But it changes job start order and log interleaving for the default `act` invocation, and it raises real parallelism, which makes the known races in #6028, #6057 and #2764 more likely to fire. It may be that this should wait until those are fixed.

3. **Would you rather have the two features as separate efforts entirely?** Parallel steps (PR 6, #6124) has no dependency on the concurrency work.

Happy to shape these however suits you, or to drop parts of it.

## Known issue in this branch

The context-carried log writers in the parallel-steps work silently disabled `newCompositeCommandExecutor`'s `ReplaceLogWriter`, which broke composite action outputs. Fixed in b8f60ec; the split PRs sequence the change so it cannot recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

