### PR TITLE
feat: run steps in parallel with background, wait, wait-all and cancel

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"net/netip"
 
@@ -197,6 +198,9 @@ func (cr *containerReference) GetHealth(ctx context.Context) Health {
 }
 
 func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Writer) (io.Writer, io.Writer) {
+	cr.logWriterMutex.Lock()
+	defer cr.logWriterMutex.Unlock()
+
 	out := cr.input.Stdout
 	err := cr.input.Stderr
 
@@ -206,12 +210,30 @@ func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Write
 	return out, err
 }
 
+// getLogWriters returns the current log writers, they are replaced per step
+// and read concurrently by steps running in the background
+func (cr *containerReference) getLogWriters() (io.Writer, io.Writer) {
+	cr.logWriterMutex.Lock()
+	defer cr.logWriterMutex.Unlock()
+
+	outWriter := io.Writer(os.Stdout)
+	if cr.input.Stdout != nil {
+		outWriter = cr.input.Stdout
+	}
+	errWriter := io.Writer(os.Stderr)
+	if cr.input.Stderr != nil {
+		errWriter = cr.input.Stderr
+	}
+	return outWriter, errWriter
+}
+
 type containerReference struct {
-	cli   client.APIClient
-	id    string
-	input *NewContainerInput
-	UID   int
-	GID   int
+	cli            client.APIClient
+	id             string
+	input          *NewContainerInput
+	UID            int
+	GID            int
+	logWriterMutex sync.Mutex
 	LinuxContainerEnvironmentExtensions
 }
 
@@ -666,17 +688,8 @@ func (cr *containerReference) waitForCommand(ctx context.Context, isTerminal boo
 
 	cmdResponse := make(chan error)
 
+	outWriter, errWriter := cr.getLogWriters()
 	go func() {
-		var outWriter io.Writer
-		outWriter = cr.input.Stdout
-		if outWriter == nil {
-			outWriter = os.Stdout
-		}
-		errWriter := cr.input.Stderr
-		if errWriter == nil {
-			errWriter = os.Stderr
-		}
-
 		var err error
 		if !isTerminal || os.Getenv("NORAW") != "" {
 			_, err = stdcopy.StdCopy(outWriter, errWriter, resp.Reader)
@@ -852,15 +865,7 @@ func (cr *containerReference) attach() common.Executor {
 		}
 		isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 
-		var outWriter io.Writer
-		outWriter = cr.input.Stdout
-		if outWriter == nil {
-			outWriter = os.Stdout
-		}
-		errWriter := cr.input.Stderr
-		if errWriter == nil {
-			errWriter = os.Stderr
-		}
+		outWriter, errWriter := cr.getLogWriters()
 		go func() {
 			if !isTerminal || os.Getenv("NORAW") != "" {
 				_, err = stdcopy.StdCopy(outWriter, errWriter, out.Reader)

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-git/go-billy/v5/helper/polyfill"
@@ -33,6 +35,16 @@ type HostEnvironment struct {
 	ActPath   string
 	CleanUp   func()
 	StdOut    io.Writer
+
+	// stdoutMutex guards StdOut, it is replaced per step and read
+	// concurrently by steps running in the background
+	stdoutMutex sync.Mutex
+}
+
+func (e *HostEnvironment) getStdOut() io.Writer {
+	e.stdoutMutex.Lock()
+	defer e.stdoutMutex.Unlock()
+	return e.StdOut
 }
 
 func (e *HostEnvironment) Create(_ []string, _ []string) common.Executor {
@@ -182,12 +194,12 @@ func (e *HostEnvironment) Start(_ bool) common.Executor {
 
 type ptyWriter struct {
 	Out       io.Writer
-	AutoStop  bool
+	AutoStop  atomic.Bool
 	dirtyLine bool
 }
 
 func (w *ptyWriter) Write(buf []byte) (int, error) {
-	if w.AutoStop && len(buf) > 0 && buf[len(buf)-1] == 4 {
+	if w.AutoStop.Load() && len(buf) > 0 && buf[len(buf)-1] == 4 {
 		n, err := w.Out.Write(buf[:len(buf)-1])
 		if err != nil {
 			return n, err
@@ -294,7 +306,8 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 	} else {
 		wd = e.Path
 	}
-	f, err := lookupPathHost(command[0], env, e.StdOut)
+	stdout := e.getStdOut()
+	f, err := lookupPathHost(command[0], env, stdout)
 	if err != nil {
 		return err
 	}
@@ -302,9 +315,9 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 	cmd.Path = f
 	cmd.Args = command
 	cmd.Stdin = nil
-	cmd.Stdout = e.StdOut
+	cmd.Stdout = stdout
 	cmd.Env = envList
-	cmd.Stderr = e.StdOut
+	cmd.Stderr = stdout
 	cmd.Dir = wd
 	cmd.SysProcAttr = getSysProcAttr(cmdline, false)
 	var ppty *os.File
@@ -324,7 +337,7 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 			common.Logger(ctx).Debugf("Failed to setup Pty %v\n", err.Error())
 		}
 	}
-	writer := &ptyWriter{Out: e.StdOut}
+	writer := &ptyWriter{Out: stdout}
 	logctx, finishLog := context.WithCancel(context.Background())
 	if ppty != nil {
 		go copyPtyOutput(writer, ppty, finishLog)
@@ -339,7 +352,7 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 		return err
 	}
 	if tty != nil {
-		writer.AutoStop = true
+		writer.AutoStop.Store(true)
 		if _, err := tty.Write([]byte("\x04")); err != nil {
 			common.Logger(ctx).Debug("Failed to write EOT")
 		}
@@ -460,6 +473,8 @@ func (e *HostEnvironment) GetHealth(_ context.Context) Health {
 }
 
 func (e *HostEnvironment) ReplaceLogWriter(stdout io.Writer, _ io.Writer) (io.Writer, io.Writer) {
+	e.stdoutMutex.Lock()
+	defer e.stdoutMutex.Unlock()
 	org := e.StdOut
 	e.StdOut = stdout
 	return org, org

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -580,6 +580,56 @@ type Step struct {
 	With               map[string]string `yaml:"with"`
 	RawContinueOnError string            `yaml:"continue-on-error"`
 	TimeoutMinutes     string            `yaml:"timeout-minutes"`
+	Background         string            `yaml:"background"`
+	RawWait            yaml.Node         `yaml:"wait"`
+	RawWaitAll         yaml.Node         `yaml:"wait-all"`
+	Cancel             string            `yaml:"cancel"`
+	RawParallel        yaml.Node         `yaml:"parallel"`
+}
+
+// IsBackground returns true if the step runs asynchronously while the job
+// continues with the next step
+func (s *Step) IsBackground() bool {
+	background, _ := strconv.ParseBool(s.Background)
+	return background
+}
+
+// Wait returns the ids of the background steps a `wait` step waits for
+func (s *Step) Wait() []string {
+	switch s.RawWait.Kind {
+	case yaml.ScalarNode:
+		var id string
+		if !decodeNode(s.RawWait, &id) || id == "" {
+			return nil
+		}
+		return []string{id}
+	case yaml.SequenceNode:
+		var ids []string
+		if !decodeNode(s.RawWait, &ids) {
+			return nil
+		}
+		return ids
+	}
+	return nil
+}
+
+// IsBackgroundControl returns true for `wait`, `wait-all` and `cancel` steps
+// that synchronize with or stop background steps
+func (s *Step) IsBackgroundControl() bool {
+	stepType := s.Type()
+	return stepType == StepTypeWait || stepType == StepTypeWaitAll || stepType == StepTypeCancel
+}
+
+// ParallelSteps returns the nested steps of a `parallel` step group
+func (s *Step) ParallelSteps() []*Step {
+	if s.RawParallel.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var steps []*Step
+	if !decodeNode(s.RawParallel, &steps) {
+		return nil
+	}
+	return steps
 }
 
 // String gets the name of step
@@ -590,6 +640,14 @@ func (s *Step) String() string {
 		return s.Uses
 	} else if s.Run != "" {
 		return s.Run
+	} else if s.RawWait.Kind != 0 {
+		return fmt.Sprintf("wait: %s", strings.Join(s.Wait(), ", "))
+	} else if s.RawWaitAll.Kind != 0 {
+		return "wait-all"
+	} else if s.Cancel != "" {
+		return fmt.Sprintf("cancel: %s", s.Cancel)
+	} else if s.RawParallel.Kind != 0 {
+		return "parallel"
 	}
 	return s.ID
 }
@@ -665,6 +723,18 @@ const (
 
 	// StepTypeInvalid is for steps that have invalid step action
 	StepTypeInvalid
+
+	// StepTypeWait is a step with a `wait` attribute that waits for one or more background steps
+	StepTypeWait
+
+	// StepTypeWaitAll is a step with a `wait-all` attribute that waits for all active background steps
+	StepTypeWaitAll
+
+	// StepTypeCancel is a step with a `cancel` attribute that gracefully terminates a background step
+	StepTypeCancel
+
+	// StepTypeParallel is a step with a `parallel` attribute containing a group of steps that run concurrently
+	StepTypeParallel
 )
 
 func (s StepType) String() string {
@@ -683,12 +753,33 @@ func (s StepType) String() string {
 		return "local-reusable-workflow"
 	case StepTypeReusableWorkflowRemote:
 		return "remote-reusable-workflow"
+	case StepTypeWait:
+		return "wait"
+	case StepTypeWaitAll:
+		return "wait-all"
+	case StepTypeCancel:
+		return "cancel"
+	case StepTypeParallel:
+		return "parallel"
 	}
 	return "unknown"
 }
 
 // Type returns the type of the step
 func (s *Step) Type() StepType {
+	if s.RawWait.Kind != 0 {
+		return StepTypeWait
+	}
+	if s.RawWaitAll.Kind != 0 {
+		return StepTypeWaitAll
+	}
+	if s.Cancel != "" {
+		return StepTypeCancel
+	}
+	if s.RawParallel.Kind != 0 {
+		return StepTypeParallel
+	}
+
 	if s.Run == "" && s.Uses == "" {
 		return StepTypeInvalid
 	}

--- a/pkg/model/workflow_test.go
+++ b/pkg/model/workflow_test.go
@@ -136,6 +136,71 @@ jobs:
 	assert.Contains(t, workflow.Jobs["test2"].Container().Env["foo"], "bar")
 }
 
+func TestReadWorkflow_BackgroundSteps(t *testing.T) {
+	yaml := `
+name: background-steps
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Start server
+      id: server
+      run: npm start
+      background: true
+    - name: A uses step in the background
+      id: action
+      uses: ./actions/docker-url
+      background: true
+    - name: Not a background step
+      run: echo
+    - name: Wait for one step
+      wait: server
+    - wait: [server, action]
+    - wait-all:
+    - cancel: server
+    - parallel:
+        - name: Build frontend
+          run: npm run build:frontend
+        - id: backend
+          uses: ./actions/backend
+`
+
+	workflow, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.NoError(t, err, "read workflow should succeed")
+
+	steps := workflow.GetJob("test").Steps
+	require.Len(t, steps, 8)
+
+	assert.True(t, steps[0].IsBackground())
+	assert.Equal(t, StepTypeRun, steps[0].Type())
+	assert.True(t, steps[1].IsBackground())
+	assert.Equal(t, StepTypeUsesActionLocal, steps[1].Type())
+	assert.False(t, steps[2].IsBackground())
+
+	assert.Equal(t, StepTypeWait, steps[3].Type())
+	assert.Equal(t, []string{"server"}, steps[3].Wait())
+	assert.Equal(t, "Wait for one step", steps[3].String())
+
+	assert.Equal(t, StepTypeWait, steps[4].Type())
+	assert.Equal(t, []string{"server", "action"}, steps[4].Wait())
+	assert.Equal(t, "wait: server, action", steps[4].String())
+
+	assert.Equal(t, StepTypeWaitAll, steps[5].Type())
+	assert.Equal(t, "wait-all", steps[5].String())
+
+	assert.Equal(t, StepTypeCancel, steps[6].Type())
+	assert.Equal(t, "server", steps[6].Cancel)
+	assert.Equal(t, "cancel: server", steps[6].String())
+
+	assert.Equal(t, StepTypeParallel, steps[7].Type())
+	group := steps[7].ParallelSteps()
+	require.Len(t, group, 2)
+	assert.Equal(t, "npm run build:frontend", group[0].Run)
+	assert.Equal(t, "./actions/backend", group[1].Uses)
+}
+
 func TestReadWorkflow_ObjectContainer(t *testing.T) {
 	yaml := `
 name: local-action-docker-url

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -100,13 +100,26 @@ func execAsComposite(step actionStep) common.Executor {
 
 		// Map outputs from composite RunContext to job RunContext
 		eval := compositeRC.NewExpressionEvaluator(ctx)
+		outputs := make(map[string]string, len(action.Outputs))
 		for outputName, output := range action.Outputs {
-			rc.setOutput(ctx, map[string]string{
-				"name": outputName,
-			}, eval.Interpolate(ctx, output.Value))
+			outputs[outputName] = eval.Interpolate(ctx, output.Value)
 		}
 
-		rc.Masks = append(rc.Masks, compositeRC.Masks...)
+		for _, mask := range compositeRC.Masks {
+			rc.AddMask(mask)
+		}
+
+		stepID := step.getStepModel().ID
+		lock := rc.stepStateLock()
+		lock.Lock()
+		defer lock.Unlock()
+
+		for outputName, value := range outputs {
+			rc.setOutputForStep(ctx, stepID, map[string]string{
+				"name": outputName,
+			}, value)
+		}
+
 		rc.ExtraPath = compositeRC.ExtraPath
 		// compositeRC.Env is dirty, contains INPUT_ and merged step env, only rely on compositeRC.GlobalEnv
 		mergeIntoMap := mergeIntoMapCaseSensitive

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -34,6 +34,13 @@ func tryParseRawActionCommand(line string) (command string, kvPairs map[string]s
 }
 
 func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
+	return rc.stepCommandHandler(ctx, "")
+}
+
+// stepCommandHandler returns a line handler routing step scoped commands to
+// stepID. With an empty stepID commands are routed to the current step, which
+// is ambiguous while background steps run concurrently.
+func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) common.LineHandler {
 	logger := common.Logger(ctx)
 	resumeCommand := ""
 	return func(line string) bool {
@@ -48,6 +55,14 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		}
 		arg = unescapeCommandData(arg)
 		kvPairs = unescapeKvPairs(kvPairs)
+
+		lock := rc.stepStateLock()
+		lock.Lock()
+		defer lock.Unlock()
+		if stepID == "" {
+			stepID = rc.currentStep()
+		}
+
 		defCommandLogger := logger.WithFields(logrus.Fields{"command": command, "kvPairs": kvPairs, "arg": arg, "raw": line})
 		switch command {
 		case "set-env":
@@ -57,7 +72,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			}
 			rc.setEnv(ctx, kvPairs, arg)
 		case "set-output":
-			rc.setOutput(ctx, kvPairs, arg)
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
 		case "add-path":
 			if rc.Env["ACTIONS_ALLOW_UNSECURE_COMMANDS"] != "true" {
 				defCommandLogger.Errorf("The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsafe commands by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.")
@@ -81,7 +96,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			defCommandLogger.Infof("  \U00002699  %s", line)
 		case "save-state":
 			defCommandLogger.Infof("  \U0001f4be  %s", line)
-			rc.saveState(ctx, kvPairs, arg)
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
 		case "add-matcher":
 			defCommandLogger.Infof("  \U00002753 add-matcher %s", arg)
 		default:
@@ -111,9 +126,8 @@ func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg
 	mergeIntoMap(rc.Env, newenv)
 	mergeIntoMap(rc.GlobalEnv, newenv)
 }
-func (rc *RunContext) setOutput(ctx context.Context, kvPairs map[string]string, arg string) {
+func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPairs map[string]string, arg string) {
 	logger := common.Logger(ctx)
-	stepID := rc.CurrentStep
 	outputName := kvPairs["name"]
 	if outputMapping, ok := rc.OutputMappings[MappableOutput{StepID: stepID, OutputName: outputName}]; ok {
 		stepID = outputMapping.StepID
@@ -182,8 +196,7 @@ func unescapeKvPairs(kvPairs map[string]string) map[string]string {
 	return kvPairs
 }
 
-func (rc *RunContext) saveState(_ context.Context, kvPairs map[string]string, arg string) {
-	stepID := rc.CurrentStep
+func (rc *RunContext) saveStateForStep(_ context.Context, stepID string, kvPairs map[string]string, arg string) {
 	if stepID != "" {
 		if rc.IntraActionState == nil {
 			rc.IntraActionState = map[string]map[string]string{}

--- a/pkg/runner/container_mock_test.go
+++ b/pkg/runner/container_mock_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
@@ -13,6 +14,14 @@ type containerMock struct {
 	mock.Mock
 	container.Container
 	container.LinuxContainerEnvironmentExtensions
+}
+
+// matchCmdFile matches a runner file command path regardless of the unique
+// per step directory it is placed in
+func matchCmdFile(name string) interface{} {
+	return mock.MatchedBy(func(path string) bool {
+		return strings.HasPrefix(path, "/var/run/act/workflow/") && strings.HasSuffix(path, "/"+name)
+	})
 }
 
 func (cm *containerMock) Create(capAdd []string, capDrop []string) common.Executor {

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -33,11 +33,16 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		return nil
 	})
 
-	infoSteps := info.steps()
+	infoSteps, expandErr := expandParallelStepGroups(info.steps())
+	if expandErr != nil {
+		return common.NewErrorExecutor(expandErr)
+	}
 
 	if len(infoSteps) == 0 {
 		return common.NewDebugExecutor("No steps found")
 	}
+
+	backgroundSteps := newBackgroundStepRegistry()
 
 	preSteps = append(preSteps, func(ctx context.Context) error {
 		// Have to be skipped for some Tests
@@ -73,6 +78,13 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			stepModel.ID = fmt.Sprintf("%d", i)
 		}
 
+		if stepModel.IsBackgroundControl() {
+			// wait, wait-all and cancel steps always run, they are not
+			// skipped when a previous step failed and have no pre/post stage
+			steps = append(steps, newControlStepExecutor(rc, backgroundSteps, stepModel, setJobError))
+			continue
+		}
+
 		step, err := sf.newStep(stepModel, rc)
 
 		if err != nil {
@@ -81,16 +93,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 
 		preSteps = append(preSteps, useStepLogger(rc, stepModel, stepStagePre, step.pre().ThenError(setJobError)))
 
-		stepExec := step.main()
-		steps = append(steps, useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
-			err := stepExec(ctx)
-			if err != nil {
-				_ = setJobError(ctx, err)
-			} else if ctx.Err() != nil {
-				_ = setJobError(ctx, ctx.Err())
-			}
-			return nil
-		}))
+		steps = append(steps, newMainStepExecutor(rc, backgroundSteps, stepModel, step.main(), setJobError))
 
 		postExec := useStepLogger(rc, stepModel, stepStagePost, step.post().ThenError(setJobError))
 		if postExecutor != nil {
@@ -135,6 +138,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 				Then(common.NewFieldExecutor("stepResult", model.StepStatusSuccess, common.NewInfoExecutor("  \u2705  Success - Set up job"))).
 				ThenError(setJobError).OnError(common.NewFieldExecutor("stepResult", model.StepStatusFailure, common.NewInfoExecutor("  \u274C  Failure - Set up job"))))),
 		common.NewPipelineExecutor(pipeline...).
+			Finally(backgroundSteps.cancelRemaining()).
 			Finally(func(ctx context.Context) error { //nolint:contextcheck
 				var cancel context.CancelFunc
 				if ctx.Err() == context.Canceled {
@@ -202,7 +206,7 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 		ctx = withStepLogger(ctx, stepModel.ID, rc.ExprEval.Interpolate(ctx, stepModel.String()), stage.String())
 
 		rawLogger := common.Logger(ctx).WithField("raw_output", true)
-		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+		logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, stepModel.ID), func(s string) bool {
 			if rc.Config.LogOutput {
 				rawLogger.Infof("%s", s)
 			} else {

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -41,6 +41,11 @@ type masksContextKey string
 
 const masksContextKeyVal = masksContextKey("logrus.FieldLogger")
 
+// masksMutex guards the masks slices of all jobs, they are appended to by
+// running steps and read whenever a log line is formatted. With background
+// steps both can happen concurrently.
+var masksMutex sync.RWMutex
+
 // Logger returns the appropriate logger for current context
 func Masks(ctx context.Context) *[]string {
 	val := ctx.Value(masksContextKeyVal)
@@ -153,7 +158,9 @@ func valueMasker(insecureSecrets bool, secrets map[string]string) entryProcessor
 			return entry
 		}
 
-		masks := Masks(entry.Context)
+		masksMutex.RLock()
+		masks := append([]string{}, *Masks(entry.Context)...)
+		masksMutex.RUnlock()
 
 		for _, v := range ssecrets {
 			if v != "" {
@@ -161,7 +168,7 @@ func valueMasker(insecureSecrets bool, secrets map[string]string) entryProcessor
 			}
 		}
 
-		for _, v := range *masks {
+		for _, v := range masks {
 			if v != "" {
 				entry.Message = strings.ReplaceAll(entry.Message, v, "***")
 			}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/go-connections/nat"
@@ -53,9 +54,43 @@ type RunContext struct {
 	caller              *caller // job calling this RunContext (reusable workflows)
 	Cancelled           bool
 	nodeToolFullPath    string
+
+	// stepStateMu serializes mutations of the shared job state (StepResults,
+	// Env, ExtraPath, ...) between steps running concurrently because of
+	// `background: true`
+	stepStateMu sync.Mutex
+
+	// currentStepMu guards CurrentStep, which is also read while steps run
+	// concurrently in the background
+	currentStepMu sync.RWMutex
+}
+
+func (rc *RunContext) setCurrentStep(stepID string) {
+	rc.currentStepMu.Lock()
+	defer rc.currentStepMu.Unlock()
+	rc.CurrentStep = stepID
+}
+
+func (rc *RunContext) currentStep() string {
+	rc.currentStepMu.RLock()
+	defer rc.currentStepMu.RUnlock()
+	return rc.CurrentStep
+}
+
+// stepStateLock returns the mutex guarding the shared job state. Composite
+// action steps share the lock of their root RunContext since they mutate
+// state of their parents.
+func (rc *RunContext) stepStateLock() *sync.Mutex {
+	root := rc
+	for root.Parent != nil {
+		root = root.Parent
+	}
+	return &root.stepStateMu
 }
 
 func (rc *RunContext) AddMask(mask string) {
+	masksMutex.Lock()
+	defer masksMutex.Unlock()
 	rc.Masks = append(rc.Masks, mask)
 }
 
@@ -85,7 +120,9 @@ func (rc *RunContext) GetEnv() map[string]string {
 			}
 		}
 	}
-	rc.Env["ACT"] = "true"
+	if rc.Env["ACT"] != "true" {
+		rc.Env["ACT"] = "true"
+	}
 	return rc.Env
 }
 
@@ -888,7 +925,7 @@ func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext
 		RunNumber:        rc.Config.Env["GITHUB_RUN_NUMBER"],
 		Actor:            rc.Config.Actor,
 		EventName:        rc.Config.EventName,
-		Action:           rc.CurrentStep,
+		Action:           rc.currentStep(),
 		Token:            rc.Config.Token,
 		Job:              rc.Run.JobID,
 		ActionPath:       rc.ActionPath,

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -281,6 +281,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "matrix", "push", "", platforms, secrets},
 		{workdir, "matrix-include-exclude", "push", "", platforms, secrets},
 		{workdir, "matrix-exitcode", "push", "Job 'test' failed", platforms, secrets},
+		{workdir, "background-steps-container", "push", "", platforms, secrets},
 		{workdir, "commands", "push", "", platforms, secrets},
 		{workdir, "workdir", "push", "", platforms, secrets},
 		{workdir, "defaults-run", "push", "", platforms, secrets},

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nektos/act/pkg/common"
@@ -91,14 +92,25 @@ func processRunnerEnvFileCommand(ctx context.Context, fileName string, rc *RunCo
 	return nil
 }
 
+// stepFileCommandSeq makes the runner file command paths unique per step
+// execution, so steps running concurrently because of `background: true` do
+// not read each other's commands
+var stepFileCommandSeq atomic.Int64
+
 func runStepExecutor(step step, stage stepStage, executor common.Executor) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
 		rc := step.getRunContext()
 		stepModel := step.getStepModel()
 
+		// the shared job state is locked during the setup and the result
+		// processing of the step, but not while the step itself runs, so
+		// background steps run concurrently with other steps
+		lock := rc.stepStateLock()
+		lock.Lock()
+
 		ifExpression := step.getIfExpression(ctx, stage)
-		rc.CurrentStep = stepModel.ID
+		rc.setCurrentStep(stepModel.ID)
 
 		stepResult := &model.StepResult{
 			Outcome:    model.StepStatusSuccess,
@@ -106,11 +118,12 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			Outputs:    make(map[string]string),
 		}
 		if stage == stepStageMain {
-			rc.StepResults[rc.CurrentStep] = stepResult
+			rc.StepResults[stepModel.ID] = stepResult
 		}
 
 		err := setupEnv(ctx, step)
 		if err != nil {
+			lock.Unlock()
 			return err
 		}
 
@@ -121,6 +134,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		if err != nil {
 			stepResult.Conclusion = model.StepStatusFailure
 			stepResult.Outcome = model.StepStatusFailure
+			lock.Unlock()
 			return err
 		}
 
@@ -128,6 +142,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			stepResult.Conclusion = model.StepStatusSkipped
 			stepResult.Outcome = model.StepStatusSkipped
 			logger.WithField("stepResult", stepResult.Outcome).Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
+			lock.Unlock()
 			return nil
 		}
 
@@ -139,20 +154,21 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 
 		// Prepare and clean Runner File Commands
 		actPath := rc.JobContainer.GetActPath()
+		cmdDir := path.Join("workflow", fmt.Sprintf("cmds-%d-%s", stepFileCommandSeq.Add(1), stage.String()))
 
-		outputFileCommand := path.Join("workflow", "outputcmd.txt")
+		outputFileCommand := path.Join(cmdDir, "outputcmd.txt")
 		(*step.getEnv())["GITHUB_OUTPUT"] = path.Join(actPath, outputFileCommand)
 
-		stateFileCommand := path.Join("workflow", "statecmd.txt")
+		stateFileCommand := path.Join(cmdDir, "statecmd.txt")
 		(*step.getEnv())["GITHUB_STATE"] = path.Join(actPath, stateFileCommand)
 
-		pathFileCommand := path.Join("workflow", "pathcmd.txt")
+		pathFileCommand := path.Join(cmdDir, "pathcmd.txt")
 		(*step.getEnv())["GITHUB_PATH"] = path.Join(actPath, pathFileCommand)
 
-		envFileCommand := path.Join("workflow", "envs.txt")
+		envFileCommand := path.Join(cmdDir, "envs.txt")
 		(*step.getEnv())["GITHUB_ENV"] = path.Join(actPath, envFileCommand)
 
-		summaryFileCommand := path.Join("workflow", "SUMMARY.md")
+		summaryFileCommand := path.Join(cmdDir, "SUMMARY.md")
 		(*step.getEnv())["GITHUB_STEP_SUMMARY"] = path.Join(actPath, summaryFileCommand)
 
 		_ = rc.JobContainer.Copy(actPath, &container.FileEntry{
@@ -172,15 +188,22 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			Mode: 0o666,
 		})(ctx)
 
+		timeout := rc.ExprEval.Interpolate(ctx, stepModel.TimeoutMinutes)
+		lock.Unlock()
+
 		stepCtx, cancelStepCtx := context.WithCancel(ctx)
 		defer cancelStepCtx()
 		var cancelTimeOut context.CancelFunc
-		stepCtx, cancelTimeOut = evaluateStepTimeout(stepCtx, rc.ExprEval, stepModel)
+		stepCtx, cancelTimeOut = evaluateStepTimeout(stepCtx, timeout)
 		defer cancelTimeOut()
 		monitorJobCancellation(ctx, stepCtx, cctx, rc, logger, ifExpression, step, stage, cancelStepCtx)
 		startTime := time.Now()
 		err = executor(stepCtx)
 		executionTime := time.Since(startTime)
+
+		lock.Lock()
+		defer lock.Unlock()
+		rc.setCurrentStep(stepModel.ID)
 
 		if err == nil {
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u2705  Success - %s %s [%s]", stage, stepString, executionTime)
@@ -204,10 +227,15 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u274C  Failure - %s %s [%s]", stage, stepString, executionTime)
 		}
 		// Process Runner File Commands
+		stepID := stepModel.ID
 		ferrors := []error{err}
 		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, envFileCommand, rc, rc.setEnv))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, rc.saveState))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, rc.setOutput))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
+		}))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
+		}))
 		ferrors = append(ferrors, processRunnerSummaryCommand(ctx, summaryFileCommand, rc))
 		ferrors = append(ferrors, rc.UpdateExtraPath(ctx, path.Join(actPath, pathFileCommand)))
 		return errors.Join(ferrors...)
@@ -219,9 +247,12 @@ func monitorJobCancellation(ctx context.Context, stepCtx context.Context, jobCan
 		go func() {
 			select {
 			case <-jobCancellationCtx.Done():
+				lock := rc.stepStateLock()
+				lock.Lock()
 				rc.Cancelled = true
 				logger.Infof("Reevaluate condition %v due to cancellation", ifExpression)
 				keepStepRunning, err := isStepEnabled(ctx, ifExpression, step, stage)
+				lock.Unlock()
 				logger.Infof("Result condition keepStepRunning=%v", keepStepRunning)
 				if !keepStepRunning || err != nil {
 					cancelStepCtx()
@@ -232,8 +263,7 @@ func monitorJobCancellation(ctx context.Context, stepCtx context.Context, jobCan
 	}
 }
 
-func evaluateStepTimeout(ctx context.Context, exprEval ExpressionEvaluator, stepModel *model.Step) (context.Context, context.CancelFunc) {
-	timeout := exprEval.Interpolate(ctx, stepModel.TimeoutMinutes)
+func evaluateStepTimeout(ctx context.Context, timeout string) (context.Context, context.CancelFunc) {
 	if timeout != "" {
 		if timeOutMinutes, err := strconv.ParseInt(timeout, 10, 64); err == nil {
 			return context.WithTimeout(ctx, time.Duration(timeOutMinutes)*time.Minute)

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -73,20 +73,20 @@ func TestStepActionLocalTest(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	salm.On("runAction", sal, filepath.Clean("/tmp/path/to/action"), (*remoteAction)(nil)).Return(func(_ context.Context) error {
 		return nil
@@ -270,20 +270,20 @@ func TestStepActionLocalPost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sal.post()(ctx)

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -175,20 +175,20 @@ func TestStepActionRemote(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.pre()(ctx)
@@ -588,20 +588,20 @@ func TestStepActionRemotePost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.post()(ctx)

--- a/pkg/runner/step_background.go
+++ b/pkg/runner/step_background.go
@@ -1,0 +1,343 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/exprparser"
+	"github.com/nektos/act/pkg/model"
+)
+
+// maxConcurrentBackgroundSteps limits how many background steps of a job run
+// at the same time, additional background steps queue until a slot is free
+const maxConcurrentBackgroundSteps = 10
+
+// backgroundStep tracks one running background step of a job
+type backgroundStep struct {
+	id     string
+	done   chan struct{}
+	cancel context.CancelFunc
+
+	mu        sync.Mutex
+	err       error
+	cancelled bool
+	collected bool
+}
+
+// markCancelled gracefully terminates the step, a deliberately cancelled
+// step does not fail the job
+func (bs *backgroundStep) markCancelled() {
+	bs.mu.Lock()
+	bs.cancelled = true
+	bs.mu.Unlock()
+	bs.cancel()
+}
+
+func (bs *backgroundStep) setError(err error) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if !bs.cancelled {
+		bs.err = err
+	}
+}
+
+// takeError returns the failure of the step the first time it is called, so
+// a background step fails the job only at the first `wait` that includes it
+func (bs *backgroundStep) takeError() error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if bs.cancelled || bs.collected {
+		return nil
+	}
+	bs.collected = true
+	return bs.err
+}
+
+func (bs *backgroundStep) running() bool {
+	select {
+	case <-bs.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// backgroundStepRegistry tracks the background steps of one job execution
+type backgroundStepRegistry struct {
+	mu    sync.Mutex
+	slots chan struct{}
+	steps map[string]*backgroundStep
+	order []*backgroundStep
+}
+
+func newBackgroundStepRegistry() *backgroundStepRegistry {
+	return &backgroundStepRegistry{
+		slots: make(chan struct{}, maxConcurrentBackgroundSteps),
+		steps: map[string]*backgroundStep{},
+	}
+}
+
+func (r *backgroundStepRegistry) get(id string) *backgroundStep {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.steps[id]
+}
+
+func (r *backgroundStepRegistry) all() []*backgroundStep {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*backgroundStep{}, r.order...)
+}
+
+// launch starts executor asynchronously as a background step and returns as
+// soon as it is registered, the step waits for one of the limited background
+// slots before it runs
+func (r *backgroundStepRegistry) launch(ctx context.Context, id string, executor common.Executor) {
+	stepCtx, cancel := context.WithCancel(ctx)
+	bs := &backgroundStep{id: id, done: make(chan struct{}), cancel: cancel}
+
+	r.mu.Lock()
+	r.steps[id] = bs
+	r.order = append(r.order, bs)
+	r.mu.Unlock()
+
+	go func() {
+		defer close(bs.done)
+		defer cancel()
+		select {
+		case r.slots <- struct{}{}:
+		case <-stepCtx.Done():
+			bs.setError(stepCtx.Err())
+			return
+		}
+		defer func() { <-r.slots }()
+		bs.setError(executor(stepCtx))
+	}()
+}
+
+func (r *backgroundStepRegistry) waitFor(ctx context.Context, bs *backgroundStep) error {
+	select {
+	case <-bs.done:
+		return bs.takeError()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// cancelRemaining stops background steps that are still running when the job
+// ends, like services started with `background: true` that were never waited
+// for, their results do not affect the job result
+func (r *backgroundStepRegistry) cancelRemaining() common.Executor {
+	return func(ctx context.Context) error {
+		logger := common.Logger(ctx)
+		for _, bs := range r.all() {
+			if bs.running() {
+				logger.Infof("\U0001F6D1  Stopping background step '%s' still running at the end of the job", bs.id)
+				bs.markCancelled()
+			}
+		}
+		for _, bs := range r.all() {
+			select {
+			case <-bs.done:
+			case <-time.After(time.Minute):
+				logger.Errorf("Background step '%s' did not stop in time", bs.id)
+			}
+		}
+		return nil
+	}
+}
+
+// expandParallelStepGroups desugars every `parallel` step group into
+// background steps followed by an implicit `wait` for the whole group
+func expandParallelStepGroups(steps []*model.Step) ([]*model.Step, error) {
+	expanded := make([]*model.Step, 0, len(steps))
+	for _, stepModel := range steps {
+		if stepModel == nil || stepModel.Type() != model.StepTypeParallel {
+			expanded = append(expanded, stepModel)
+			continue
+		}
+		group := stepModel.ParallelSteps()
+		if len(group) == 0 {
+			return nil, fmt.Errorf("parallel step group '%s' contains no steps", stepModel.String())
+		}
+		ids := make([]string, 0, len(group))
+		for i, child := range group {
+			if child == nil {
+				return nil, fmt.Errorf("invalid step %d in parallel step group '%s': missing run or uses key", i, stepModel.String())
+			}
+			if child.ID == "" {
+				child.ID = fmt.Sprintf("%d", len(expanded))
+			}
+			child.Background = "true"
+			ids = append(ids, child.ID)
+			expanded = append(expanded, child)
+		}
+		wait := &model.Step{
+			ID:   stepModel.ID,
+			Name: fmt.Sprintf("Wait for parallel steps (%s)", strings.Join(ids, ", ")),
+		}
+		wait.RawWait.Kind = yaml.SequenceNode
+		wait.RawWait.Tag = "!!seq"
+		for _, id := range ids {
+			wait.RawWait.Content = append(wait.RawWait.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: id})
+		}
+		expanded = append(expanded, wait)
+	}
+	return expanded, nil
+}
+
+// newMainStepExecutor returns the main stage executor of a regular step.
+// Steps with `background: true` are only started and the job continues with
+// the next step right away, their failures surface at the next `wait` or
+// `wait-all` step that includes them.
+func newMainStepExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step, stepExec common.Executor, setJobError func(context.Context, error) error) common.Executor {
+	if stepModel.IsBackground() {
+		backgroundExec := useStepLogger(rc, stepModel, stepStageMain, stepExec)
+		stepID := stepModel.ID
+		stepName := stepModel.String()
+		return func(ctx context.Context) error {
+			common.Logger(ctx).Infof("⏩ Starting background step '%s'", stepName)
+			registry.launch(ctx, stepID, backgroundExec)
+			return nil
+		}
+	}
+	return useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
+		err := stepExec(ctx)
+		if err != nil {
+			_ = setJobError(ctx, err)
+		} else if ctx.Err() != nil {
+			_ = setJobError(ctx, ctx.Err())
+		}
+		return nil
+	})
+}
+
+// newControlStepExecutor runs a `wait`, `wait-all` or `cancel` step. These
+// steps always run, even when a previous step failed, and do not support the
+// `if` conditional.
+func newControlStepExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step, setJobError func(context.Context, error) error) common.Executor {
+	controlExec := newBackgroundControlExecutor(rc, registry, stepModel)
+	return useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
+		err := controlExec(ctx)
+		if err != nil {
+			_ = setJobError(ctx, err)
+		} else if ctx.Err() != nil {
+			_ = setJobError(ctx, ctx.Err())
+		}
+		return nil
+	})
+}
+
+func newBackgroundControlExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step) common.Executor {
+	return func(ctx context.Context) error {
+		logger := common.Logger(ctx)
+
+		stepResult := &model.StepResult{
+			Outcome:    model.StepStatusSuccess,
+			Conclusion: model.StepStatusSuccess,
+			Outputs:    make(map[string]string),
+		}
+		lock := rc.stepStateLock()
+		lock.Lock()
+		rc.StepResults[stepModel.ID] = stepResult
+		lock.Unlock()
+
+		logger.Infof("⭐ Run %s", stepModel.String())
+
+		var err error
+		switch stepModel.Type() {
+		case model.StepTypeWait:
+			err = runWaitStep(ctx, registry, stepModel)
+		case model.StepTypeWaitAll:
+			err = runWaitAllStep(ctx, registry)
+		case model.StepTypeCancel:
+			err = runCancelStep(ctx, registry, stepModel)
+		default:
+			err = fmt.Errorf("step '%s' is not a background control step", stepModel.ID)
+		}
+
+		if err == nil {
+			logger.WithField("stepResult", stepResult.Outcome).Infof("  ✅  Success - %s", stepModel.String())
+			return nil
+		}
+
+		stepResult.Outcome = model.StepStatusFailure
+		continueOnError, parseErr := evalStepContinueOnError(ctx, rc, stepModel)
+		if parseErr != nil {
+			stepResult.Conclusion = model.StepStatusFailure
+			return parseErr
+		}
+		if continueOnError {
+			logger.Infof("Failed but continue next step")
+			logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
+			return nil
+		}
+		stepResult.Conclusion = model.StepStatusFailure
+		logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
+		return err
+	}
+}
+
+func runWaitStep(ctx context.Context, registry *backgroundStepRegistry, stepModel *model.Step) error {
+	ids := stepModel.Wait()
+	if len(ids) == 0 {
+		return fmt.Errorf("wait step '%s' does not reference any background step", stepModel.ID)
+	}
+	var errs []error
+	for _, id := range ids {
+		bs := registry.get(id)
+		if bs == nil {
+			errs = append(errs, fmt.Errorf("'%s' is not a background step", id))
+			continue
+		}
+		common.Logger(ctx).Infof("⏸  Waiting for background step '%s'", id)
+		if err := registry.waitFor(ctx, bs); err != nil {
+			errs = append(errs, fmt.Errorf("background step '%s' failed: %w", id, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func runWaitAllStep(ctx context.Context, registry *backgroundStepRegistry) error {
+	var errs []error
+	for _, bs := range registry.all() {
+		common.Logger(ctx).Infof("⏸  Waiting for background step '%s'", bs.id)
+		if err := registry.waitFor(ctx, bs); err != nil {
+			errs = append(errs, fmt.Errorf("background step '%s' failed: %w", bs.id, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func runCancelStep(ctx context.Context, registry *backgroundStepRegistry, stepModel *model.Step) error {
+	bs := registry.get(stepModel.Cancel)
+	if bs == nil {
+		return fmt.Errorf("'%s' is not a background step", stepModel.Cancel)
+	}
+	common.Logger(ctx).Infof("\U0001F6D1  Cancelling background step '%s'", bs.id)
+	bs.markCancelled()
+	select {
+	case <-bs.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func evalStepContinueOnError(ctx context.Context, rc *RunContext, stepModel *model.Step) (bool, error) {
+	if stepModel.RawContinueOnError == "" {
+		return false, nil
+	}
+	continueOnError, err := EvalBool(ctx, rc.NewExpressionEvaluator(ctx), stepModel.RawContinueOnError, exprparser.DefaultStatusCheckNone)
+	if err != nil {
+		return false, fmt.Errorf("  ❌  Error in continue-on-error-expression: \"continue-on-error: %s\" (%s)", stepModel.RawContinueOnError, err)
+	}
+	return continueOnError, nil
+}

--- a/pkg/runner/step_background_test.go
+++ b/pkg/runner/step_background_test.go
@@ -1,0 +1,151 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nektos/act/pkg/model"
+)
+
+func TestExpandParallelStepGroups(t *testing.T) {
+	workflow, err := model.ReadWorkflow(strings.NewReader(`
+name: parallel
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo before
+      - parallel:
+          - name: Build a
+            run: echo a
+          - name: Build b
+            id: build-b
+            run: echo b
+      - run: echo after
+`), false)
+	require.NoError(t, err)
+
+	steps, err := expandParallelStepGroups(workflow.GetJob("test").Steps)
+	require.NoError(t, err)
+	require.Len(t, steps, 5)
+
+	assert.Equal(t, "echo before", steps[0].Run)
+
+	assert.Equal(t, "echo a", steps[1].Run)
+	assert.True(t, steps[1].IsBackground())
+	assert.Equal(t, "1", steps[1].ID)
+
+	assert.Equal(t, "echo b", steps[2].Run)
+	assert.True(t, steps[2].IsBackground())
+	assert.Equal(t, "build-b", steps[2].ID)
+
+	assert.Equal(t, model.StepTypeWait, steps[3].Type())
+	assert.Equal(t, []string{"1", "build-b"}, steps[3].Wait())
+
+	assert.Equal(t, "echo after", steps[4].Run)
+}
+
+func runBackgroundStepsWorkflow(t *testing.T, workflowPath string, markerDir string) (*model.Plan, error) {
+	t.Helper()
+
+	log.SetLevel(logLevel)
+
+	absWorkdir, err := filepath.Abs(workdir)
+	require.NoError(t, err)
+
+	config := &Config{
+		Workdir:        absWorkdir,
+		EventName:      "push",
+		Platforms:      map[string]string{"self-hosted": "-self-hosted"},
+		GitHubInstance: "github.com",
+		Env:            map[string]string{"MARKER_DIR": markerDir},
+	}
+	runner, err := New(config)
+	require.NoError(t, err)
+
+	planner, err := model.NewWorkflowPlanner(filepath.Join(absWorkdir, workflowPath), true, false)
+	require.NoError(t, err)
+	plan, err := planner.PlanEvent("push")
+	require.NoError(t, err)
+
+	return plan, runner.NewPlanExecutor(plan)(context.Background())
+}
+
+func backgroundStepsWorkflowName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + "-windows"
+	}
+	return name
+}
+
+func markerModTime(t *testing.T, dir string, name string) time.Time {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(dir, name))
+	require.NoError(t, err, "marker file %s should exist", name)
+	return info.ModTime()
+}
+
+func TestRunBackgroundSteps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	markerDir := filepath.ToSlash(t.TempDir())
+	plan, err := runBackgroundStepsWorkflow(t, backgroundStepsWorkflowName("background-steps"), markerDir)
+	assert.NoError(t, err)
+
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			assert.Equal(t, "success", run.Job().Result, "job %s should have succeeded", run.String())
+		}
+	}
+
+	// the next step ran while the background step was still sleeping
+	workStart := markerModTime(t, markerDir, "work-start")
+	serviceEnd := markerModTime(t, markerDir, "service-end")
+	assert.True(t, workStart.Before(serviceEnd),
+		"the step after a background step must not wait for it (work started %v, service ended %v)", workStart, serviceEnd)
+
+	// both steps of the parallel group overlapped and the following step ran
+	// after the implicit wait for the whole group
+	aStart := markerModTime(t, markerDir, "a-start")
+	aEnd := markerModTime(t, markerDir, "a-end")
+	bStart := markerModTime(t, markerDir, "b-start")
+	bEnd := markerModTime(t, markerDir, "b-end")
+	assert.True(t, aStart.Before(bEnd) && bStart.Before(aEnd),
+		"steps of a parallel group must run concurrently (a: %v - %v, b: %v - %v)", aStart, aEnd, bStart, bEnd)
+	afterParallel := markerModTime(t, markerDir, "after-parallel")
+	assert.False(t, afterParallel.Before(aEnd), "the step after a parallel group must run after all steps of the group")
+	assert.False(t, afterParallel.Before(bEnd), "the step after a parallel group must run after all steps of the group")
+
+	// the quick background step completed even though the monitor was cancelled
+	assert.FileExists(t, filepath.Join(markerDir, "quick-done"))
+}
+
+func TestRunBackgroundStepFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	plan, err := runBackgroundStepsWorkflow(t, backgroundStepsWorkflowName("background-steps-fail"), filepath.ToSlash(t.TempDir()))
+	assert.ErrorContains(t, err, "Job 'fail-at-wait' failed")
+
+	results := map[string]string{}
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			results[run.JobID] = run.Job().Result
+		}
+	}
+	assert.Equal(t, "failure", results["fail-at-wait"], "a failing background step must fail the job at the wait step")
+	assert.Equal(t, "success", results["continue-on-error"], "continue-on-error on a background step must swallow its failure")
+}

--- a/pkg/runner/step_docker_test.go
+++ b/pkg/runner/step_docker_test.go
@@ -81,20 +81,20 @@ func TestStepDockerMain(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sd.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/step_run.go
+++ b/pkg/runner/step_run.go
@@ -88,7 +88,7 @@ func (sr *stepRun) setupShellCommandExecutor() common.Executor {
 func getScriptName(rc *RunContext, step *model.Step) string {
 	scriptName := step.ID
 	for rcs := rc; rcs.Parent != nil; rcs = rcs.Parent {
-		scriptName = fmt.Sprintf("%s-composite-%s", rcs.Parent.CurrentStep, scriptName)
+		scriptName = fmt.Sprintf("%s-composite-%s", rcs.Parent.currentStep(), scriptName)
 	}
 	return fmt.Sprintf("workflow/%s", scriptName)
 }

--- a/pkg/runner/step_run_test.go
+++ b/pkg/runner/step_run_test.go
@@ -60,22 +60,22 @@ func TestStepRun(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
 	ctx := context.Background()
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sr.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/testdata/background-steps-container/push.yml
+++ b/pkg/runner/testdata/background-steps-container/push.yml
@@ -1,0 +1,28 @@
+name: background-steps-container
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Background step
+        id: bg
+        run: |
+          echo "value=from-background" >> "$GITHUB_OUTPUT"
+          sleep 1
+          touch /tmp/bg-done
+        background: true
+      - run: echo main work
+      - wait: bg
+      - name: Outputs are available after the wait
+        run: |
+          [ "${{ steps.bg.outputs.value }}" = "from-background" ]
+          [ -f /tmp/bg-done ]
+      - parallel:
+          - run: sleep 1 && echo a
+          - run: sleep 1 && echo b
+      - name: Long running monitor
+        id: monitor
+        run: sleep 60
+        background: true
+      - cancel: monitor
+      - wait-all:

--- a/pkg/runner/testdata/background-steps-fail-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-fail-windows/push.yml
@@ -1,0 +1,27 @@
+name: background-steps-fail
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  fail-at-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step
+        id: failing
+        run: exit 1
+        background: true
+      - name: Still runs before the failure surfaces
+        run: echo ok
+      - name: The job fails here
+        wait: failing
+  continue-on-error:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step with continue-on-error
+        id: failing
+        run: exit 1
+        background: true
+        continue-on-error: true
+      - name: Does not fail the job
+        wait: failing

--- a/pkg/runner/testdata/background-steps-fail/push.yml
+++ b/pkg/runner/testdata/background-steps-fail/push.yml
@@ -1,0 +1,27 @@
+name: background-steps-fail
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  fail-at-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step
+        id: failing
+        run: exit 1
+        background: true
+      - name: Still runs before the failure surfaces
+        run: echo ok
+      - name: The job fails here
+        wait: failing
+  continue-on-error:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step with continue-on-error
+        id: failing
+        run: exit 1
+        background: true
+        continue-on-error: true
+      - name: Does not fail the job
+        wait: failing

--- a/pkg/runner/testdata/background-steps-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-windows/push.yml
@@ -1,0 +1,58 @@
+name: background-steps
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  background-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Start background service
+        id: service
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "value=from-background"
+          New-Item -ItemType File -Path "$env:MARKER_DIR/service-start" | Out-Null
+          Start-Sleep -Seconds 2
+          New-Item -ItemType File -Path "$env:MARKER_DIR/service-end" | Out-Null
+        background: true
+      - name: Work while the service runs
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/work-start" | Out-Null
+      - name: Wait for the service
+        wait: service
+      - name: Outputs of the service are available after the wait
+        run: |
+          if ("${{ steps.service.outputs.value }}" -ne "from-background") { exit 1 }
+          if (-not (Test-Path "$env:MARKER_DIR/service-end")) { exit 1 }
+  parallel-group:
+    runs-on: self-hosted
+    steps:
+      - parallel:
+          - name: Build a
+            id: build-a
+            run: |
+              New-Item -ItemType File -Path "$env:MARKER_DIR/a-start" | Out-Null
+              Start-Sleep -Seconds 2
+              New-Item -ItemType File -Path "$env:MARKER_DIR/a-end" | Out-Null
+          - name: Build b
+            id: build-b
+            run: |
+              New-Item -ItemType File -Path "$env:MARKER_DIR/b-start" | Out-Null
+              Start-Sleep -Seconds 2
+              New-Item -ItemType File -Path "$env:MARKER_DIR/b-end" | Out-Null
+      - name: Runs after the whole group
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/after-parallel" | Out-Null
+  cancel-and-wait-all:
+    runs-on: self-hosted
+    steps:
+      - name: Long running monitor
+        id: monitor
+        run: Start-Sleep -Seconds 60
+        background: true
+      - name: Quick background work
+        id: quick
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/quick-done" | Out-Null
+        background: true
+      - name: Stop the monitor
+        cancel: monitor
+      - name: Wait for the rest
+        wait-all:

--- a/pkg/runner/testdata/background-steps/push.yml
+++ b/pkg/runner/testdata/background-steps/push.yml
@@ -1,0 +1,58 @@
+name: background-steps
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  background-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Start background service
+        id: service
+        run: |
+          echo "value=from-background" >> "$GITHUB_OUTPUT"
+          touch "$MARKER_DIR/service-start"
+          sleep 2
+          touch "$MARKER_DIR/service-end"
+        background: true
+      - name: Work while the service runs
+        run: touch "$MARKER_DIR/work-start"
+      - name: Wait for the service
+        wait: service
+      - name: Outputs of the service are available after the wait
+        run: |
+          [ "${{ steps.service.outputs.value }}" = "from-background" ]
+          [ -f "$MARKER_DIR/service-end" ]
+  parallel-group:
+    runs-on: self-hosted
+    steps:
+      - parallel:
+          - name: Build a
+            id: build-a
+            run: |
+              touch "$MARKER_DIR/a-start"
+              sleep 2
+              touch "$MARKER_DIR/a-end"
+          - name: Build b
+            id: build-b
+            run: |
+              touch "$MARKER_DIR/b-start"
+              sleep 2
+              touch "$MARKER_DIR/b-end"
+      - name: Runs after the whole group
+        run: touch "$MARKER_DIR/after-parallel"
+  cancel-and-wait-all:
+    runs-on: self-hosted
+    steps:
+      - name: Long running monitor
+        id: monitor
+        run: sleep 60
+        background: true
+      - name: Quick background work
+        id: quick
+        run: touch "$MARKER_DIR/quick-done"
+        background: true
+      - name: Stop the monitor
+        cancel: monitor
+      - name: Wait for the rest
+        wait-all:

--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1710,7 +1710,7 @@
       }
     },
     "steps-item": {
-      "one-of": ["run-step", "regular-step"]
+      "one-of": ["run-step", "regular-step", "wait-step", "wait-all-step", "cancel-step", "parallel-step"]
     },
     "run-step": {
       "mapping": {
@@ -1727,7 +1727,8 @@
           "continue-on-error": "step-continue-on-error",
           "env": "step-env",
           "working-directory": "string-steps-context",
-          "shell": "shell"
+          "shell": "shell",
+          "background": "step-background"
         }
       }
     },
@@ -1744,9 +1745,87 @@
             "required": true
           },
           "with": "step-with",
-          "env": "step-env"
+          "env": "step-env",
+          "background": "step-background"
         }
       }
+    },
+    "step-background": {
+      "description": "Runs the step asynchronously so the job continues to the next step without waiting for it to finish. Use `wait`, `wait-all` or `cancel` steps to synchronize with or stop background steps. A maximum of 10 background steps run concurrently, additional background steps queue until a slot becomes available.",
+      "boolean": {}
+    },
+    "wait-step": {
+      "description": "Pauses the job until one or more background steps complete. Provide a single step id as a string or multiple ids as an array. After a `wait` step completes, the outputs of the referenced background steps become available to subsequent steps. A `wait` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait": {
+            "type": "wait-targets",
+            "required": true
+          }
+        }
+      }
+    },
+    "wait-targets": {
+      "one-of": ["non-empty-string", "wait-targets-sequence"]
+    },
+    "wait-targets-sequence": {
+      "sequence": {
+        "item-type": "non-empty-string"
+      }
+    },
+    "wait-all-step": {
+      "description": "Pauses the job until all active background steps complete. A `wait-all` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait-all": {
+            "type": "wait-all-value",
+            "required": true
+          }
+        }
+      }
+    },
+    "wait-all-value": {
+      "one-of": ["null", "boolean"]
+    },
+    "cancel-step": {
+      "description": "Gracefully terminates a running background step referenced by its id. A `cancel` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "cancel": {
+            "type": "non-empty-string",
+            "required": true
+          }
+        }
+      }
+    },
+    "parallel-step": {
+      "description": "Runs a group of steps in parallel: every step in the group runs as a background step, with an implicit `wait` at the end. Each step in the group is subject to the same 10-step concurrency limit as other background steps. You cannot use `parallel` inside a composite action.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "parallel": {
+            "type": "parallel-steps",
+            "required": true
+          }
+        }
+      }
+    },
+    "parallel-steps": {
+      "sequence": {
+        "item-type": "parallel-steps-item"
+      }
+    },
+    "parallel-steps-item": {
+      "one-of": ["run-step", "regular-step"]
     },
     "step-uses": {
       "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, or in a published Docker container image.",


### PR DESCRIPTION
Implements the concurrent step syntax GitHub [shipped on June 25, 2026](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/): `jobs.<job_id>.steps[*].background`, `wait`, `wait-all`, `cancel` and `parallel` ([reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel)). act's schema currently rejects these keys as unknown properties, so workflows using them cannot run locally at all.

## What this does

* **`background: true`** starts the step asynchronously and continues with the next step. At most 10 background steps run concurrently (matching GitHub's documented limit), additional ones queue until a slot frees up.
* **`wait:`** (single id or array) pauses the job until the referenced background steps complete; **`wait-all:`** waits for all active background steps. A failed background step fails the job at the first `wait`/`wait-all` that includes it — later steps before the wait still run — unless `continue-on-error` is set. Outputs of background steps become available after the wait. Both step kinds always run (even after a previous failure) and do not support `if`, per the documentation.
* **`cancel:`** gracefully terminates a running background step (context cancellation kills the process/exec); a deliberately cancelled step does not fail the job. Background steps still running when the job ends (e.g. services) are stopped the same way without affecting the job result.
* **`parallel:`** desugars to background steps plus an implicit `wait` for the group — exactly the shorthand described in the changelog. Not supported inside composite actions, matching GitHub.

Schema, model (`Step` type, parsing, new `StepType`s) and runner (a per-job background step registry) are covered.

## Thread safety

Steps now genuinely run concurrently inside one job, so the shared job state handling was hardened:

* Shared state mutations (StepResults, env files, extra path, intra-action state) are serialized: each step holds a lock during its setup and result-processing phase, while the actual command runs unlocked.
* The runner file commands (`GITHUB_OUTPUT`, `GITHUB_ENV`, ...) get a unique directory per step execution so concurrent steps no longer share the same files.
* Outputs and saved state are routed by explicit step id instead of the mutable `CurrentStep` field.
* The log writer swap in `HostEnvironment` and the docker container reference now happens under a mutex, and mask lists are guarded (they are appended by running steps and read on every formatted log line). This also fixes a pre-existing `ptyWriter.AutoStop` race.

The new integration tests pass with `-race` on Linux.

Known limitation: log lines of concurrently running steps can occasionally be attributed to the wrong step label in terminal output (GitHub renders separate log sections per background step; act interleaves). Legacy `::set-output::` workflow commands from concurrently running steps are routed by the step that owns the output stream.

## Testing

* `TestReadWorkflow_BackgroundSteps` — parsing and schema validation of all five keys.
* `TestExpandParallelStepGroups` — the `parallel` desugaring (ids, implicit wait).
* `TestRunBackgroundSteps` (host environment, bash + PowerShell testdata variants) — proves via file timestamps that a background step overlaps the following step, that parallel group members overlap each other and complete before the next step, that outputs are visible after `wait`, and that `cancel` stops a 60s step immediately.
* `TestRunBackgroundStepFailure` — failure surfaces at the `wait` (not before), and `continue-on-error` suppresses it.
* A container-based workflow added to the `TestRunEvent` table; also verified manually against Docker (background exec, cancel and wait-all all behave inside job containers).

`go build ./...`, `go vet`, and `golangci-lint run` (v2.11.4) are clean on the touched packages, and the new tests were run with the race detector enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
