### PR TITLE
feat: add the pkg/model side of concurrency.queue (builds on #6096)

### DIFF
--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -17,12 +17,44 @@ import (
 
 // Workflow is the structure of the files in .github/workflows
 type Workflow struct {
-	File     string
-	Name     string            `yaml:"name"`
-	RawOn    yaml.Node         `yaml:"on"`
-	Env      map[string]string `yaml:"env"`
-	Jobs     map[string]*Job   `yaml:"jobs"`
-	Defaults Defaults          `yaml:"defaults"`
+	File           string
+	Name           string            `yaml:"name"`
+	RawOn          yaml.Node         `yaml:"on"`
+	Env            map[string]string `yaml:"env"`
+	Jobs           map[string]*Job   `yaml:"jobs"`
+	Defaults       Defaults          `yaml:"defaults"`
+	RawConcurrency yaml.Node         `yaml:"concurrency"`
+}
+
+// Concurrency for a workflow or job. Group, CancelInProgress and Queue may
+// contain expressions that have to be evaluated before use.
+type Concurrency struct {
+	Group            string `yaml:"group"`
+	CancelInProgress string `yaml:"cancel-in-progress"`
+	Queue            string `yaml:"queue"`
+}
+
+// Concurrency returns the workflow level concurrency settings or nil if none are defined
+func (w *Workflow) Concurrency() *Concurrency {
+	return parseConcurrency(w.RawConcurrency)
+}
+
+func parseConcurrency(node yaml.Node) *Concurrency {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		var group string
+		if !decodeNode(node, &group) || group == "" {
+			return nil
+		}
+		return &Concurrency{Group: group}
+	case yaml.MappingNode:
+		var concurrency Concurrency
+		if !decodeNode(node, &concurrency) || concurrency.Group == "" {
+			return nil
+		}
+		return &concurrency
+	}
+	return nil
 }
 
 // On events for the workflow
@@ -81,7 +113,43 @@ func (w *Workflow) UnmarshalYAML(node *yaml.Node) error {
 		return errors.Join(err, fmt.Errorf("Actions YAML Schema Validation Error detected:\nFor more information, see: https://nektosact.com/usage/schema.html"))
 	}
 	type WorkflowDefault Workflow
-	return node.Decode((*WorkflowDefault)(w))
+	if err := node.Decode((*WorkflowDefault)(w)); err != nil {
+		return err
+	}
+	return w.validateConcurrency()
+}
+
+// validateConcurrency rejects concurrency blocks GitHub refuses to run before
+// the workflow is planned, so no job runs and produces side effects first.
+// Only literal values can be checked here, expression values are validated
+// once they are evaluated.
+func (w *Workflow) validateConcurrency() error {
+	if err := invalidConcurrencyCombination(w.Concurrency()); err != nil {
+		return fmt.Errorf("invalid workflow level 'concurrency': %w", err)
+	}
+	for id, job := range w.Jobs {
+		if job == nil {
+			continue
+		}
+		if err := invalidConcurrencyCombination(job.Concurrency()); err != nil {
+			return fmt.Errorf("invalid 'concurrency' for job '%s': %w", id, err)
+		}
+	}
+	return nil
+}
+
+func invalidConcurrencyCombination(concurrency *Concurrency) error {
+	if concurrency == nil {
+		return nil
+	}
+	// `${{ }}` values are only known after evaluation
+	if strings.Contains(concurrency.Queue, "${{") || strings.Contains(concurrency.CancelInProgress, "${{") {
+		return nil
+	}
+	if concurrency.Queue == "max" && concurrency.CancelInProgress == "true" {
+		return errors.New("the combination of 'queue: max' and 'cancel-in-progress: true' is not allowed")
+	}
+	return nil
 }
 
 type WorkflowStrict Workflow
@@ -99,7 +167,10 @@ func (w *WorkflowStrict) UnmarshalYAML(node *yaml.Node) error {
 		return errors.Join(err, fmt.Errorf("Actions YAML Strict Schema Validation Error detected:\nFor more information, see: https://nektosact.com/usage/schema.html"))
 	}
 	type WorkflowDefault Workflow
-	return node.Decode((*WorkflowDefault)(w))
+	if err := node.Decode((*WorkflowDefault)(w)); err != nil {
+		return err
+	}
+	return (*Workflow)(w).validateConcurrency()
 }
 
 type WorkflowDispatchInput struct {
@@ -209,7 +280,13 @@ type Job struct {
 	Uses           string                    `yaml:"uses"`
 	With           map[string]interface{}    `yaml:"with"`
 	RawSecrets     yaml.Node                 `yaml:"secrets"`
+	RawConcurrency yaml.Node                 `yaml:"concurrency"`
 	Result         string
+}
+
+// Concurrency returns the job level concurrency settings or nil if none are defined
+func (j *Job) Concurrency() *Concurrency {
+	return parseConcurrency(j.RawConcurrency)
 }
 
 // Strategy for the job

--- a/pkg/model/workflow_test.go
+++ b/pkg/model/workflow_test.go
@@ -136,6 +136,176 @@ jobs:
 	assert.Contains(t, workflow.Jobs["test2"].Container().Env["foo"], "bar")
 }
 
+func TestReadWorkflow_Concurrency(t *testing.T) {
+	yaml := `
+name: concurrency
+on: push
+
+concurrency:
+  group: workflow-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scalar:
+    runs-on: ubuntu-latest
+    concurrency: job-group
+    steps:
+    - run: echo
+  mapping:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: job-group-${{ github.event_name }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+    - run: echo
+  none:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo
+`
+
+	workflow, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.NoError(t, err, "read workflow should succeed")
+
+	concurrency := workflow.Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "workflow-${{ github.ref }}", concurrency.Group)
+	assert.Equal(t, "true", concurrency.CancelInProgress)
+
+	concurrency = workflow.GetJob("scalar").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "job-group", concurrency.Group)
+	assert.Equal(t, "", concurrency.CancelInProgress)
+
+	concurrency = workflow.GetJob("mapping").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "job-group-${{ github.event_name }}", concurrency.Group)
+	assert.Equal(t, "${{ github.ref != 'refs/heads/main' }}", concurrency.CancelInProgress)
+
+	assert.Nil(t, workflow.GetJob("none").Concurrency())
+}
+
+func TestReadWorkflow_ConcurrencyQueue(t *testing.T) {
+	yaml := `
+name: concurrency-queue
+on: push
+
+concurrency:
+  group: workflow-group
+  queue: max
+
+jobs:
+  queued:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: job-group
+      queue: single
+    steps:
+    - run: echo
+  defaulted:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: other-group
+    steps:
+    - run: echo
+  expression:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: expr-group
+      queue: ${{ vars.QUEUE_MODE }}
+    steps:
+    - run: echo
+`
+
+	workflow, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.NoError(t, err, "read workflow should succeed")
+
+	concurrency := workflow.Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "max", concurrency.Queue)
+
+	concurrency = workflow.GetJob("queued").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "single", concurrency.Queue)
+
+	concurrency = workflow.GetJob("defaulted").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "", concurrency.Queue, "queue defaults to single and is left empty when not set")
+
+	concurrency = workflow.GetJob("expression").Concurrency()
+	require.NotNil(t, concurrency)
+	assert.Equal(t, "${{ vars.QUEUE_MODE }}", concurrency.Queue, "expressions are kept for later evaluation")
+}
+
+func TestReadWorkflow_ConcurrencyQueueInvalid(t *testing.T) {
+	invalidValue := `
+name: invalid-queue-value
+on: push
+concurrency:
+  group: g
+  queue: enormous
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo
+`
+	_, err := ReadWorkflow(strings.NewReader(invalidValue), false)
+	assert.ErrorContains(t, err, "Expected one of single,max got enormous")
+
+	// GitHub refuses this combination, so the workflow must not plan at all
+	workflowLevel := `
+name: invalid-combination
+on: push
+concurrency:
+  group: g
+  queue: max
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo
+`
+	_, err = ReadWorkflow(strings.NewReader(workflowLevel), false)
+	assert.ErrorContains(t, err, "invalid workflow level 'concurrency'")
+	assert.ErrorContains(t, err, "'queue: max' and 'cancel-in-progress: true' is not allowed")
+
+	jobLevel := `
+name: invalid-combination-job
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: g
+      queue: max
+      cancel-in-progress: true
+    steps:
+    - run: echo
+`
+	_, err = ReadWorkflow(strings.NewReader(jobLevel), false)
+	assert.ErrorContains(t, err, "invalid 'concurrency' for job 'test'")
+
+	// an expression is only known after evaluation, so it must not be
+	// rejected while reading the workflow
+	expression := `
+name: deferred-combination
+on: push
+concurrency:
+  group: g
+  queue: max
+  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo
+`
+	_, err = ReadWorkflow(strings.NewReader(expression), false)
+	assert.NoError(t, err)
+}
+
 func TestReadWorkflow_ObjectContainer(t *testing.T) {
 	yaml := `
 name: local-action-docker-url

--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1643,9 +1643,17 @@
           "cancel-in-progress": {
             "type": "boolean",
             "description": "To cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true."
+          },
+          "queue": {
+            "type": "concurrency-queue",
+            "description": "Controls how many jobs or workflow runs can be `pending` in the concurrency group. The combination of `queue: max` and `cancel-in-progress: true` is not allowed."
           }
         }
       }
+    },
+    "concurrency-queue": {
+      "description": "To allow more than one `pending` job or workflow run to wait in the same concurrency group, use the optional `queue` property.\n\n* `single` (default): At most one job or workflow run can be `pending` in the concurrency group. When a new job or workflow run is queued, any existing `pending` job or workflow run in the same group is canceled and replaced.\n* `max`: Up to 100 jobs or workflow runs can be `pending` in the concurrency group. When the queue is full, any additional jobs or workflow runs are canceled.",
+      "allowed-values": ["single", "max"]
     },
     "job-environment": {
       "description": "The environment that the job references. All environment protection rules must pass before a job referencing the environment is sent to a runner.",


### PR DESCRIPTION
> **#6096 came first and should land first.** @xenjke filed #6095 and opened #6096 with a schema-only fix a minute later; I opened this months afterwards without spotting it. Theirs is the better-scoped fix for that issue and I have deliberately stopped this PR from claiming to close it. See [my note there](https://github.com/nektos/act/pull/6096#issuecomment-5203006061) — happy to close this, or to rebase it on top of #6096, whichever the maintainers prefer.

What this adds beyond #6096 is the `pkg/model` side of the same feature, which the concurrency runtime work needs.

## Background

GitHub added a `queue` property to concurrency groups on [7 May 2026](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/), selecting how many runs may wait in a group. act's schema does not know it, so a valid workflow fails to parse:

```
Error: workflow is not valid. 'q.yml': Line: 5 Column 3: Unknown Property queue
```

and none of its jobs run.

## What this does

The schema half overlaps with #6096: adds `queue` to `concurrency-mapping` with the documented `single` / `max` values, matching [`actions/languageservices`](https://github.com/actions/languageservices) `workflow-v1.0.json`. Both `workflow-concurrency` and `job-concurrency` one-of into that mapping, so workflow-, job- and reusable-workflow-level blocks all accept it.

The part that is not in #6096 is `pkg/model`: a `Concurrency` type (`Group`, `CancelInProgress`, `Queue`) with parsing for both the scalar shorthand and the mapping form, exposed as `Workflow.Concurrency()` / `Job.Concurrency()`. Nothing consumes it yet — act still ignores `concurrency` at runtime, exactly as on master — but it is what the runtime implementation builds on.

## The one judgement call

`queue: max` combined with `cancel-in-progress: true` is a combination GitHub refuses. This rejects it while the workflow is read, so it fails before any job runs:

```
Error: workflow is not valid. 'push.yml': invalid workflow level 'concurrency':
the combination of 'queue: max' and 'cancel-in-progress: true' is not allowed
```

That makes act **stricter than the shared schema**, which accepts the combination and leaves GitHub to enforce it at run time. It is a policy choice, not a fidelity one — happy to drop it or downgrade it to a warning. Values that are expressions are left alone, since they are only known after evaluation.

## Notes

- The enum is case-sensitive, so `queue: Max` is rejected. This matches SchemaStore and actionlint.
- `concurrency: {cancel-in-progress: true}` with no `group` is still ignored rather than rejected, unchanged from master.

## Testing

Table-driven tests in `pkg/model/workflow_test.go` cover the scalar shorthand, the mapping form, `single` / `max`, expression values bypassing both the enum and the combination check, job-level-only concurrency, and the rejected combination at workflow and job level. `go test ./pkg/model/... ./pkg/schema/...` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
