### PR TITLE
fix: give each step execution its own runner file command directory

### DIFF
--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -388,7 +388,7 @@ func newStepContainer(ctx context.Context, step step, image string, cmd []string
 	rc := step.getRunContext()
 	stepModel := step.getStepModel()
 	rawLogger := common.Logger(ctx).WithField("raw_output", true)
-	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+	logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, stepModel.ID), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)
 		} else {

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -73,6 +73,7 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		Masks:            parent.Masks,
 		ExtraPath:        parent.ExtraPath,
 		Parent:           parent,
+		parentStepID:     step.getStepModel().ID,
 		EventJSON:        parent.EventJSON,
 		nodeToolFullPath: parent.nodeToolFullPath,
 	}
@@ -98,10 +99,13 @@ func execAsComposite(step actionStep) common.Executor {
 
 		err := steps.main(ctx)
 
-		// Map outputs from composite RunContext to job RunContext
+		// Map outputs from composite RunContext to job RunContext. They
+		// belong to the step that used the action, not to whichever step is
+		// current once the composite finished.
+		stepID := step.getStepModel().ID
 		eval := compositeRC.NewExpressionEvaluator(ctx)
 		for outputName, output := range action.Outputs {
-			rc.setOutput(ctx, map[string]string{
+			rc.setOutputForStep(ctx, stepID, map[string]string{
 				"name": outputName,
 			}, eval.Interpolate(ctx, output.Value))
 		}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -34,6 +34,13 @@ func tryParseRawActionCommand(line string) (command string, kvPairs map[string]s
 }
 
 func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
+	return rc.stepCommandHandler(ctx, "")
+}
+
+// stepCommandHandler returns a line handler that records step scoped commands
+// against stepID. With an empty stepID they are recorded against the step that
+// is current when the command is processed.
+func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) common.LineHandler {
 	logger := common.Logger(ctx)
 	resumeCommand := ""
 	return func(line string) bool {
@@ -48,6 +55,9 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		}
 		arg = unescapeCommandData(arg)
 		kvPairs = unescapeKvPairs(kvPairs)
+		if stepID == "" {
+			stepID = rc.CurrentStep
+		}
 		defCommandLogger := logger.WithFields(logrus.Fields{"command": command, "kvPairs": kvPairs, "arg": arg, "raw": line})
 		switch command {
 		case "set-env":
@@ -57,7 +67,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			}
 			rc.setEnv(ctx, kvPairs, arg)
 		case "set-output":
-			rc.setOutput(ctx, kvPairs, arg)
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
 		case "add-path":
 			if rc.Env["ACTIONS_ALLOW_UNSECURE_COMMANDS"] != "true" {
 				defCommandLogger.Errorf("The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsafe commands by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.")
@@ -81,7 +91,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			defCommandLogger.Infof("  \U00002699  %s", line)
 		case "save-state":
 			defCommandLogger.Infof("  \U0001f4be  %s", line)
-			rc.saveState(ctx, kvPairs, arg)
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
 		case "add-matcher":
 			defCommandLogger.Infof("  \U00002753 add-matcher %s", arg)
 		default:
@@ -111,9 +121,8 @@ func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg
 	mergeIntoMap(rc.Env, newenv)
 	mergeIntoMap(rc.GlobalEnv, newenv)
 }
-func (rc *RunContext) setOutput(ctx context.Context, kvPairs map[string]string, arg string) {
+func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPairs map[string]string, arg string) {
 	logger := common.Logger(ctx)
-	stepID := rc.CurrentStep
 	outputName := kvPairs["name"]
 	if outputMapping, ok := rc.OutputMappings[MappableOutput{StepID: stepID, OutputName: outputName}]; ok {
 		stepID = outputMapping.StepID
@@ -182,8 +191,7 @@ func unescapeKvPairs(kvPairs map[string]string) map[string]string {
 	return kvPairs
 }
 
-func (rc *RunContext) saveState(_ context.Context, kvPairs map[string]string, arg string) {
-	stepID := rc.CurrentStep
+func (rc *RunContext) saveStateForStep(_ context.Context, stepID string, kvPairs map[string]string, arg string) {
 	if stepID != "" {
 		if rc.IntraActionState == nil {
 			rc.IntraActionState = map[string]map[string]string{}

--- a/pkg/runner/container_mock_test.go
+++ b/pkg/runner/container_mock_test.go
@@ -3,11 +3,20 @@ package runner
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
 	"github.com/stretchr/testify/mock"
 )
+
+// matchCmdFile matches a runner file command path regardless of the unique
+// per step execution directory it now lives in
+func matchCmdFile(name string) interface{} {
+	return mock.MatchedBy(func(path string) bool {
+		return strings.HasPrefix(path, "/var/run/act/workflow/") && strings.HasSuffix(path, "/"+name)
+	})
+}
 
 type containerMock struct {
 	mock.Mock

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -202,7 +202,7 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 		ctx = withStepLogger(ctx, stepModel.ID, rc.ExprEval.Interpolate(ctx, stepModel.String()), stage.String())
 
 		rawLogger := common.Logger(ctx).WithField("raw_output", true)
-		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+		logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, stepModel.ID), func(s string) bool {
 			if rc.Config.LogOutput {
 				rawLogger.Infof("%s", s)
 			} else {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -53,6 +53,10 @@ type RunContext struct {
 	caller              *caller // job calling this RunContext (reusable workflows)
 	Cancelled           bool
 	nodeToolFullPath    string
+
+	// parentStepID is the id of the action step a composite RunContext was
+	// created for. It is stable, unlike the mutable CurrentStep.
+	parentStepID string
 }
 
 func (rc *RunContext) AddMask(mask string) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -285,6 +285,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "workdir", "push", "", platforms, secrets},
 		{workdir, "defaults-run", "push", "", platforms, secrets},
 		{workdir, "composite-fail-with-output", "push", "", platforms, secrets},
+		{workdir, "composite-undeclared-outputs", "push", "", platforms, secrets},
 		{workdir, "issue-597", "push", "", platforms, secrets},
 		{workdir, "issue-598", "push", "", platforms, secrets},
 		{workdir, "if-env-act", "push", "", platforms, secrets},
@@ -557,6 +558,7 @@ func TestRunEventHostEnvironment(t *testing.T) {
 			// shell sh is not necessarily bash if the job has no override
 			// {workdir, "defaults-run", "push", "", platforms, secrets},
 			{workdir, "composite-fail-with-output", "push", "", platforms, secrets},
+			{workdir, "composite-undeclared-outputs", "push", "", platforms, secrets},
 			{workdir, "issue-597", "push", "", platforms, secrets},
 			{workdir, "issue-598", "push", "", platforms, secrets},
 			{workdir, "if-env-act", "push", "", platforms, secrets},

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nektos/act/pkg/common"
@@ -91,6 +92,10 @@ func processRunnerEnvFileCommand(ctx context.Context, fileName string, rc *RunCo
 	return nil
 }
 
+// stepFileCommandSeq makes the runner file command paths unique per step
+// execution, so the commands of one step cannot be read by the next
+var stepFileCommandSeq atomic.Int64
+
 func runStepExecutor(step step, stage stepStage, executor common.Executor) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
@@ -137,22 +142,25 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		}
 		logger.Infof("\u2B50 Run %s %s", stage, stepString)
 
-		// Prepare and clean Runner File Commands
+		// Prepare and clean Runner File Commands. Every step execution gets
+		// its own directory, so a step never reads the file commands another
+		// step left behind.
 		actPath := rc.JobContainer.GetActPath()
+		cmdDir := path.Join("workflow", fmt.Sprintf("cmds-%d-%s", stepFileCommandSeq.Add(1), stage.String()))
 
-		outputFileCommand := path.Join("workflow", "outputcmd.txt")
+		outputFileCommand := path.Join(cmdDir, "outputcmd.txt")
 		(*step.getEnv())["GITHUB_OUTPUT"] = path.Join(actPath, outputFileCommand)
 
-		stateFileCommand := path.Join("workflow", "statecmd.txt")
+		stateFileCommand := path.Join(cmdDir, "statecmd.txt")
 		(*step.getEnv())["GITHUB_STATE"] = path.Join(actPath, stateFileCommand)
 
-		pathFileCommand := path.Join("workflow", "pathcmd.txt")
+		pathFileCommand := path.Join(cmdDir, "pathcmd.txt")
 		(*step.getEnv())["GITHUB_PATH"] = path.Join(actPath, pathFileCommand)
 
-		envFileCommand := path.Join("workflow", "envs.txt")
+		envFileCommand := path.Join(cmdDir, "envs.txt")
 		(*step.getEnv())["GITHUB_ENV"] = path.Join(actPath, envFileCommand)
 
-		summaryFileCommand := path.Join("workflow", "SUMMARY.md")
+		summaryFileCommand := path.Join(cmdDir, "SUMMARY.md")
 		(*step.getEnv())["GITHUB_STEP_SUMMARY"] = path.Join(actPath, summaryFileCommand)
 
 		_ = rc.JobContainer.Copy(actPath, &container.FileEntry{
@@ -203,11 +211,18 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u274C  Failure - %s %s [%s]", stage, stepString, executionTime)
 		}
-		// Process Runner File Commands
+		// Process Runner File Commands. They belong to this step, so they are
+		// recorded against its id rather than whatever CurrentStep happens to
+		// hold by the time they are read.
+		stepID := stepModel.ID
 		ferrors := []error{err}
 		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, envFileCommand, rc, rc.setEnv))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, rc.saveState))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, rc.setOutput))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
+		}))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
+		}))
 		ferrors = append(ferrors, processRunnerSummaryCommand(ctx, summaryFileCommand, rc))
 		ferrors = append(ferrors, rc.UpdateExtraPath(ctx, path.Join(actPath, pathFileCommand)))
 		return errors.Join(ferrors...)

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -73,20 +73,20 @@ func TestStepActionLocalTest(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	salm.On("runAction", sal, filepath.Clean("/tmp/path/to/action"), (*remoteAction)(nil)).Return(func(_ context.Context) error {
 		return nil
@@ -270,20 +270,20 @@ func TestStepActionLocalPost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sal.post()(ctx)

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -175,20 +175,20 @@ func TestStepActionRemote(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.pre()(ctx)
@@ -588,20 +588,20 @@ func TestStepActionRemotePost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.post()(ctx)

--- a/pkg/runner/step_docker.go
+++ b/pkg/runner/step_docker.go
@@ -94,7 +94,7 @@ func (sd *stepDocker) newStepContainer(ctx context.Context, image string, cmd []
 	step := sd.Step
 
 	rawLogger := common.Logger(ctx).WithField("raw_output", true)
-	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+	logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, step.ID), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)
 		} else {

--- a/pkg/runner/step_docker_test.go
+++ b/pkg/runner/step_docker_test.go
@@ -81,20 +81,20 @@ func TestStepDockerMain(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sd.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/step_run.go
+++ b/pkg/runner/step_run.go
@@ -88,7 +88,7 @@ func (sr *stepRun) setupShellCommandExecutor() common.Executor {
 func getScriptName(rc *RunContext, step *model.Step) string {
 	scriptName := step.ID
 	for rcs := rc; rcs.Parent != nil; rcs = rcs.Parent {
-		scriptName = fmt.Sprintf("%s-composite-%s", rcs.Parent.CurrentStep, scriptName)
+		scriptName = fmt.Sprintf("%s-composite-%s", rcs.parentStepID, scriptName)
 	}
 	return fmt.Sprintf("workflow/%s", scriptName)
 }

--- a/pkg/runner/step_run_test.go
+++ b/pkg/runner/step_run_test.go
@@ -60,22 +60,22 @@ func TestStepRun(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
 	ctx := context.Background()
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sr.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/testdata/composite-undeclared-outputs/composite/action.yml
+++ b/pkg/runner/testdata/composite-undeclared-outputs/composite/action.yml
@@ -1,0 +1,18 @@
+name: 'composite with an undeclared inner output'
+description: |
+  The inner step writes an output that the action does not declare. GitHub
+  scopes it to the inner step, so it must not appear on the step that used
+  this action.
+outputs:
+  declared:
+    description: 'an output the action does declare'
+    value: ${{ steps.inner.outputs.declared }}
+runs:
+  using: composite
+  steps:
+    - id: inner
+      shell: bash
+      run: |
+        echo "declared=declared-value" >> "$GITHUB_OUTPUT"
+        echo "undeclared=undeclared-value" >> "$GITHUB_OUTPUT"
+        echo "::set-output name=undeclared-legacy::undeclared-legacy-value"

--- a/pkg/runner/testdata/composite-undeclared-outputs/nested/action.yml
+++ b/pkg/runner/testdata/composite-undeclared-outputs/nested/action.yml
@@ -1,0 +1,13 @@
+name: 'composite nesting another composite'
+description: |
+  Wraps the composite action, so the same scoping is exercised one level
+  deeper.
+outputs:
+  declared:
+    description: 'forwarded from the inner composite'
+    value: ${{ steps.inner-composite.outputs.declared }}
+runs:
+  using: composite
+  steps:
+    - id: inner-composite
+      uses: ./composite-undeclared-outputs/composite

--- a/pkg/runner/testdata/composite-undeclared-outputs/push.yml
+++ b/pkg/runner/testdata/composite-undeclared-outputs/push.yml
@@ -1,0 +1,25 @@
+name: composite-undeclared-outputs
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: plain
+        uses: ./composite-undeclared-outputs/composite
+      - name: a declared output is visible on the step that used the action
+        run: |
+          [ "${{ steps.plain.outputs.declared }}" = "declared-value" ]
+      - name: outputs the action does not declare stay scoped to the inner step
+        run: |
+          [ -z "${{ steps.plain.outputs.undeclared }}" ]
+          [ -z "${{ steps.plain.outputs['undeclared-legacy'] }}" ]
+
+      - id: nested
+        uses: ./composite-undeclared-outputs/nested
+      - name: the same holds one level of nesting deeper
+        run: |
+          [ "${{ steps.nested.outputs.declared }}" = "declared-value" ]
+          [ -z "${{ steps.nested.outputs.undeclared }}" ]
+          [ -z "${{ steps.nested.outputs['undeclared-legacy'] }}" ]


### PR DESCRIPTION
Refs #2184, #2697, #2553.

Every step writes its file commands to the same five paths in the job container — `workflow/outputcmd.txt`, `statecmd.txt`, `pathcmd.txt`, `envs.txt`, `SUMMARY.md` — and reads them back after it finishes. A step therefore reads whatever the previously executed step left behind.

The visible consequence is composite actions leaking outputs. GitHub scopes an output written by a composite action's inner step to that inner step, exposing only the outputs the action declares in its `outputs:`. In act the inner step's writes to `$GITHUB_OUTPUT` are still sitting in the shared file when the enclosing job step processes it, so they surface as outputs of the step that used the action.

## What this does

Each step execution gets its own `workflow/cmds-<n>-<stage>/` directory, so nothing is inherited from the previous step.

Two related fixes for the same root cause — step-scoped data keyed off mutable state:

* File command results are recorded against the id of the step they belong to, rather than whatever `RunContext.CurrentStep` holds by the time they are read. Same for the `::set-output` / `::save-state` handlers, which now take the step id of the step whose output stream they are attached to.
* Composite script names are derived from a new stable `parentStepID` instead of `CurrentStep`.

## Testing

New `composite-undeclared-outputs` fixture, added to the docker `TestRunEvent` table. It asserts that an output a composite action **declares** is visible on the step that used it, and that outputs it does **not** declare are not — for a plain composite and one nesting another composite, over both `$GITHUB_OUTPUT` and legacy `::set-output`.

**It fails on master and passes with this change**, which is the point of including it.

The rest of the composite and file-command suite is green: `uses-composite`, `uses-nested-composite`, `composite-fail-with-output`, `act-composite-env-test`, `do-not-leak-step-env-in-composite`, `uses-composite-with-pre-and-post-steps`, `outputs`, `GITHUB_STATE`, `environment-files`.

## Things to be aware of

- The in-container paths of `$GITHUB_OUTPUT`, `$GITHUB_ENV`, `$GITHUB_PATH`, `$GITHUB_STATE` and `$GITHUB_STEP_SUMMARY` change. Anything that hard-codes them rather than reading the environment variable would break — I could not find such a case, but it is worth a second pair of eyes.
- The per-execution directories are not cleaned up, so they accumulate for the lifetime of the job container. Negligible in size, but it is a change from one fixed set of files.
- `$GITHUB_STEP_SUMMARY` becomes per step *execution* rather than per step id. Summaries are already emitted per step, so this should not be observable.
- The four step unit tests matched the old fixed paths exactly; they now match through a `matchCmdFile` helper.

I have deliberately **not** marked #2184 / #2697 / #2553 as closed. This addresses the mechanism all three describe, but they should be re-checked against the original reproductions before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
