### PR TITLE
fix(security): add timeout to notices HTTP client and path guard to file collector

### DIFF
--- a/cmd/notices.go
+++ b/cmd/notices.go
@@ -79,7 +79,7 @@ func getVersionNotices(version string) []Notice {
 
 	noticeURL.RawQuery = query.Encode()
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 15 * time.Second}
 	req, err := http.NewRequest("GET", noticeURL.String(), nil)
 	if err != nil {
 		log.Debug(err)

--- a/pkg/filecollector/file_collector.go
+++ b/pkg/filecollector/file_collector.go
@@ -64,7 +64,11 @@ type CopyCollector struct {
 }
 
 func (cc *CopyCollector) WriteFile(fpath string, fi fs.FileInfo, linkName string, f io.Reader) error {
+	cleanDst := filepath.Clean(cc.DstDir) + string(os.PathSeparator)
 	fdestpath := filepath.Join(cc.DstDir, fpath)
+	if !strings.HasPrefix(filepath.Clean(fdestpath)+string(os.PathSeparator), cleanDst) {
+		return fmt.Errorf("path %q escapes destination directory", fpath)
+	}
 	if err := os.MkdirAll(filepath.Dir(fdestpath), 0o777); err != nil {
 		return err
 	}


### PR DESCRIPTION
Two small security fixes: the notices HTTP client in cmd/notices.go uses http.Client{} with no Timeout, so a slow remote server stalls act on startup; added a 15-second timeout. The file collector in pkg/filecollector/file_collector.go joins tar entry paths to the destination without a containment check, allowing a crafted archive to write outside the target directory; added a filepath.Clean prefix guard before any file is created.