### PR TITLE
feat: run steps in parallel with background, wait, wait-all, cancel and parallel

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -210,9 +210,8 @@ func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Write
 	return out, err
 }
 
-// getLogWriters returns the writers command output is copied to. They are
-// replaced while a command may already be running, so they must not be read
-// without the mutex.
+// getLogWriters returns the current log writers, they are replaced per step
+// and read concurrently by steps running in the background
 func (cr *containerReference) getLogWriters() (io.Writer, io.Writer) {
 	cr.logWriterMutex.Lock()
 	defer cr.logWriterMutex.Unlock()
@@ -690,6 +689,9 @@ func (cr *containerReference) waitForCommand(ctx context.Context, isTerminal boo
 	cmdResponse := make(chan error)
 
 	outWriter, errWriter := cr.getLogWriters()
+	if ctxOut, ctxErr, ok := LogWriters(ctx); ok {
+		outWriter, errWriter = ctxOut, ctxErr
+	}
 	go func() {
 		var err error
 		if !isTerminal || os.Getenv("NORAW") != "" {

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"net/netip"
 
@@ -197,6 +198,9 @@ func (cr *containerReference) GetHealth(ctx context.Context) Health {
 }
 
 func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Writer) (io.Writer, io.Writer) {
+	cr.logWriterMutex.Lock()
+	defer cr.logWriterMutex.Unlock()
+
 	out := cr.input.Stdout
 	err := cr.input.Stderr
 
@@ -206,12 +210,31 @@ func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Write
 	return out, err
 }
 
+// getLogWriters returns the writers command output is copied to. They are
+// replaced while a command may already be running, so they must not be read
+// without the mutex.
+func (cr *containerReference) getLogWriters() (io.Writer, io.Writer) {
+	cr.logWriterMutex.Lock()
+	defer cr.logWriterMutex.Unlock()
+
+	outWriter := io.Writer(os.Stdout)
+	if cr.input.Stdout != nil {
+		outWriter = cr.input.Stdout
+	}
+	errWriter := io.Writer(os.Stderr)
+	if cr.input.Stderr != nil {
+		errWriter = cr.input.Stderr
+	}
+	return outWriter, errWriter
+}
+
 type containerReference struct {
-	cli   client.APIClient
-	id    string
-	input *NewContainerInput
-	UID   int
-	GID   int
+	cli            client.APIClient
+	id             string
+	input          *NewContainerInput
+	UID            int
+	GID            int
+	logWriterMutex sync.Mutex
 	LinuxContainerEnvironmentExtensions
 }
 
@@ -666,17 +689,8 @@ func (cr *containerReference) waitForCommand(ctx context.Context, isTerminal boo
 
 	cmdResponse := make(chan error)
 
+	outWriter, errWriter := cr.getLogWriters()
 	go func() {
-		var outWriter io.Writer
-		outWriter = cr.input.Stdout
-		if outWriter == nil {
-			outWriter = os.Stdout
-		}
-		errWriter := cr.input.Stderr
-		if errWriter == nil {
-			errWriter = os.Stderr
-		}
-
 		var err error
 		if !isTerminal || os.Getenv("NORAW") != "" {
 			_, err = stdcopy.StdCopy(outWriter, errWriter, resp.Reader)
@@ -852,15 +866,7 @@ func (cr *containerReference) attach() common.Executor {
 		}
 		isTerminal := term.IsTerminal(int(os.Stdout.Fd()))
 
-		var outWriter io.Writer
-		outWriter = cr.input.Stdout
-		if outWriter == nil {
-			outWriter = os.Stdout
-		}
-		errWriter := cr.input.Stderr
-		if errWriter == nil {
-			errWriter = os.Stderr
-		}
+		outWriter, errWriter := cr.getLogWriters()
 		go func() {
 			if !isTerminal || os.Getenv("NORAW") != "" {
 				_, err = stdcopy.StdCopy(outWriter, errWriter, out.Reader)

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-git/go-billy/v5/helper/polyfill"
@@ -33,6 +35,16 @@ type HostEnvironment struct {
 	ActPath   string
 	CleanUp   func()
 	StdOut    io.Writer
+
+	// stdoutMutex guards StdOut, which is replaced while a command may
+	// already be running and reading it
+	stdoutMutex sync.Mutex
+}
+
+func (e *HostEnvironment) getStdOut() io.Writer {
+	e.stdoutMutex.Lock()
+	defer e.stdoutMutex.Unlock()
+	return e.StdOut
 }
 
 func (e *HostEnvironment) Create(_ []string, _ []string) common.Executor {
@@ -181,13 +193,15 @@ func (e *HostEnvironment) Start(_ bool) common.Executor {
 }
 
 type ptyWriter struct {
-	Out       io.Writer
-	AutoStop  bool
+	Out io.Writer
+	// AutoStop is set on the executing goroutine after copyPtyOutput has
+	// already started reading it
+	AutoStop  atomic.Bool
 	dirtyLine bool
 }
 
 func (w *ptyWriter) Write(buf []byte) (int, error) {
-	if w.AutoStop && len(buf) > 0 && buf[len(buf)-1] == 4 {
+	if w.AutoStop.Load() && len(buf) > 0 && buf[len(buf)-1] == 4 {
 		n, err := w.Out.Write(buf[:len(buf)-1])
 		if err != nil {
 			return n, err
@@ -294,7 +308,8 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 	} else {
 		wd = e.Path
 	}
-	f, err := lookupPathHost(command[0], env, e.StdOut)
+	stdout := e.getStdOut()
+	f, err := lookupPathHost(command[0], env, stdout)
 	if err != nil {
 		return err
 	}
@@ -302,9 +317,9 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 	cmd.Path = f
 	cmd.Args = command
 	cmd.Stdin = nil
-	cmd.Stdout = e.StdOut
+	cmd.Stdout = stdout
 	cmd.Env = envList
-	cmd.Stderr = e.StdOut
+	cmd.Stderr = stdout
 	cmd.Dir = wd
 	cmd.SysProcAttr = getSysProcAttr(cmdline, false)
 	var ppty *os.File
@@ -324,7 +339,7 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 			common.Logger(ctx).Debugf("Failed to setup Pty %v\n", err.Error())
 		}
 	}
-	writer := &ptyWriter{Out: e.StdOut}
+	writer := &ptyWriter{Out: stdout}
 	logctx, finishLog := context.WithCancel(context.Background())
 	if ppty != nil {
 		go copyPtyOutput(writer, ppty, finishLog)
@@ -339,7 +354,7 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 		return err
 	}
 	if tty != nil {
-		writer.AutoStop = true
+		writer.AutoStop.Store(true)
 		if _, err := tty.Write([]byte("\x04")); err != nil {
 			common.Logger(ctx).Debug("Failed to write EOT")
 		}
@@ -460,6 +475,8 @@ func (e *HostEnvironment) GetHealth(_ context.Context) Health {
 }
 
 func (e *HostEnvironment) ReplaceLogWriter(stdout io.Writer, _ io.Writer) (io.Writer, io.Writer) {
+	e.stdoutMutex.Lock()
+	defer e.stdoutMutex.Unlock()
 	org := e.StdOut
 	e.StdOut = stdout
 	return org, org

--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -36,8 +36,8 @@ type HostEnvironment struct {
 	CleanUp   func()
 	StdOut    io.Writer
 
-	// stdoutMutex guards StdOut, which is replaced while a command may
-	// already be running and reading it
+	// stdoutMutex guards StdOut, it is replaced per step and read
+	// concurrently by steps running in the background
 	stdoutMutex sync.Mutex
 }
 
@@ -193,9 +193,7 @@ func (e *HostEnvironment) Start(_ bool) common.Executor {
 }
 
 type ptyWriter struct {
-	Out io.Writer
-	// AutoStop is set on the executing goroutine after copyPtyOutput has
-	// already started reading it
+	Out       io.Writer
 	AutoStop  atomic.Bool
 	dirtyLine bool
 }
@@ -309,6 +307,9 @@ func (e *HostEnvironment) exec(ctx context.Context, command []string, cmdline st
 		wd = e.Path
 	}
 	stdout := e.getStdOut()
+	if ctxStdout, _, ok := LogWriters(ctx); ok {
+		stdout = ctxStdout
+	}
 	f, err := lookupPathHost(command[0], env, stdout)
 	if err != nil {
 		return err

--- a/pkg/container/host_environment_race_test.go
+++ b/pkg/container/host_environment_race_test.go
@@ -1,0 +1,40 @@
+package container
+
+import (
+	"io"
+	"sync"
+	"testing"
+)
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestPtyWriterAutoStopRace reproduces the race between the goroutine copying
+// the pty output, which reads AutoStop on every write, and the executing
+// goroutine, which sets it once the command finished. Run with -race.
+func TestPtyWriterAutoStopRace(t *testing.T) {
+	writer := &ptyWriter{Out: discardWriter{}}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// stands in for copyPtyOutput
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			if _, err := writer.Write([]byte("line\n")); err != nil && err != io.EOF {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+
+	// stands in for the exec goroutine signalling the end of the command
+	go func() {
+		defer wg.Done()
+		writer.AutoStop.Store(true)
+	}()
+
+	wg.Wait()
+}

--- a/pkg/container/log_writer.go
+++ b/pkg/container/log_writer.go
@@ -1,0 +1,29 @@
+package container
+
+import (
+	"context"
+	"io"
+)
+
+type logWriterContextKey struct{}
+
+type logWriters struct {
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// WithLogWriters attaches the log writers for command output to the context.
+// Execution environments prefer these writers over their global log writer,
+// so steps running concurrently each capture their own output instead of
+// racing for the single writer slot of the environment.
+func WithLogWriters(ctx context.Context, stdout io.Writer, stderr io.Writer) context.Context {
+	return context.WithValue(ctx, logWriterContextKey{}, &logWriters{stdout: stdout, stderr: stderr})
+}
+
+// LogWriters returns the log writers attached to the context, if any
+func LogWriters(ctx context.Context) (io.Writer, io.Writer, bool) {
+	if writers, ok := ctx.Value(logWriterContextKey{}).(*logWriters); ok {
+		return writers.stdout, writers.stderr, true
+	}
+	return nil, nil, false
+}

--- a/pkg/model/workflow.go
+++ b/pkg/model/workflow.go
@@ -580,6 +580,56 @@ type Step struct {
 	With               map[string]string `yaml:"with"`
 	RawContinueOnError string            `yaml:"continue-on-error"`
 	TimeoutMinutes     string            `yaml:"timeout-minutes"`
+	Background         string            `yaml:"background"`
+	RawWait            yaml.Node         `yaml:"wait"`
+	RawWaitAll         yaml.Node         `yaml:"wait-all"`
+	Cancel             string            `yaml:"cancel"`
+	RawParallel        yaml.Node         `yaml:"parallel"`
+}
+
+// IsBackground returns true if the step runs asynchronously while the job
+// continues with the next step
+func (s *Step) IsBackground() bool {
+	background, _ := strconv.ParseBool(s.Background)
+	return background
+}
+
+// Wait returns the ids of the background steps a `wait` step waits for
+func (s *Step) Wait() []string {
+	switch s.RawWait.Kind {
+	case yaml.ScalarNode:
+		var id string
+		if !decodeNode(s.RawWait, &id) || id == "" {
+			return nil
+		}
+		return []string{id}
+	case yaml.SequenceNode:
+		var ids []string
+		if !decodeNode(s.RawWait, &ids) {
+			return nil
+		}
+		return ids
+	}
+	return nil
+}
+
+// IsBackgroundControl returns true for `wait`, `wait-all` and `cancel` steps
+// that synchronize with or stop background steps
+func (s *Step) IsBackgroundControl() bool {
+	stepType := s.Type()
+	return stepType == StepTypeWait || stepType == StepTypeWaitAll || stepType == StepTypeCancel
+}
+
+// ParallelSteps returns the nested steps of a `parallel` step group
+func (s *Step) ParallelSteps() []*Step {
+	if s.RawParallel.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var steps []*Step
+	if !decodeNode(s.RawParallel, &steps) {
+		return nil
+	}
+	return steps
 }
 
 // String gets the name of step
@@ -590,6 +640,14 @@ func (s *Step) String() string {
 		return s.Uses
 	} else if s.Run != "" {
 		return s.Run
+	} else if s.RawWait.Kind != 0 {
+		return fmt.Sprintf("wait: %s", strings.Join(s.Wait(), ", "))
+	} else if s.RawWaitAll.Kind != 0 {
+		return "wait-all"
+	} else if s.Cancel != "" {
+		return fmt.Sprintf("cancel: %s", s.Cancel)
+	} else if s.RawParallel.Kind != 0 {
+		return "parallel"
 	}
 	return s.ID
 }
@@ -665,6 +723,18 @@ const (
 
 	// StepTypeInvalid is for steps that have invalid step action
 	StepTypeInvalid
+
+	// StepTypeWait is a step with a `wait` attribute that waits for one or more background steps
+	StepTypeWait
+
+	// StepTypeWaitAll is a step with a `wait-all` attribute that waits for all active background steps
+	StepTypeWaitAll
+
+	// StepTypeCancel is a step with a `cancel` attribute that gracefully terminates a background step
+	StepTypeCancel
+
+	// StepTypeParallel is a step with a `parallel` attribute containing a group of steps that run concurrently
+	StepTypeParallel
 )
 
 func (s StepType) String() string {
@@ -683,12 +753,33 @@ func (s StepType) String() string {
 		return "local-reusable-workflow"
 	case StepTypeReusableWorkflowRemote:
 		return "remote-reusable-workflow"
+	case StepTypeWait:
+		return "wait"
+	case StepTypeWaitAll:
+		return "wait-all"
+	case StepTypeCancel:
+		return "cancel"
+	case StepTypeParallel:
+		return "parallel"
 	}
 	return "unknown"
 }
 
 // Type returns the type of the step
 func (s *Step) Type() StepType {
+	if s.RawWait.Kind != 0 {
+		return StepTypeWait
+	}
+	if s.RawWaitAll.Kind != 0 {
+		return StepTypeWaitAll
+	}
+	if s.Cancel != "" {
+		return StepTypeCancel
+	}
+	if s.RawParallel.Kind != 0 {
+		return StepTypeParallel
+	}
+
 	if s.Run == "" && s.Uses == "" {
 		return StepTypeInvalid
 	}

--- a/pkg/model/workflow_test.go
+++ b/pkg/model/workflow_test.go
@@ -136,6 +136,71 @@ jobs:
 	assert.Contains(t, workflow.Jobs["test2"].Container().Env["foo"], "bar")
 }
 
+func TestReadWorkflow_BackgroundSteps(t *testing.T) {
+	yaml := `
+name: background-steps
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Start server
+      id: server
+      run: npm start
+      background: true
+    - name: A uses step in the background
+      id: action
+      uses: ./actions/docker-url
+      background: true
+    - name: Not a background step
+      run: echo
+    - name: Wait for one step
+      wait: server
+    - wait: [server, action]
+    - wait-all:
+    - cancel: server
+    - parallel:
+        - name: Build frontend
+          run: npm run build:frontend
+        - id: backend
+          uses: ./actions/backend
+`
+
+	workflow, err := ReadWorkflow(strings.NewReader(yaml), false)
+	assert.NoError(t, err, "read workflow should succeed")
+
+	steps := workflow.GetJob("test").Steps
+	require.Len(t, steps, 8)
+
+	assert.True(t, steps[0].IsBackground())
+	assert.Equal(t, StepTypeRun, steps[0].Type())
+	assert.True(t, steps[1].IsBackground())
+	assert.Equal(t, StepTypeUsesActionLocal, steps[1].Type())
+	assert.False(t, steps[2].IsBackground())
+
+	assert.Equal(t, StepTypeWait, steps[3].Type())
+	assert.Equal(t, []string{"server"}, steps[3].Wait())
+	assert.Equal(t, "Wait for one step", steps[3].String())
+
+	assert.Equal(t, StepTypeWait, steps[4].Type())
+	assert.Equal(t, []string{"server", "action"}, steps[4].Wait())
+	assert.Equal(t, "wait: server, action", steps[4].String())
+
+	assert.Equal(t, StepTypeWaitAll, steps[5].Type())
+	assert.Equal(t, "wait-all", steps[5].String())
+
+	assert.Equal(t, StepTypeCancel, steps[6].Type())
+	assert.Equal(t, "server", steps[6].Cancel)
+	assert.Equal(t, "cancel: server", steps[6].String())
+
+	assert.Equal(t, StepTypeParallel, steps[7].Type())
+	group := steps[7].ParallelSteps()
+	require.Len(t, group, 2)
+	assert.Equal(t, "npm run build:frontend", group[0].Run)
+	assert.Equal(t, "./actions/backend", group[1].Uses)
+}
+
 func TestReadWorkflow_ObjectContainer(t *testing.T) {
 	yaml := `
 name: local-action-docker-url

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -388,7 +388,7 @@ func newStepContainer(ctx context.Context, step step, image string, cmd []string
 	rc := step.getRunContext()
 	stepModel := step.getStepModel()
 	rawLogger := common.Logger(ctx).WithField("raw_output", true)
-	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+	logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, stepModel.ID), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)
 		} else {

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
 )
 
@@ -51,6 +52,13 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 	configCopy := *(parent.Config)
 	configCopy.Secrets = nil
 
+	// snapshot the parent state that may be mutated by steps running
+	// concurrently in the background
+	lock := parent.stepStateLock()
+	lock.Lock()
+	extraPath := append([]string{}, parent.ExtraPath...)
+	lock.Unlock()
+
 	// create a run context for the composite action to run in
 	compositerc := &RunContext{
 		Name:    parent.Name,
@@ -71,7 +79,7 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		Env:              env,
 		GlobalEnv:        parent.GlobalEnv,
 		Masks:            parent.masksSnapshot(),
-		ExtraPath:        parent.ExtraPath,
+		ExtraPath:        extraPath,
 		Parent:           parent,
 		parentStepID:     step.getStepModel().ID,
 		EventJSON:        parent.EventJSON,
@@ -99,21 +107,45 @@ func execAsComposite(step actionStep) common.Executor {
 
 		err := steps.main(ctx)
 
-		// Map outputs from composite RunContext to job RunContext. They
-		// belong to the step that used the action, not to whichever step is
-		// current once the composite finished.
-		stepID := step.getStepModel().ID
+		// Map outputs from composite RunContext to job RunContext
 		eval := compositeRC.NewExpressionEvaluator(ctx)
+		outputs := make(map[string]string, len(action.Outputs))
 		for outputName, output := range action.Outputs {
-			rc.setOutputForStep(ctx, stepID, map[string]string{
-				"name": outputName,
-			}, eval.Interpolate(ctx, output.Value))
+			outputs[outputName] = eval.Interpolate(ctx, output.Value)
 		}
 
 		for _, mask := range compositeRC.masksSnapshot() {
 			rc.AddMask(mask)
 		}
-		rc.ExtraPath = compositeRC.ExtraPath
+
+		stepID := step.getStepModel().ID
+		lock := rc.stepStateLock()
+		lock.Lock()
+		defer lock.Unlock()
+
+		for outputName, value := range outputs {
+			rc.setOutputForStep(ctx, stepID, map[string]string{
+				"name": outputName,
+			}, value)
+		}
+
+		// merge the PATH additions of the composite action into the current
+		// extra path instead of overwriting it, other steps may have added
+		// entries while the composite action ran
+		mergedPath := append([]string{}, compositeRC.ExtraPath...)
+		for _, entry := range rc.ExtraPath {
+			exists := false
+			for _, merged := range mergedPath {
+				if merged == entry {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				mergedPath = append(mergedPath, entry)
+			}
+		}
+		rc.ExtraPath = mergedPath
 		// compositeRC.Env is dirty, contains INPUT_ and merged step env, only rely on compositeRC.GlobalEnv
 		mergeIntoMap := mergeIntoMapCaseSensitive
 		if rc.JobContainer.IsEnvironmentCaseInsensitive() {
@@ -218,8 +250,11 @@ func (rc *RunContext) newCompositeCommandExecutor(executor common.Executor) comm
 			return true
 		})
 
-		oldout, olderr := rc.JobContainer.ReplaceLogWriter(logWriter, logWriter)
-		defer rc.JobContainer.ReplaceLogWriter(oldout, olderr)
+		// the handler is published on the context, which the execution
+		// environments prefer over their global writer slot; a step running
+		// this composite action has its own writers on the context and they
+		// must not swallow the commands of the composite's inner steps
+		ctx = container.WithLogWriters(ctx, logWriter, logWriter)
 
 		return executor(ctx)
 	}

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -70,7 +70,7 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		ActionPath:       actionPath,
 		Env:              env,
 		GlobalEnv:        parent.GlobalEnv,
-		Masks:            parent.Masks,
+		Masks:            parent.masksSnapshot(),
 		ExtraPath:        parent.ExtraPath,
 		Parent:           parent,
 		EventJSON:        parent.EventJSON,
@@ -106,7 +106,9 @@ func execAsComposite(step actionStep) common.Executor {
 			}, eval.Interpolate(ctx, output.Value))
 		}
 
-		rc.Masks = append(rc.Masks, compositeRC.Masks...)
+		for _, mask := range compositeRC.masksSnapshot() {
+			rc.AddMask(mask)
+		}
 		rc.ExtraPath = compositeRC.ExtraPath
 		// compositeRC.Env is dirty, contains INPUT_ and merged step env, only rely on compositeRC.GlobalEnv
 		mergeIntoMap := mergeIntoMapCaseSensitive

--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -73,6 +73,7 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		Masks:            parent.Masks,
 		ExtraPath:        parent.ExtraPath,
 		Parent:           parent,
+		parentStepID:     step.getStepModel().ID,
 		EventJSON:        parent.EventJSON,
 		nodeToolFullPath: parent.nodeToolFullPath,
 	}
@@ -98,10 +99,13 @@ func execAsComposite(step actionStep) common.Executor {
 
 		err := steps.main(ctx)
 
-		// Map outputs from composite RunContext to job RunContext
+		// Map outputs from composite RunContext to job RunContext. They
+		// belong to the step that used the action, not to whichever step is
+		// current once the composite finished.
+		stepID := step.getStepModel().ID
 		eval := compositeRC.NewExpressionEvaluator(ctx)
 		for outputName, output := range action.Outputs {
-			rc.setOutput(ctx, map[string]string{
+			rc.setOutputForStep(ctx, stepID, map[string]string{
 				"name": outputName,
 			}, eval.Interpolate(ctx, output.Value))
 		}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -34,6 +34,13 @@ func tryParseRawActionCommand(line string) (command string, kvPairs map[string]s
 }
 
 func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
+	return rc.stepCommandHandler(ctx, "")
+}
+
+// stepCommandHandler returns a line handler that records step scoped commands
+// against stepID. With an empty stepID they are recorded against the step that
+// is current when the command is processed.
+func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) common.LineHandler {
 	logger := common.Logger(ctx)
 	resumeCommand := ""
 	return func(line string) bool {
@@ -48,6 +55,9 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 		}
 		arg = unescapeCommandData(arg)
 		kvPairs = unescapeKvPairs(kvPairs)
+		if stepID == "" {
+			stepID = rc.CurrentStep
+		}
 		defCommandLogger := logger.WithFields(logrus.Fields{"command": command, "kvPairs": kvPairs, "arg": arg, "raw": line})
 		switch command {
 		case "set-env":
@@ -57,7 +67,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			}
 			rc.setEnv(ctx, kvPairs, arg)
 		case "set-output":
-			rc.setOutput(ctx, kvPairs, arg)
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
 		case "add-path":
 			if rc.Env["ACTIONS_ALLOW_UNSECURE_COMMANDS"] != "true" {
 				defCommandLogger.Errorf("The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsafe commands by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.")
@@ -81,7 +91,7 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 			defCommandLogger.Infof("  \U00002699  %s", line)
 		case "save-state":
 			defCommandLogger.Infof("  \U0001f4be  %s", line)
-			rc.saveState(ctx, kvPairs, arg)
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
 		case "add-matcher":
 			defCommandLogger.Infof("  \U00002753 add-matcher %s", arg)
 		default:
@@ -111,9 +121,8 @@ func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg
 	mergeIntoMap(rc.Env, newenv)
 	mergeIntoMap(rc.GlobalEnv, newenv)
 }
-func (rc *RunContext) setOutput(ctx context.Context, kvPairs map[string]string, arg string) {
+func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPairs map[string]string, arg string) {
 	logger := common.Logger(ctx)
-	stepID := rc.CurrentStep
 	outputName := kvPairs["name"]
 	if outputMapping, ok := rc.OutputMappings[MappableOutput{StepID: stepID, OutputName: outputName}]; ok {
 		stepID = outputMapping.StepID
@@ -182,8 +191,7 @@ func unescapeKvPairs(kvPairs map[string]string) map[string]string {
 	return kvPairs
 }
 
-func (rc *RunContext) saveState(_ context.Context, kvPairs map[string]string, arg string) {
-	stepID := rc.CurrentStep
+func (rc *RunContext) saveStateForStep(_ context.Context, stepID string, kvPairs map[string]string, arg string) {
 	if stepID != "" {
 		if rc.IntraActionState == nil {
 			rc.IntraActionState = map[string]map[string]string{}

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -37,9 +37,9 @@ func (rc *RunContext) commandHandler(ctx context.Context) common.LineHandler {
 	return rc.stepCommandHandler(ctx, "")
 }
 
-// stepCommandHandler returns a line handler that records step scoped commands
-// against stepID. With an empty stepID they are recorded against the step that
-// is current when the command is processed.
+// stepCommandHandler returns a line handler routing step scoped commands to
+// stepID. With an empty stepID commands are routed to the current step, which
+// is ambiguous while background steps run concurrently.
 func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) common.LineHandler {
 	logger := common.Logger(ctx)
 	resumeCommand := ""
@@ -55,9 +55,18 @@ func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) com
 		}
 		arg = unescapeCommandData(arg)
 		kvPairs = unescapeKvPairs(kvPairs)
+
+		lock := rc.stepStateLock()
+		lock.Lock()
+		defer lock.Unlock()
+		// resolved per line rather than assigned to the captured stepID, which
+		// would pin every later command of this handler to the step that
+		// happened to be current when the first one arrived
+		stepID := stepID
 		if stepID == "" {
-			stepID = rc.CurrentStep
+			stepID = rc.currentStep()
 		}
+
 		defCommandLogger := logger.WithFields(logrus.Fields{"command": command, "kvPairs": kvPairs, "arg": arg, "raw": line})
 		switch command {
 		case "set-env":
@@ -105,6 +114,9 @@ func (rc *RunContext) stepCommandHandler(ctx context.Context, stepID string) com
 func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg string) {
 	name := kvPairs["name"]
 	common.Logger(ctx).WithFields(logrus.Fields{"command": "set-env", "name": name, "arg": arg}).Infof("  \U00002699  ::set-env:: %s=%s", name, arg)
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	if rc.Env == nil {
 		rc.Env = make(map[string]string)
 	}
@@ -123,6 +135,9 @@ func (rc *RunContext) setEnv(ctx context.Context, kvPairs map[string]string, arg
 }
 func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPairs map[string]string, arg string) {
 	logger := common.Logger(ctx)
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	outputName := kvPairs["name"]
 	if outputMapping, ok := rc.OutputMappings[MappableOutput{StepID: stepID, OutputName: outputName}]; ok {
 		stepID = outputMapping.StepID
@@ -140,6 +155,9 @@ func (rc *RunContext) setOutputForStep(ctx context.Context, stepID string, kvPai
 }
 func (rc *RunContext) addPath(ctx context.Context, arg string) {
 	common.Logger(ctx).WithFields(logrus.Fields{"command": "add-path", "arg": arg}).Infof("  \U00002699  ::add-path:: %s", arg)
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	extraPath := []string{arg}
 	for _, v := range rc.ExtraPath {
 		if v != arg {
@@ -192,6 +210,9 @@ func unescapeKvPairs(kvPairs map[string]string) map[string]string {
 }
 
 func (rc *RunContext) saveStateForStep(_ context.Context, stepID string, kvPairs map[string]string, arg string) {
+	dataLock := rc.stateDataLock()
+	dataLock.Lock()
+	defer dataLock.Unlock()
 	if stepID != "" {
 		if rc.IntraActionState == nil {
 			rc.IntraActionState = map[string]map[string]string{}

--- a/pkg/runner/container_mock_test.go
+++ b/pkg/runner/container_mock_test.go
@@ -10,18 +10,18 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// matchCmdFile matches a runner file command path regardless of the unique
-// per step execution directory it now lives in
-func matchCmdFile(name string) interface{} {
-	return mock.MatchedBy(func(path string) bool {
-		return strings.HasPrefix(path, "/var/run/act/workflow/") && strings.HasSuffix(path, "/"+name)
-	})
-}
-
 type containerMock struct {
 	mock.Mock
 	container.Container
 	container.LinuxContainerEnvironmentExtensions
+}
+
+// matchCmdFile matches a runner file command path regardless of the unique
+// per step directory it is placed in
+func matchCmdFile(name string) interface{} {
+	return mock.MatchedBy(func(path string) bool {
+		return strings.HasPrefix(path, "/var/run/act/workflow/") && strings.HasSuffix(path, "/"+name)
+	})
 }
 
 func (cm *containerMock) Create(capAdd []string, capDrop []string) common.Executor {

--- a/pkg/runner/container_mock_test.go
+++ b/pkg/runner/container_mock_test.go
@@ -3,11 +3,20 @@ package runner
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/container"
 	"github.com/stretchr/testify/mock"
 )
+
+// matchCmdFile matches a runner file command path regardless of the unique
+// per step execution directory it now lives in
+func matchCmdFile(name string) interface{} {
+	return mock.MatchedBy(func(path string) bool {
+		return strings.HasPrefix(path, "/var/run/act/workflow/") && strings.HasSuffix(path, "/"+name)
+	})
+}
 
 type containerMock struct {
 	mock.Mock

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -26,9 +26,11 @@ type ExpressionEvaluator interface {
 	Interpolate(context.Context, string) string
 }
 
-// NewExpressionEvaluator creates a new evaluator
+// NewExpressionEvaluator creates a new evaluator. The evaluator operates on
+// a snapshot of the job env and step results taken at creation time, so it
+// can be used while steps running concurrently in the background mutate them.
 func (rc *RunContext) NewExpressionEvaluator(ctx context.Context) ExpressionEvaluator {
-	return rc.NewExpressionEvaluatorWithEnv(ctx, rc.GetEnv())
+	return rc.NewExpressionEvaluatorWithEnv(ctx, rc.envSnapshot())
 }
 
 func (rc *RunContext) NewExpressionEvaluatorWithEnv(ctx context.Context, env map[string]string) ExpressionEvaluator {
@@ -82,7 +84,7 @@ func (rc *RunContext) NewExpressionEvaluatorWithEnv(ctx context.Context, env map
 		Jobs:   &workflowCallResult,
 		// todo: should be unavailable
 		// but required to interpolate/evaluate the step outputs on the job
-		Steps:     rc.getStepsContext(),
+		Steps:     rc.stepsSnapshot(),
 		Secrets:   getWorkflowSecrets(ctx, rc),
 		Vars:      getWorkflowVars(ctx, rc),
 		Strategy:  strategy,
@@ -144,7 +146,7 @@ func (rc *RunContext) newStepExpressionEvaluator(ctx context.Context, step step,
 		Github:   step.getGithubContext(ctx),
 		Env:      *step.getEnv(),
 		Job:      rc.getJobContext(),
-		Steps:    rc.getStepsContext(),
+		Steps:    rc.stepsSnapshot(),
 		Secrets:  getWorkflowSecrets(ctx, rc),
 		Vars:     getWorkflowVars(ctx, rc),
 		Strategy: strategy,
@@ -200,18 +202,15 @@ func getHashFilesFunction(ctx context.Context, rc *RunContext) func(v []reflect.
 				env["followSymbolicLinks"] = "true"
 			}
 
-			stdout, stderr := rc.JobContainer.ReplaceLogWriter(hout, herr)
+			// capture the output of the helper on the context, which the
+			// execution environments prefer over their global writer slot
 			_ = rc.JobContainer.Copy(rc.JobContainer.GetActPath(), &container.FileEntry{
 				Name: name,
 				Mode: 0o644,
 				Body: hashfiles,
 			}).
 				Then(rc.execJobContainer([]string{rc.GetNodeToolFullPath(ctx), path.Join(rc.JobContainer.GetActPath(), name)},
-					env, "", "")).
-				Finally(func(context.Context) error {
-					rc.JobContainer.ReplaceLogWriter(stdout, stderr)
-					return nil
-				})(timeed)
+					env, "", ""))(container.WithLogWriters(timeed, hout, herr))
 			output := hout.String() + "\n" + herr.String()
 			guard := "__OUTPUT__"
 			outstart := strings.Index(output, guard)

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
 	"github.com/nektos/act/pkg/model"
 )
 
@@ -33,11 +34,16 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		return nil
 	})
 
-	infoSteps := info.steps()
+	infoSteps, expandErr := expandParallelStepGroups(info.steps())
+	if expandErr != nil {
+		return common.NewErrorExecutor(expandErr)
+	}
 
 	if len(infoSteps) == 0 {
 		return common.NewDebugExecutor("No steps found")
 	}
+
+	backgroundSteps := newBackgroundStepRegistry()
 
 	preSteps = append(preSteps, func(ctx context.Context) error {
 		// Have to be skipped for some Tests
@@ -73,6 +79,13 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			stepModel.ID = fmt.Sprintf("%d", i)
 		}
 
+		if stepModel.IsBackgroundControl() {
+			// wait, wait-all and cancel steps always run, they are not
+			// skipped when a previous step failed and have no pre/post stage
+			steps = append(steps, newControlStepExecutor(rc, backgroundSteps, stepModel, setJobError))
+			continue
+		}
+
 		step, err := sf.newStep(stepModel, rc)
 
 		if err != nil {
@@ -81,16 +94,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 
 		preSteps = append(preSteps, useStepLogger(rc, stepModel, stepStagePre, step.pre().ThenError(setJobError)))
 
-		stepExec := step.main()
-		steps = append(steps, useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
-			err := stepExec(ctx)
-			if err != nil {
-				_ = setJobError(ctx, err)
-			} else if ctx.Err() != nil {
-				_ = setJobError(ctx, ctx.Err())
-			}
-			return nil
-		}))
+		steps = append(steps, newMainStepExecutor(rc, backgroundSteps, stepModel, step.main(), setJobError))
 
 		postExec := useStepLogger(rc, stepModel, stepStagePost, step.post().ThenError(setJobError))
 		if postExecutor != nil {
@@ -99,6 +103,12 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		} else {
 			postExecutor = postExec
 		}
+	}
+
+	if postExecutor == nil {
+		// a job may consist only of wait/wait-all/cancel steps, which have
+		// no post stage
+		postExecutor = common.NewPipelineExecutor()
 	}
 
 	var stopContainerExecutor common.Executor = func(ctx context.Context) error {
@@ -135,6 +145,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 				Then(common.NewFieldExecutor("stepResult", model.StepStatusSuccess, common.NewInfoExecutor("  \u2705  Success - Set up job"))).
 				ThenError(setJobError).OnError(common.NewFieldExecutor("stepResult", model.StepStatusFailure, common.NewInfoExecutor("  \u274C  Failure - Set up job"))))),
 		common.NewPipelineExecutor(pipeline...).
+			Finally(backgroundSteps.cancelRemaining()).
 			Finally(func(ctx context.Context) error { //nolint:contextcheck
 				var cancel context.CancelFunc
 				if ctx.Err() == context.Canceled {
@@ -211,8 +222,10 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 			return true
 		})
 
-		oldout, olderr := rc.JobContainer.ReplaceLogWriter(logWriter, logWriter)
-		defer rc.JobContainer.ReplaceLogWriter(oldout, olderr)
+		// the writers travel with the context instead of being swapped in
+		// the execution environment's single global writer slot, so steps
+		// running concurrently each capture their own output
+		ctx = container.WithLogWriters(ctx, logWriter, logWriter)
 
 		return executor(ctx)
 	}

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -202,7 +202,7 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 		ctx = withStepLogger(ctx, stepModel.ID, rc.ExprEval.Interpolate(ctx, stepModel.String()), stage.String())
 
 		rawLogger := common.Logger(ctx).WithField("raw_output", true)
-		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+		logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, stepModel.ID), func(s string) bool {
 			if rc.Config.LogOutput {
 				rawLogger.Infof("%s", s)
 			} else {

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -41,6 +41,10 @@ type masksContextKey string
 
 const masksContextKeyVal = masksContextKey("logrus.FieldLogger")
 
+// masksMutex guards the masks slices, which are appended to by running steps
+// and read whenever a log line is formatted
+var masksMutex sync.RWMutex
+
 // Logger returns the appropriate logger for current context
 func Masks(ctx context.Context) *[]string {
 	val := ctx.Value(masksContextKeyVal)
@@ -153,15 +157,15 @@ func valueMasker(insecureSecrets bool, secrets map[string]string) entryProcessor
 			return entry
 		}
 
-		masks := Masks(entry.Context)
-
 		for _, v := range ssecrets {
 			if v != "" {
 				entry.Message = strings.ReplaceAll(entry.Message, v, "***")
 			}
 		}
 
-		for _, v := range *masks {
+		masksMutex.RLock()
+		defer masksMutex.RUnlock()
+		for _, v := range *Masks(entry.Context) {
 			if v != "" {
 				entry.Message = strings.ReplaceAll(entry.Message, v, "***")
 			}

--- a/pkg/runner/logger.go
+++ b/pkg/runner/logger.go
@@ -41,8 +41,9 @@ type masksContextKey string
 
 const masksContextKeyVal = masksContextKey("logrus.FieldLogger")
 
-// masksMutex guards the masks slices, which are appended to by running steps
-// and read whenever a log line is formatted
+// masksMutex guards the masks slices of all jobs, they are appended to by
+// running steps and read whenever a log line is formatted. With background
+// steps both can happen concurrently.
 var masksMutex sync.RWMutex
 
 // Logger returns the appropriate logger for current context
@@ -157,15 +158,23 @@ func valueMasker(insecureSecrets bool, secrets map[string]string) entryProcessor
 			return entry
 		}
 
+		// copied rather than held under the lock for the whole rewrite, so a
+		// step adding a mask is not blocked by unrelated log formatting. The
+		// common case is no masks at all, which allocates nothing.
+		var masks []string
+		masksMutex.RLock()
+		if current := *Masks(entry.Context); len(current) > 0 {
+			masks = append(make([]string, 0, len(current)), current...)
+		}
+		masksMutex.RUnlock()
+
 		for _, v := range ssecrets {
 			if v != "" {
 				entry.Message = strings.ReplaceAll(entry.Message, v, "***")
 			}
 		}
 
-		masksMutex.RLock()
-		defer masksMutex.RUnlock()
-		for _, v := range *Masks(entry.Context) {
+		for _, v := range masks {
 			if v != "" {
 				entry.Message = strings.ReplaceAll(entry.Message, v, "***")
 			}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/go-connections/nat"
@@ -55,8 +56,89 @@ type RunContext struct {
 	nodeToolFullPath    string
 
 	// parentStepID is the id of the action step a composite RunContext was
-	// created for. It is stable, unlike the mutable CurrentStep.
+	// created for, it is stable while the mutable CurrentStep is not
 	parentStepID string
+
+	// stepStateMu serializes mutations of the shared job state (StepResults,
+	// Env, ExtraPath, ...) between steps running concurrently because of
+	// `background: true`
+	stepStateMu sync.Mutex
+
+	// currentStepMu guards CurrentStep, which is also read while steps run
+	// concurrently in the background
+	currentStepMu sync.RWMutex
+
+	// stateDataMu guards the shared maps and slices themselves (Env,
+	// StepResults, ExtraPath, IntraActionState): expression evaluators
+	// snapshot them under a read lock while running steps mutate them under
+	// the write lock, so a step executing concurrently in the background
+	// never observes a map mid-write
+	stateDataMu sync.RWMutex
+}
+
+// stateDataLock returns the mutex guarding the shared data structures.
+// Composite action steps share the lock of their root RunContext.
+func (rc *RunContext) stateDataLock() *sync.RWMutex {
+	root := rc
+	for root.Parent != nil {
+		root = root.Parent
+	}
+	return &root.stateDataMu
+}
+
+// envSnapshot returns a copy of the job env for expression evaluation, safe
+// to read while other steps concurrently change the env
+func (rc *RunContext) envSnapshot() map[string]string {
+	lock := rc.stateDataLock()
+	lock.Lock()
+	defer lock.Unlock()
+	env := rc.getEnvLocked()
+	snapshot := make(map[string]string, len(env))
+	for k, v := range env {
+		snapshot[k] = v
+	}
+	return snapshot
+}
+
+// stepsSnapshot returns a copy of the step results for expression
+// evaluation, safe to read while other steps concurrently record results
+func (rc *RunContext) stepsSnapshot() map[string]*model.StepResult {
+	lock := rc.stateDataLock()
+	lock.RLock()
+	defer lock.RUnlock()
+	snapshot := make(map[string]*model.StepResult, len(rc.StepResults))
+	for id, result := range rc.StepResults {
+		copied := *result
+		copied.Outputs = make(map[string]string, len(result.Outputs))
+		for k, v := range result.Outputs {
+			copied.Outputs[k] = v
+		}
+		snapshot[id] = &copied
+	}
+	return snapshot
+}
+
+func (rc *RunContext) setCurrentStep(stepID string) {
+	rc.currentStepMu.Lock()
+	defer rc.currentStepMu.Unlock()
+	rc.CurrentStep = stepID
+}
+
+func (rc *RunContext) currentStep() string {
+	rc.currentStepMu.RLock()
+	defer rc.currentStepMu.RUnlock()
+	return rc.CurrentStep
+}
+
+// stepStateLock returns the mutex guarding the shared job state. Composite
+// action steps share the lock of their root RunContext since they mutate
+// state of their parents.
+func (rc *RunContext) stepStateLock() *sync.Mutex {
+	root := rc
+	for root.Parent != nil {
+		root = root.Parent
+	}
+	return &root.stepStateMu
 }
 
 func (rc *RunContext) AddMask(mask string) {
@@ -65,8 +147,8 @@ func (rc *RunContext) AddMask(mask string) {
 	rc.Masks = append(rc.Masks, mask)
 }
 
-// masksSnapshot returns a copy of the current masks; the slice is appended to
-// by running steps and must not be read without the mutex
+// masksSnapshot returns a copy of the current masks, the slice is appended
+// to by running steps and must not be read without the mutex
 func (rc *RunContext) masksSnapshot() []string {
 	masksMutex.RLock()
 	defer masksMutex.RUnlock()
@@ -90,6 +172,13 @@ func (rc *RunContext) String() string {
 
 // GetEnv returns the env for the context
 func (rc *RunContext) GetEnv() map[string]string {
+	lock := rc.stateDataLock()
+	lock.Lock()
+	defer lock.Unlock()
+	return rc.getEnvLocked()
+}
+
+func (rc *RunContext) getEnvLocked() map[string]string {
 	if rc.Env == nil {
 		rc.Env = map[string]string{}
 		if rc.Run != nil && rc.Run.Workflow != nil && rc.Config != nil {
@@ -99,7 +188,9 @@ func (rc *RunContext) GetEnv() map[string]string {
 			}
 		}
 	}
-	rc.Env["ACT"] = "true"
+	if rc.Env["ACT"] != "true" {
+		rc.Env["ACT"] = "true"
+	}
 	return rc.Env
 }
 
@@ -483,13 +574,10 @@ func (rc *RunContext) GetNodeToolFullPath(ctx context.Context) string {
 		cenv[path] = cpath
 		hout := &bytes.Buffer{}
 		herr := &bytes.Buffer{}
-		stdout, stderr := rc.JobContainer.ReplaceLogWriter(hout, herr)
+		// capture the output on the context, which the execution
+		// environments prefer over their global writer slot
 		err := rc.execJobContainer([]string{"node", "--no-warnings", "-e", "console.log(process.execPath)"},
-			cenv, "", "").
-			Finally(func(context.Context) error {
-				rc.JobContainer.ReplaceLogWriter(stdout, stderr)
-				return nil
-			})(timeed)
+			cenv, "", "")(container.WithLogWriters(timeed, hout, herr))
 		rawStr := strings.Trim(hout.String(), "\r\n")
 		if err == nil && !strings.ContainsAny(rawStr, "\r\n") {
 			rc.nodeToolFullPath = rawStr
@@ -501,7 +589,15 @@ func (rc *RunContext) GetNodeToolFullPath(ctx context.Context) string {
 }
 
 func (rc *RunContext) ApplyExtraPath(ctx context.Context, env *map[string]string) {
-	if len(rc.ExtraPath) > 0 {
+	lock := rc.stateDataLock()
+	lock.RLock()
+	extraPath := append([]string{}, rc.ExtraPath...)
+	lock.RUnlock()
+	rc.applyExtraPathSnapshot(ctx, extraPath, env)
+}
+
+func (rc *RunContext) applyExtraPathSnapshot(ctx context.Context, extraPath []string, env *map[string]string) {
+	if len(extraPath) > 0 {
 		path := rc.JobContainer.GetPathVariableName()
 		if rc.JobContainer.IsEnvironmentCaseInsensitive() {
 			// On windows system Path and PATH could also be in the map
@@ -525,7 +621,7 @@ func (rc *RunContext) ApplyExtraPath(ctx context.Context, env *map[string]string
 			}
 			(*env)[path] = cpath
 		}
-		(*env)[path] = rc.JobContainer.JoinPathVariable(append(rc.ExtraPath, (*env)[path])...)
+		(*env)[path] = rc.JobContainer.JoinPathVariable(append(extraPath, (*env)[path])...)
 	}
 }
 
@@ -872,6 +968,9 @@ func trimToLen(s string, l int) string {
 }
 
 func (rc *RunContext) getJobContext() *model.JobContext {
+	lock := rc.stateDataLock()
+	lock.RLock()
+	defer lock.RUnlock()
 	jobStatus := "success"
 	if rc.Cancelled {
 		jobStatus = "cancelled"
@@ -894,6 +993,11 @@ func (rc *RunContext) getStepsContext() map[string]*model.StepResult {
 
 func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext {
 	logger := common.Logger(ctx)
+	lock := rc.stateDataLock()
+	lock.RLock()
+	actionRepository := rc.Env["GITHUB_ACTION_REPOSITORY"]
+	actionRef := rc.Env["GITHUB_ACTION_REF"]
+	lock.RUnlock()
 	ghc := &model.GithubContext{
 		Event:            make(map[string]interface{}),
 		Workflow:         rc.Run.Workflow.Name,
@@ -902,12 +1006,12 @@ func (rc *RunContext) getGithubContext(ctx context.Context) *model.GithubContext
 		RunNumber:        rc.Config.Env["GITHUB_RUN_NUMBER"],
 		Actor:            rc.Config.Actor,
 		EventName:        rc.Config.EventName,
-		Action:           rc.CurrentStep,
+		Action:           rc.currentStep(),
 		Token:            rc.Config.Token,
 		Job:              rc.Run.JobID,
 		ActionPath:       rc.ActionPath,
-		ActionRepository: rc.Env["GITHUB_ACTION_REPOSITORY"],
-		ActionRef:        rc.Env["GITHUB_ACTION_REF"],
+		ActionRepository: actionRepository,
+		ActionRef:        actionRef,
 		RepositoryOwner:  rc.Config.Env["GITHUB_REPOSITORY_OWNER"],
 		RetentionDays:    rc.Config.Env["GITHUB_RETENTION_DAYS"],
 		RunnerPerflog:    rc.Config.Env["RUNNER_PERFLOG"],

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -53,6 +53,10 @@ type RunContext struct {
 	caller              *caller // job calling this RunContext (reusable workflows)
 	Cancelled           bool
 	nodeToolFullPath    string
+
+	// parentStepID is the id of the action step a composite RunContext was
+	// created for. It is stable, unlike the mutable CurrentStep.
+	parentStepID string
 }
 
 func (rc *RunContext) AddMask(mask string) {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -56,7 +56,17 @@ type RunContext struct {
 }
 
 func (rc *RunContext) AddMask(mask string) {
+	masksMutex.Lock()
+	defer masksMutex.Unlock()
 	rc.Masks = append(rc.Masks, mask)
+}
+
+// masksSnapshot returns a copy of the current masks; the slice is appended to
+// by running steps and must not be read without the mutex
+func (rc *RunContext) masksSnapshot() []string {
+	masksMutex.RLock()
+	defer masksMutex.RUnlock()
+	return append([]string{}, rc.Masks...)
 }
 
 type MappableOutput struct {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -285,6 +285,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "workdir", "push", "", platforms, secrets},
 		{workdir, "defaults-run", "push", "", platforms, secrets},
 		{workdir, "composite-fail-with-output", "push", "", platforms, secrets},
+		{workdir, "composite-undeclared-outputs", "push", "", platforms, secrets},
 		{workdir, "issue-597", "push", "", platforms, secrets},
 		{workdir, "issue-598", "push", "", platforms, secrets},
 		{workdir, "if-env-act", "push", "", platforms, secrets},
@@ -557,6 +558,7 @@ func TestRunEventHostEnvironment(t *testing.T) {
 			// shell sh is not necessarily bash if the job has no override
 			// {workdir, "defaults-run", "push", "", platforms, secrets},
 			{workdir, "composite-fail-with-output", "push", "", platforms, secrets},
+			{workdir, "composite-undeclared-outputs", "push", "", platforms, secrets},
 			{workdir, "issue-597", "push", "", platforms, secrets},
 			{workdir, "issue-598", "push", "", platforms, secrets},
 			{workdir, "if-env-act", "push", "", platforms, secrets},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -281,6 +281,8 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "matrix", "push", "", platforms, secrets},
 		{workdir, "matrix-include-exclude", "push", "", platforms, secrets},
 		{workdir, "matrix-exitcode", "push", "Job 'test' failed", platforms, secrets},
+		{workdir, "background-steps-container", "push", "", platforms, secrets},
+		{workdir, "background-steps-matrix", "push", "", platforms, secrets},
 		{workdir, "commands", "push", "", platforms, secrets},
 		{workdir, "workdir", "push", "", platforms, secrets},
 		{workdir, "defaults-run", "push", "", platforms, secrets},

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/nektos/act/pkg/common"
@@ -91,6 +92,10 @@ func processRunnerEnvFileCommand(ctx context.Context, fileName string, rc *RunCo
 	return nil
 }
 
+// stepFileCommandSeq makes the runner file command paths unique per step
+// execution, so the commands of one step cannot be read by the next
+var stepFileCommandSeq atomic.Int64
+
 func runStepExecutor(step step, stage stepStage, executor common.Executor) common.Executor {
 	return func(ctx context.Context) error {
 		logger := common.Logger(ctx)
@@ -137,22 +142,25 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		}
 		logger.Infof("\u2B50 Run %s %s", stage, stepString)
 
-		// Prepare and clean Runner File Commands
+		// Prepare and clean Runner File Commands. Every step execution gets
+		// its own directory, so a step never reads the file commands another
+		// step left behind.
 		actPath := rc.JobContainer.GetActPath()
+		cmdDir := path.Join("workflow", fmt.Sprintf("cmds-%d-%s", stepFileCommandSeq.Add(1), stage.String()))
 
-		outputFileCommand := path.Join("workflow", "outputcmd.txt")
+		outputFileCommand := path.Join(cmdDir, "outputcmd.txt")
 		(*step.getEnv())["GITHUB_OUTPUT"] = path.Join(actPath, outputFileCommand)
 
-		stateFileCommand := path.Join("workflow", "statecmd.txt")
+		stateFileCommand := path.Join(cmdDir, "statecmd.txt")
 		(*step.getEnv())["GITHUB_STATE"] = path.Join(actPath, stateFileCommand)
 
-		pathFileCommand := path.Join("workflow", "pathcmd.txt")
+		pathFileCommand := path.Join(cmdDir, "pathcmd.txt")
 		(*step.getEnv())["GITHUB_PATH"] = path.Join(actPath, pathFileCommand)
 
-		envFileCommand := path.Join("workflow", "envs.txt")
+		envFileCommand := path.Join(cmdDir, "envs.txt")
 		(*step.getEnv())["GITHUB_ENV"] = path.Join(actPath, envFileCommand)
 
-		summaryFileCommand := path.Join("workflow", "SUMMARY.md")
+		summaryFileCommand := path.Join(cmdDir, "SUMMARY.md")
 		(*step.getEnv())["GITHUB_STEP_SUMMARY"] = path.Join(actPath, summaryFileCommand)
 
 		_ = rc.JobContainer.Copy(actPath, &container.FileEntry{
@@ -203,11 +211,18 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u274C  Failure - %s %s [%s]", stage, stepString, executionTime)
 		}
-		// Process Runner File Commands
+		// Process Runner File Commands. They belong to this step, so they are
+		// recorded against its id rather than whatever CurrentStep happens to
+		// hold by the time they are read.
+		stepID := stepModel.ID
 		ferrors := []error{err}
 		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, envFileCommand, rc, rc.setEnv))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, rc.saveState))
-		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, rc.setOutput))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, stateFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.saveStateForStep(ctx, stepID, kvPairs, arg)
+		}))
+		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, outputFileCommand, rc, func(ctx context.Context, kvPairs map[string]string, arg string) {
+			rc.setOutputForStep(ctx, stepID, kvPairs, arg)
+		}))
 		ferrors = append(ferrors, processRunnerSummaryCommand(ctx, summaryFileCommand, rc))
 		ferrors = append(ferrors, rc.UpdateExtraPath(ctx, path.Join(actPath, pathFileCommand)))
 		return errors.Join(ferrors...)

--- a/pkg/runner/step.go
+++ b/pkg/runner/step.go
@@ -93,7 +93,8 @@ func processRunnerEnvFileCommand(ctx context.Context, fileName string, rc *RunCo
 }
 
 // stepFileCommandSeq makes the runner file command paths unique per step
-// execution, so the commands of one step cannot be read by the next
+// execution, so steps running concurrently because of `background: true` do
+// not read each other's commands
 var stepFileCommandSeq atomic.Int64
 
 func runStepExecutor(step step, stage stepStage, executor common.Executor) common.Executor {
@@ -102,8 +103,16 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		rc := step.getRunContext()
 		stepModel := step.getStepModel()
 
+		// the shared job state is locked during the setup and the result
+		// processing of the step, but not while the step itself runs, so
+		// background steps run concurrently with other steps
+		lock := rc.stepStateLock()
+		lock.Lock()
+
 		ifExpression := step.getIfExpression(ctx, stage)
-		rc.CurrentStep = stepModel.ID
+		rc.setCurrentStep(stepModel.ID)
+
+		dataLock := rc.stateDataLock()
 
 		stepResult := &model.StepResult{
 			Outcome:    model.StepStatusSuccess,
@@ -111,28 +120,39 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			Outputs:    make(map[string]string),
 		}
 		if stage == stepStageMain {
-			rc.StepResults[rc.CurrentStep] = stepResult
+			dataLock.Lock()
+			rc.StepResults[stepModel.ID] = stepResult
+			dataLock.Unlock()
 		}
 
 		err := setupEnv(ctx, step)
 		if err != nil {
+			lock.Unlock()
 			return err
 		}
 
 		cctx := common.JobCancelContext(ctx)
+		dataLock.Lock()
 		rc.Cancelled = cctx != nil && cctx.Err() != nil
+		dataLock.Unlock()
 
 		runStep, err := isStepEnabled(ctx, ifExpression, step, stage)
 		if err != nil {
+			dataLock.Lock()
 			stepResult.Conclusion = model.StepStatusFailure
 			stepResult.Outcome = model.StepStatusFailure
+			dataLock.Unlock()
+			lock.Unlock()
 			return err
 		}
 
 		if !runStep {
+			dataLock.Lock()
 			stepResult.Conclusion = model.StepStatusSkipped
 			stepResult.Outcome = model.StepStatusSkipped
+			dataLock.Unlock()
 			logger.WithField("stepResult", stepResult.Outcome).Debugf("Skipping step '%s' due to '%s'", stepModel, ifExpression)
+			lock.Unlock()
 			return nil
 		}
 
@@ -142,9 +162,7 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 		}
 		logger.Infof("\u2B50 Run %s %s", stage, stepString)
 
-		// Prepare and clean Runner File Commands. Every step execution gets
-		// its own directory, so a step never reads the file commands another
-		// step left behind.
+		// Prepare and clean Runner File Commands
 		actPath := rc.JobContainer.GetActPath()
 		cmdDir := path.Join("workflow", fmt.Sprintf("cmds-%d-%s", stepFileCommandSeq.Add(1), stage.String()))
 
@@ -180,27 +198,39 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			Mode: 0o666,
 		})(ctx)
 
+		timeout := rc.ExprEval.Interpolate(ctx, stepModel.TimeoutMinutes)
+		lock.Unlock()
+
 		stepCtx, cancelStepCtx := context.WithCancel(ctx)
 		defer cancelStepCtx()
 		var cancelTimeOut context.CancelFunc
-		stepCtx, cancelTimeOut = evaluateStepTimeout(stepCtx, rc.ExprEval, stepModel)
+		stepCtx, cancelTimeOut = evaluateStepTimeout(stepCtx, timeout)
 		defer cancelTimeOut()
 		monitorJobCancellation(ctx, stepCtx, cctx, rc, logger, ifExpression, step, stage, cancelStepCtx)
 		startTime := time.Now()
 		err = executor(stepCtx)
 		executionTime := time.Since(startTime)
 
+		lock.Lock()
+		defer lock.Unlock()
+		rc.setCurrentStep(stepModel.ID)
+
 		if err == nil {
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u2705  Success - %s %s [%s]", stage, stepString, executionTime)
 		} else {
+			dataLock.Lock()
 			stepResult.Outcome = model.StepStatusFailure
+			dataLock.Unlock()
 
 			continueOnError, parseErr := isContinueOnError(ctx, stepModel.RawContinueOnError, step, stage)
 			if parseErr != nil {
+				dataLock.Lock()
 				stepResult.Conclusion = model.StepStatusFailure
+				dataLock.Unlock()
 				return parseErr
 			}
 
+			dataLock.Lock()
 			if continueOnError {
 				logger.Infof("Failed but continue next step")
 				err = nil
@@ -208,12 +238,11 @@ func runStepExecutor(step step, stage stepStage, executor common.Executor) commo
 			} else {
 				stepResult.Conclusion = model.StepStatusFailure
 			}
+			dataLock.Unlock()
 
 			logger.WithFields(logrus.Fields{"executionTime": executionTime, "stepResult": stepResult.Outcome}).Infof("  \u274C  Failure - %s %s [%s]", stage, stepString, executionTime)
 		}
-		// Process Runner File Commands. They belong to this step, so they are
-		// recorded against its id rather than whatever CurrentStep happens to
-		// hold by the time they are read.
+		// Process Runner File Commands
 		stepID := stepModel.ID
 		ferrors := []error{err}
 		ferrors = append(ferrors, processRunnerEnvFileCommand(ctx, envFileCommand, rc, rc.setEnv))
@@ -234,9 +263,15 @@ func monitorJobCancellation(ctx context.Context, stepCtx context.Context, jobCan
 		go func() {
 			select {
 			case <-jobCancellationCtx.Done():
+				lock := rc.stepStateLock()
+				lock.Lock()
+				dataLock := rc.stateDataLock()
+				dataLock.Lock()
 				rc.Cancelled = true
+				dataLock.Unlock()
 				logger.Infof("Reevaluate condition %v due to cancellation", ifExpression)
 				keepStepRunning, err := isStepEnabled(ctx, ifExpression, step, stage)
+				lock.Unlock()
 				logger.Infof("Result condition keepStepRunning=%v", keepStepRunning)
 				if !keepStepRunning || err != nil {
 					cancelStepCtx()
@@ -247,8 +282,7 @@ func monitorJobCancellation(ctx context.Context, stepCtx context.Context, jobCan
 	}
 }
 
-func evaluateStepTimeout(ctx context.Context, exprEval ExpressionEvaluator, stepModel *model.Step) (context.Context, context.CancelFunc) {
-	timeout := exprEval.Interpolate(ctx, stepModel.TimeoutMinutes)
+func evaluateStepTimeout(ctx context.Context, timeout string) (context.Context, context.CancelFunc) {
 	if timeout != "" {
 		if timeOutMinutes, err := strconv.ParseInt(timeout, 10, 64); err == nil {
 			return context.WithTimeout(ctx, time.Duration(timeOutMinutes)*time.Minute)

--- a/pkg/runner/step_action_local_test.go
+++ b/pkg/runner/step_action_local_test.go
@@ -73,20 +73,20 @@ func TestStepActionLocalTest(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	salm.On("runAction", sal, filepath.Clean("/tmp/path/to/action"), (*remoteAction)(nil)).Return(func(_ context.Context) error {
 		return nil
@@ -270,20 +270,20 @@ func TestStepActionLocalPost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sal.post()(ctx)

--- a/pkg/runner/step_action_remote_test.go
+++ b/pkg/runner/step_action_remote_test.go
@@ -175,20 +175,20 @@ func TestStepActionRemote(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.pre()(ctx)
@@ -588,20 +588,20 @@ func TestStepActionRemotePost(t *testing.T) {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+				cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 					return nil
 				})
 
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-				cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+				cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 			}
 
 			err := sar.post()(ctx)

--- a/pkg/runner/step_background.go
+++ b/pkg/runner/step_background.go
@@ -1,0 +1,394 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/exprparser"
+	"github.com/nektos/act/pkg/model"
+)
+
+// maxConcurrentBackgroundSteps limits how many background steps of a job run
+// at the same time, additional background steps queue until a slot is free
+const maxConcurrentBackgroundSteps = 10
+
+// backgroundStep tracks one running background step of a job
+type backgroundStep struct {
+	id      string
+	started chan struct{}
+	done    chan struct{}
+	cancel  context.CancelFunc
+
+	mu        sync.Mutex
+	err       error
+	cancelled bool
+	collected bool
+}
+
+func (bs *backgroundStep) queued() bool {
+	select {
+	case <-bs.started:
+		return false
+	default:
+		return true
+	}
+}
+
+// markCancelled gracefully terminates the step, a deliberately cancelled
+// step does not fail the job
+func (bs *backgroundStep) markCancelled() {
+	bs.mu.Lock()
+	bs.cancelled = true
+	bs.mu.Unlock()
+	bs.cancel()
+}
+
+func (bs *backgroundStep) setError(err error) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if !bs.cancelled {
+		bs.err = err
+	}
+}
+
+// takeError returns the failure of the step the first time it is called, so
+// a background step fails the job only at the first `wait` that includes it
+func (bs *backgroundStep) takeError() error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if bs.cancelled || bs.collected {
+		return nil
+	}
+	bs.collected = true
+	return bs.err
+}
+
+func (bs *backgroundStep) running() bool {
+	select {
+	case <-bs.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// backgroundStepRegistry tracks the background steps of one job execution
+type backgroundStepRegistry struct {
+	mu    sync.Mutex
+	slots chan struct{}
+	steps map[string]*backgroundStep
+	order []*backgroundStep
+}
+
+func newBackgroundStepRegistry() *backgroundStepRegistry {
+	return &backgroundStepRegistry{
+		slots: make(chan struct{}, maxConcurrentBackgroundSteps),
+		steps: map[string]*backgroundStep{},
+	}
+}
+
+func (r *backgroundStepRegistry) get(id string) *backgroundStep {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.steps[id]
+}
+
+func (r *backgroundStepRegistry) all() []*backgroundStep {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*backgroundStep{}, r.order...)
+}
+
+// launch starts executor asynchronously as a background step and returns as
+// soon as it is registered, the step waits for one of the limited background
+// slots before it runs
+func (r *backgroundStepRegistry) launch(ctx context.Context, id string, executor common.Executor) error {
+	stepCtx, cancel := context.WithCancel(ctx)
+	bs := &backgroundStep{id: id, started: make(chan struct{}), done: make(chan struct{}), cancel: cancel}
+
+	r.mu.Lock()
+	if _, exists := r.steps[id]; exists {
+		r.mu.Unlock()
+		cancel()
+		return fmt.Errorf("background step id '%s' is not unique, wait and cancel steps could not tell the steps apart", id)
+	}
+	r.steps[id] = bs
+	r.order = append(r.order, bs)
+	r.mu.Unlock()
+
+	go func() {
+		defer close(bs.done)
+		defer cancel()
+		select {
+		case r.slots <- struct{}{}:
+		default:
+			common.Logger(ctx).Infof("Background step '%s' is queued, at most %d background steps run concurrently", id, maxConcurrentBackgroundSteps)
+			select {
+			case r.slots <- struct{}{}:
+			case <-stepCtx.Done():
+				bs.setError(stepCtx.Err())
+				return
+			}
+		}
+		close(bs.started)
+		defer func() { <-r.slots }()
+		bs.setError(executor(stepCtx))
+	}()
+	return nil
+}
+
+func (r *backgroundStepRegistry) waitFor(ctx context.Context, bs *backgroundStep) error {
+	select {
+	case <-bs.done:
+		return bs.takeError()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// cancelRemaining stops background steps that are still running when the job
+// ends, like services started with `background: true` that were never waited
+// for, their results do not affect the job result
+func (r *backgroundStepRegistry) cancelRemaining() common.Executor {
+	return func(ctx context.Context) error {
+		logger := common.Logger(ctx)
+		for _, bs := range r.all() {
+			if bs.running() {
+				logger.Infof("\U0001F6D1  Stopping background step '%s' still running at the end of the job", bs.id)
+				bs.markCancelled()
+			}
+		}
+		for _, bs := range r.all() {
+			select {
+			case <-bs.done:
+			case <-time.After(time.Minute):
+				logger.Errorf("Background step '%s' did not stop in time", bs.id)
+			}
+		}
+		return nil
+	}
+}
+
+// expandParallelStepGroups desugars every `parallel` step group into
+// background steps followed by an implicit `wait` for the whole group
+func expandParallelStepGroups(steps []*model.Step) ([]*model.Step, error) {
+	expanded := make([]*model.Step, 0, len(steps))
+	for _, stepModel := range steps {
+		if stepModel == nil || stepModel.Type() != model.StepTypeParallel {
+			expanded = append(expanded, stepModel)
+			continue
+		}
+		group := stepModel.ParallelSteps()
+		if len(group) == 0 {
+			return nil, fmt.Errorf("parallel step group '%s' contains no steps", stepModel.String())
+		}
+		ids := make([]string, 0, len(group))
+		for i, child := range group {
+			if child == nil {
+				return nil, fmt.Errorf("invalid step %d in parallel step group '%s': missing run or uses key", i, stepModel.String())
+			}
+			// GitHub's schema allows any step inside a `parallel` group, so the
+			// workflow still validates, but a group member that is itself a
+			// group or a control step has no meaning as a background step
+			switch child.Type() {
+			case model.StepTypeParallel:
+				return nil, fmt.Errorf("step %d in parallel step group '%s': nested 'parallel' groups are not supported", i, stepModel.String())
+			case model.StepTypeWait, model.StepTypeWaitAll, model.StepTypeCancel:
+				return nil, fmt.Errorf("step %d in parallel step group '%s': '%s' steps are not supported inside a group, put them after it", i, stepModel.String(), child.Type())
+			}
+			if child.ID == "" {
+				child.ID = fmt.Sprintf("%d", len(expanded))
+			}
+			child.Background = "true"
+			ids = append(ids, child.ID)
+			expanded = append(expanded, child)
+		}
+		wait := &model.Step{
+			ID:   stepModel.ID,
+			Name: fmt.Sprintf("Wait for parallel steps (%s)", strings.Join(ids, ", ")),
+		}
+		wait.RawWait.Kind = yaml.SequenceNode
+		wait.RawWait.Tag = "!!seq"
+		for _, id := range ids {
+			wait.RawWait.Content = append(wait.RawWait.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: id})
+		}
+		expanded = append(expanded, wait)
+	}
+	return expanded, nil
+}
+
+// newMainStepExecutor returns the main stage executor of a regular step.
+// Steps with `background: true` are only started and the job continues with
+// the next step right away, their failures surface at the next `wait` or
+// `wait-all` step that includes them.
+func newMainStepExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step, stepExec common.Executor, setJobError func(context.Context, error) error) common.Executor {
+	if stepModel.IsBackground() {
+		backgroundExec := useStepLogger(rc, stepModel, stepStageMain, stepExec)
+		stepID := stepModel.ID
+		stepName := stepModel.String()
+		return func(ctx context.Context) error {
+			common.Logger(ctx).Infof("⏩ Starting background step '%s'", stepName)
+			if err := registry.launch(ctx, stepID, backgroundExec); err != nil {
+				_ = setJobError(ctx, err)
+			}
+			return nil
+		}
+	}
+	return useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
+		err := stepExec(ctx)
+		if err != nil {
+			_ = setJobError(ctx, err)
+		} else if ctx.Err() != nil {
+			_ = setJobError(ctx, ctx.Err())
+		}
+		return nil
+	})
+}
+
+// newControlStepExecutor runs a `wait`, `wait-all` or `cancel` step. These
+// steps always run, even when a previous step failed, and do not support the
+// `if` conditional.
+func newControlStepExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step, setJobError func(context.Context, error) error) common.Executor {
+	controlExec := newBackgroundControlExecutor(rc, registry, stepModel)
+	return useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
+		err := controlExec(ctx)
+		if err != nil {
+			_ = setJobError(ctx, err)
+		} else if ctx.Err() != nil {
+			_ = setJobError(ctx, ctx.Err())
+		}
+		return nil
+	})
+}
+
+func newBackgroundControlExecutor(rc *RunContext, registry *backgroundStepRegistry, stepModel *model.Step) common.Executor {
+	return func(ctx context.Context) error {
+		logger := common.Logger(ctx)
+
+		stepResult := &model.StepResult{
+			Outcome:    model.StepStatusSuccess,
+			Conclusion: model.StepStatusSuccess,
+			Outputs:    make(map[string]string),
+		}
+		lock := rc.stepStateLock()
+		dataLock := rc.stateDataLock()
+		lock.Lock()
+		dataLock.Lock()
+		rc.StepResults[stepModel.ID] = stepResult
+		dataLock.Unlock()
+		lock.Unlock()
+
+		logger.Infof("⭐ Run %s", stepModel.String())
+
+		var err error
+		switch stepModel.Type() {
+		case model.StepTypeWait:
+			err = runWaitStep(ctx, registry, stepModel)
+		case model.StepTypeWaitAll:
+			err = runWaitAllStep(ctx, registry)
+		case model.StepTypeCancel:
+			err = runCancelStep(ctx, registry, stepModel)
+		default:
+			err = fmt.Errorf("step '%s' is not a background control step", stepModel.ID)
+		}
+
+		if err == nil {
+			logger.WithField("stepResult", stepResult.Outcome).Infof("  ✅  Success - %s", stepModel.String())
+			return nil
+		}
+
+		dataLock.Lock()
+		stepResult.Outcome = model.StepStatusFailure
+		dataLock.Unlock()
+		continueOnError, parseErr := evalStepContinueOnError(ctx, rc, stepModel)
+		if parseErr != nil {
+			dataLock.Lock()
+			stepResult.Conclusion = model.StepStatusFailure
+			dataLock.Unlock()
+			return parseErr
+		}
+		if continueOnError {
+			logger.Infof("Failed but continue next step")
+			logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
+			return nil
+		}
+		dataLock.Lock()
+		stepResult.Conclusion = model.StepStatusFailure
+		dataLock.Unlock()
+		logger.WithField("stepResult", stepResult.Outcome).Infof("  ❌  Failure - %s", stepModel.String())
+		return err
+	}
+}
+
+func runWaitStep(ctx context.Context, registry *backgroundStepRegistry, stepModel *model.Step) error {
+	ids := stepModel.Wait()
+	if len(ids) == 0 {
+		return fmt.Errorf("wait step '%s' does not reference any background step", stepModel.ID)
+	}
+	var errs []error
+	for _, id := range ids {
+		bs := registry.get(id)
+		if bs == nil {
+			errs = append(errs, fmt.Errorf("'%s' is not a background step", id))
+			continue
+		}
+		if bs.queued() {
+			common.Logger(ctx).Warnf("Background step '%s' has not started yet, it is queued until one of the %d background slots is free", id, maxConcurrentBackgroundSteps)
+		}
+		common.Logger(ctx).Infof("⏸  Waiting for background step '%s'", id)
+		if err := registry.waitFor(ctx, bs); err != nil {
+			errs = append(errs, fmt.Errorf("background step '%s' failed: %w", id, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func runWaitAllStep(ctx context.Context, registry *backgroundStepRegistry) error {
+	var errs []error
+	for _, bs := range registry.all() {
+		common.Logger(ctx).Infof("⏸  Waiting for background step '%s'", bs.id)
+		if err := registry.waitFor(ctx, bs); err != nil {
+			errs = append(errs, fmt.Errorf("background step '%s' failed: %w", bs.id, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func runCancelStep(ctx context.Context, registry *backgroundStepRegistry, stepModel *model.Step) error {
+	bs := registry.get(stepModel.Cancel)
+	if bs == nil {
+		return fmt.Errorf("'%s' is not a background step", stepModel.Cancel)
+	}
+	if !bs.running() {
+		// cancelling a step that already finished must not suppress a
+		// failure it recorded, a later wait still reports it
+		common.Logger(ctx).Infof("Background step '%s' already finished, nothing to cancel", bs.id)
+		return nil
+	}
+	common.Logger(ctx).Infof("\U0001F6D1  Cancelling background step '%s'", bs.id)
+	bs.markCancelled()
+	select {
+	case <-bs.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func evalStepContinueOnError(ctx context.Context, rc *RunContext, stepModel *model.Step) (bool, error) {
+	if stepModel.RawContinueOnError == "" {
+		return false, nil
+	}
+	continueOnError, err := EvalBool(ctx, rc.NewExpressionEvaluator(ctx), stepModel.RawContinueOnError, exprparser.DefaultStatusCheckNone)
+	if err != nil {
+		return false, fmt.Errorf("  ❌  Error in continue-on-error-expression: \"continue-on-error: %s\" (%s)", stepModel.RawContinueOnError, err)
+	}
+	return continueOnError, nil
+}

--- a/pkg/runner/step_background_test.go
+++ b/pkg/runner/step_background_test.go
@@ -1,0 +1,245 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nektos/act/pkg/model"
+)
+
+func TestExpandParallelStepGroups(t *testing.T) {
+	workflow, err := model.ReadWorkflow(strings.NewReader(`
+name: parallel
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo before
+      - parallel:
+          - name: Build a
+            run: echo a
+          - name: Build b
+            id: build-b
+            run: echo b
+      - run: echo after
+`), false)
+	require.NoError(t, err)
+
+	steps, err := expandParallelStepGroups(workflow.GetJob("test").Steps)
+	require.NoError(t, err)
+	require.Len(t, steps, 5)
+
+	assert.Equal(t, "echo before", steps[0].Run)
+
+	assert.Equal(t, "echo a", steps[1].Run)
+	assert.True(t, steps[1].IsBackground())
+	assert.Equal(t, "1", steps[1].ID)
+
+	assert.Equal(t, "echo b", steps[2].Run)
+	assert.True(t, steps[2].IsBackground())
+	assert.Equal(t, "build-b", steps[2].ID)
+
+	assert.Equal(t, model.StepTypeWait, steps[3].Type())
+	assert.Equal(t, []string{"1", "build-b"}, steps[3].Wait())
+
+	assert.Equal(t, "echo after", steps[4].Run)
+}
+
+// The schema mirrors GitHub's, which types the members of a `parallel` group
+// as `steps-item` and so accepts groups and control steps inside a group.
+// Those have no meaning as background steps, so the expansion has to reject
+// them with a diagnostic rather than silently dropping them.
+func TestExpandParallelStepGroupsRejectsNesting(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		member string
+		errMsg string
+	}{
+		{
+			name:   "nested group",
+			member: "- parallel:\n              - run: echo nested",
+			errMsg: "nested 'parallel' groups are not supported",
+		},
+		{
+			name:   "wait inside a group",
+			member: "- wait: something",
+			errMsg: "'wait' steps are not supported inside a group",
+		},
+		{
+			name:   "wait-all inside a group",
+			member: "- wait-all:",
+			errMsg: "'wait-all' steps are not supported inside a group",
+		},
+		{
+			name:   "cancel inside a group",
+			member: "- cancel: something",
+			errMsg: "'cancel' steps are not supported inside a group",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			workflow, err := model.ReadWorkflow(strings.NewReader(`
+name: parallel
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - run: echo ok
+          `+tt.member+`
+`), false)
+			require.NoError(t, err, "the workflow has to validate, GitHub accepts it")
+
+			_, err = expandParallelStepGroups(workflow.GetJob("test").Steps)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// Expansion must not write through to the steps the job model holds, since
+// matrix entries of the same job share them.
+func TestExpandParallelStepGroupsDoesNotMutateTheJobModel(t *testing.T) {
+	workflow, err := model.ReadWorkflow(strings.NewReader(`
+name: parallel
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - run: echo a
+          - run: echo b
+`), false)
+	require.NoError(t, err)
+
+	jobSteps := workflow.GetJob("test").Steps
+	require.Len(t, jobSteps, 1)
+
+	first, err := expandParallelStepGroups(jobSteps)
+	require.NoError(t, err)
+	require.Len(t, first, 3)
+
+	// the job model still holds the single unexpanded group step
+	require.Len(t, jobSteps, 1)
+	assert.Equal(t, model.StepTypeParallel, jobSteps[0].Type())
+
+	// a second expansion, as another matrix entry would do, produces the same
+	// ids rather than continuing to count from where the first one stopped
+	second, err := expandParallelStepGroups(jobSteps)
+	require.NoError(t, err)
+	require.Len(t, second, 3)
+	assert.Equal(t, first[0].ID, second[0].ID)
+	assert.Equal(t, first[1].ID, second[1].ID)
+	assert.NotSame(t, first[0], second[0], "each expansion needs its own steps")
+}
+
+func runBackgroundStepsWorkflow(t *testing.T, workflowPath string, markerDir string) (*model.Plan, error) {
+	t.Helper()
+
+	log.SetLevel(logLevel)
+
+	absWorkdir, err := filepath.Abs(workdir)
+	require.NoError(t, err)
+
+	config := &Config{
+		Workdir:        absWorkdir,
+		EventName:      "push",
+		Platforms:      map[string]string{"self-hosted": "-self-hosted"},
+		GitHubInstance: "github.com",
+		Env:            map[string]string{"MARKER_DIR": markerDir},
+	}
+	runner, err := New(config)
+	require.NoError(t, err)
+
+	planner, err := model.NewWorkflowPlanner(filepath.Join(absWorkdir, workflowPath), true, false)
+	require.NoError(t, err)
+	plan, err := planner.PlanEvent("push")
+	require.NoError(t, err)
+
+	return plan, runner.NewPlanExecutor(plan)(context.Background())
+}
+
+func backgroundStepsWorkflowName(name string) string {
+	if runtime.GOOS == "windows" {
+		return name + "-windows"
+	}
+	return name
+}
+
+func markerModTime(t *testing.T, dir string, name string) time.Time {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(dir, name))
+	require.NoError(t, err, "marker file %s should exist", name)
+	return info.ModTime()
+}
+
+func TestRunBackgroundSteps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	markerDir := filepath.ToSlash(t.TempDir())
+	plan, err := runBackgroundStepsWorkflow(t, backgroundStepsWorkflowName("background-steps"), markerDir)
+	assert.NoError(t, err)
+
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			assert.Equal(t, "success", run.Job().Result, "job %s should have succeeded", run.String())
+		}
+	}
+
+	// the next step ran while the background step was still sleeping
+	workStart := markerModTime(t, markerDir, "work-start")
+	serviceEnd := markerModTime(t, markerDir, "service-end")
+	assert.True(t, workStart.Before(serviceEnd),
+		"the step after a background step must not wait for it (work started %v, service ended %v)", workStart, serviceEnd)
+
+	// both steps of the parallel group overlapped and the following step ran
+	// after the implicit wait for the whole group
+	aStart := markerModTime(t, markerDir, "a-start")
+	aEnd := markerModTime(t, markerDir, "a-end")
+	bStart := markerModTime(t, markerDir, "b-start")
+	bEnd := markerModTime(t, markerDir, "b-end")
+	// the fixtures rendezvous on each other's start marker, so overlap is
+	// guaranteed by construction; the timestamps only have to be consistent
+	// with it, which allows equality at coarse filesystem granularity
+	assert.True(t, !aStart.After(bEnd) && !bStart.After(aEnd),
+		"steps of a parallel group must run concurrently (a: %v - %v, b: %v - %v)", aStart, aEnd, bStart, bEnd)
+	afterParallel := markerModTime(t, markerDir, "after-parallel")
+	assert.False(t, afterParallel.Before(aEnd), "the step after a parallel group must run after all steps of the group")
+	assert.False(t, afterParallel.Before(bEnd), "the step after a parallel group must run after all steps of the group")
+
+	// the quick background step completed even though the monitor was cancelled
+	assert.FileExists(t, filepath.Join(markerDir, "quick-done"))
+}
+
+func TestRunBackgroundStepFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	plan, err := runBackgroundStepsWorkflow(t, backgroundStepsWorkflowName("background-steps-fail"), filepath.ToSlash(t.TempDir()))
+	assert.ErrorContains(t, err, "' failed")
+
+	results := map[string]string{}
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			results[run.JobID] = run.Job().Result
+		}
+	}
+	assert.Equal(t, "failure", results["fail-at-wait"], "a failing background step must fail the job at the wait step")
+	assert.Equal(t, "success", results["continue-on-error"], "continue-on-error on a background step must swallow its failure")
+	assert.Equal(t, "failure", results["duplicate-id"], "duplicate background step ids must fail the job instead of hiding a step")
+	assert.Equal(t, "failure", results["cancel-after-failure"], "cancelling an already failed background step must not hide its failure from a later wait")
+}

--- a/pkg/runner/step_docker.go
+++ b/pkg/runner/step_docker.go
@@ -94,7 +94,7 @@ func (sd *stepDocker) newStepContainer(ctx context.Context, image string, cmd []
 	step := sd.Step
 
 	rawLogger := common.Logger(ctx).WithField("raw_output", true)
-	logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
+	logWriter := common.NewLineWriter(rc.stepCommandHandler(ctx, step.ID), func(s string) bool {
 		if rc.Config.LogOutput {
 			rawLogger.Infof("%s", s)
 		} else {

--- a/pkg/runner/step_docker_test.go
+++ b/pkg/runner/step_docker_test.go
@@ -81,20 +81,20 @@ func TestStepDockerMain(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sd.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/step_run.go
+++ b/pkg/runner/step_run.go
@@ -88,7 +88,7 @@ func (sr *stepRun) setupShellCommandExecutor() common.Executor {
 func getScriptName(rc *RunContext, step *model.Step) string {
 	scriptName := step.ID
 	for rcs := rc; rcs.Parent != nil; rcs = rcs.Parent {
-		scriptName = fmt.Sprintf("%s-composite-%s", rcs.Parent.CurrentStep, scriptName)
+		scriptName = fmt.Sprintf("%s-composite-%s", rcs.parentStepID, scriptName)
 	}
 	return fmt.Sprintf("workflow/%s", scriptName)
 }

--- a/pkg/runner/step_run_test.go
+++ b/pkg/runner/step_run_test.go
@@ -60,22 +60,22 @@ func TestStepRun(t *testing.T) {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/envs.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("envs.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/statecmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("statecmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
-	cm.On("UpdateFromEnv", "/var/run/act/workflow/outputcmd.txt", mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
+	cm.On("UpdateFromEnv", matchCmdFile("outputcmd.txt"), mock.AnythingOfType("*map[string]string")).Return(func(_ context.Context) error {
 		return nil
 	})
 
 	ctx := context.Background()
 
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/SUMMARY.md").Return(io.NopCloser(&bytes.Buffer{}), nil)
-	cm.On("GetContainerArchive", ctx, "/var/run/act/workflow/pathcmd.txt").Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("SUMMARY.md")).Return(io.NopCloser(&bytes.Buffer{}), nil)
+	cm.On("GetContainerArchive", ctx, matchCmdFile("pathcmd.txt")).Return(io.NopCloser(&bytes.Buffer{}), nil)
 
 	err := sr.main()(ctx)
 	assert.Nil(t, err)

--- a/pkg/runner/testdata/background-steps-container/push.yml
+++ b/pkg/runner/testdata/background-steps-container/push.yml
@@ -1,0 +1,28 @@
+name: background-steps-container
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Background step
+        id: bg
+        run: |
+          echo "value=from-background" >> "$GITHUB_OUTPUT"
+          sleep 1
+          touch /tmp/bg-done
+        background: true
+      - run: echo main work
+      - wait: bg
+      - name: Outputs are available after the wait
+        run: |
+          [ "${{ steps.bg.outputs.value }}" = "from-background" ]
+          [ -f /tmp/bg-done ]
+      - parallel:
+          - run: sleep 1 && echo a
+          - run: sleep 1 && echo b
+      - name: Long running monitor
+        id: monitor
+        run: sleep 60
+        background: true
+      - cancel: monitor
+      - wait-all:

--- a/pkg/runner/testdata/background-steps-fail-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-fail-windows/push.yml
@@ -1,0 +1,54 @@
+name: background-steps-fail
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  fail-at-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step
+        id: failing
+        run: exit 1
+        background: true
+      - name: Still runs before the failure surfaces
+        run: echo ok
+      - name: The job fails here
+        wait: failing
+  continue-on-error:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step with continue-on-error
+        id: failing
+        run: exit 1
+        background: true
+        continue-on-error: true
+      - name: Does not fail the job
+        wait: failing
+  duplicate-id:
+    runs-on: self-hosted
+    steps:
+      - id: dup
+        run: echo one
+        background: true
+      - id: dup
+        run: echo two
+        background: true
+      - wait: dup
+  cancel-after-failure:
+    runs-on: self-hosted
+    steps:
+      - name: Fails in the background
+        id: failing
+        run: |
+          New-Item -ItemType File -Path "$env:MARKER_DIR/cancel-after-failure-done" | Out-Null
+          exit 1
+        background: true
+      - name: Wait until the background step has finished
+        run: |
+          while (-not (Test-Path "$env:MARKER_DIR/cancel-after-failure-done")) { Start-Sleep -Milliseconds 200 }
+          Start-Sleep -Seconds 1
+      - name: Cancelling a finished step must not hide its failure
+        cancel: failing
+      - name: The job fails here
+        wait: failing

--- a/pkg/runner/testdata/background-steps-fail/push.yml
+++ b/pkg/runner/testdata/background-steps-fail/push.yml
@@ -1,0 +1,54 @@
+name: background-steps-fail
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  fail-at-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step
+        id: failing
+        run: exit 1
+        background: true
+      - name: Still runs before the failure surfaces
+        run: echo ok
+      - name: The job fails here
+        wait: failing
+  continue-on-error:
+    runs-on: self-hosted
+    steps:
+      - name: Failing background step with continue-on-error
+        id: failing
+        run: exit 1
+        background: true
+        continue-on-error: true
+      - name: Does not fail the job
+        wait: failing
+  duplicate-id:
+    runs-on: self-hosted
+    steps:
+      - id: dup
+        run: echo one
+        background: true
+      - id: dup
+        run: echo two
+        background: true
+      - wait: dup
+  cancel-after-failure:
+    runs-on: self-hosted
+    steps:
+      - name: Fails in the background
+        id: failing
+        run: |
+          touch "$MARKER_DIR/cancel-after-failure-done"
+          exit 1
+        background: true
+      - name: Wait until the background step has finished
+        run: |
+          until [ -f "$MARKER_DIR/cancel-after-failure-done" ]; do sleep 0.2; done
+          sleep 1
+      - name: Cancelling a finished step must not hide its failure
+        cancel: failing
+      - name: The job fails here
+        wait: failing

--- a/pkg/runner/testdata/background-steps-matrix/push.yml
+++ b/pkg/runner/testdata/background-steps-matrix/push.yml
@@ -1,0 +1,36 @@
+name: background-steps-matrix
+on: push
+jobs:
+  # Every matrix entry expands the same `parallel` groups, and the steps in a
+  # group that carry no `id` get one assigned from their position. This job
+  # exists to lock in that those generated ids stay per-entry: if they leaked
+  # between matrix RunContexts the background step registry would reject the
+  # duplicate and fail the job.
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        entry: [one, two, three]
+    steps:
+      - name: Loose background step
+        id: loose
+        run: |
+          echo "entry=${{ matrix.entry }}" >> "$GITHUB_OUTPUT"
+          sleep 1
+        background: true
+
+      # no ids anywhere in this group, so all of them are generated
+      - parallel:
+          - run: sleep 1 && echo "first group, ${{ matrix.entry }}"
+          - run: sleep 1 && echo "first group, ${{ matrix.entry }}"
+
+      # a second group in the same job, mixing a named step with unnamed ones
+      - parallel:
+          - id: named
+            run: echo "named in ${{ matrix.entry }}" && sleep 1
+          - run: sleep 1 && echo "second group, ${{ matrix.entry }}"
+
+      - wait: loose
+      - name: The matrix entry survived the parallel groups
+        run: |
+          [ "${{ steps.loose.outputs.entry }}" = "${{ matrix.entry }}" ]

--- a/pkg/runner/testdata/background-steps-windows/push.yml
+++ b/pkg/runner/testdata/background-steps-windows/push.yml
@@ -1,0 +1,65 @@
+name: background-steps
+on: push
+defaults:
+  run:
+    shell: powershell
+jobs:
+  background-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Start background service
+        id: service
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "value=from-background"
+          New-Item -ItemType File -Path "$env:MARKER_DIR/service-start" | Out-Null
+          $deadline = (Get-Date).AddSeconds(60)
+          while (-not (Test-Path "$env:MARKER_DIR/work-start")) { if ((Get-Date) -gt $deadline) { exit 1 }; Start-Sleep -Milliseconds 200 }
+          New-Item -ItemType File -Path "$env:MARKER_DIR/service-end" | Out-Null
+        background: true
+      - name: Work while the service runs
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/work-start" | Out-Null
+      - name: Wait for the service
+        wait: service
+      - name: Outputs of the service are available after the wait
+        run: |
+          if ("${{ steps.service.outputs.value }}" -ne "from-background") { exit 1 }
+          if (-not (Test-Path "$env:MARKER_DIR/service-end")) { exit 1 }
+  parallel-group:
+    runs-on: self-hosted
+    steps:
+      - parallel:
+          - name: Build a
+            id: build-a
+            run: |
+              New-Item -ItemType File -Path "$env:MARKER_DIR/a-start" | Out-Null
+              $deadline = (Get-Date).AddSeconds(60)
+              while (-not (Test-Path "$env:MARKER_DIR/b-start")) { if ((Get-Date) -gt $deadline) { exit 1 }; Start-Sleep -Milliseconds 200 }
+              New-Item -ItemType File -Path "$env:MARKER_DIR/a-end" | Out-Null
+          - name: Build b
+            id: build-b
+            run: |
+              New-Item -ItemType File -Path "$env:MARKER_DIR/b-start" | Out-Null
+              $deadline = (Get-Date).AddSeconds(60)
+              while (-not (Test-Path "$env:MARKER_DIR/a-start")) { if ((Get-Date) -gt $deadline) { exit 1 }; Start-Sleep -Milliseconds 200 }
+              New-Item -ItemType File -Path "$env:MARKER_DIR/b-end" | Out-Null
+      - name: Runs after the whole group
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/after-parallel" | Out-Null
+  cancel-and-wait-all:
+    runs-on: self-hosted
+    steps:
+      - name: Long running monitor
+        id: monitor
+        run: Start-Sleep -Seconds 60
+        background: true
+      - name: Quick background work
+        id: quick
+        run: New-Item -ItemType File -Path "$env:MARKER_DIR/quick-done" | Out-Null
+        background: true
+      - name: Stop the monitor
+        cancel: monitor
+      - name: Wait for the rest
+        wait-all:
+  only-control:
+    runs-on: self-hosted
+    steps:
+      - wait-all:

--- a/pkg/runner/testdata/background-steps/push.yml
+++ b/pkg/runner/testdata/background-steps/push.yml
@@ -1,0 +1,65 @@
+name: background-steps
+on: push
+defaults:
+  run:
+    shell: bash
+jobs:
+  background-wait:
+    runs-on: self-hosted
+    steps:
+      - name: Start background service
+        id: service
+        run: |
+          echo "value=from-background" >> "$GITHUB_OUTPUT"
+          touch "$MARKER_DIR/service-start"
+          for i in $(seq 1 300); do [ -f "$MARKER_DIR/work-start" ] && break; sleep 0.2; done
+          [ -f "$MARKER_DIR/work-start" ]
+          touch "$MARKER_DIR/service-end"
+        background: true
+      - name: Work while the service runs
+        run: touch "$MARKER_DIR/work-start"
+      - name: Wait for the service
+        wait: service
+      - name: Outputs of the service are available after the wait
+        run: |
+          [ "${{ steps.service.outputs.value }}" = "from-background" ]
+          [ -f "$MARKER_DIR/service-end" ]
+  parallel-group:
+    runs-on: self-hosted
+    steps:
+      - parallel:
+          - name: Build a
+            id: build-a
+            run: |
+              touch "$MARKER_DIR/a-start"
+              for i in $(seq 1 300); do [ -f "$MARKER_DIR/b-start" ] && break; sleep 0.2; done
+              [ -f "$MARKER_DIR/b-start" ]
+              touch "$MARKER_DIR/a-end"
+          - name: Build b
+            id: build-b
+            run: |
+              touch "$MARKER_DIR/b-start"
+              for i in $(seq 1 300); do [ -f "$MARKER_DIR/a-start" ] && break; sleep 0.2; done
+              [ -f "$MARKER_DIR/a-start" ]
+              touch "$MARKER_DIR/b-end"
+      - name: Runs after the whole group
+        run: touch "$MARKER_DIR/after-parallel"
+  cancel-and-wait-all:
+    runs-on: self-hosted
+    steps:
+      - name: Long running monitor
+        id: monitor
+        run: sleep 60
+        background: true
+      - name: Quick background work
+        id: quick
+        run: touch "$MARKER_DIR/quick-done"
+        background: true
+      - name: Stop the monitor
+        cancel: monitor
+      - name: Wait for the rest
+        wait-all:
+  only-control:
+    runs-on: self-hosted
+    steps:
+      - wait-all:

--- a/pkg/runner/testdata/composite-undeclared-outputs/composite/action.yml
+++ b/pkg/runner/testdata/composite-undeclared-outputs/composite/action.yml
@@ -1,0 +1,18 @@
+name: 'composite with an undeclared inner output'
+description: |
+  The inner step writes an output that the action does not declare. GitHub
+  scopes it to the inner step, so it must not appear on the step that used
+  this action.
+outputs:
+  declared:
+    description: 'an output the action does declare'
+    value: ${{ steps.inner.outputs.declared }}
+runs:
+  using: composite
+  steps:
+    - id: inner
+      shell: bash
+      run: |
+        echo "declared=declared-value" >> "$GITHUB_OUTPUT"
+        echo "undeclared=undeclared-value" >> "$GITHUB_OUTPUT"
+        echo "::set-output name=undeclared-legacy::undeclared-legacy-value"

--- a/pkg/runner/testdata/composite-undeclared-outputs/nested/action.yml
+++ b/pkg/runner/testdata/composite-undeclared-outputs/nested/action.yml
@@ -1,0 +1,13 @@
+name: 'composite nesting another composite'
+description: |
+  Wraps the composite action, so the same scoping is exercised one level
+  deeper.
+outputs:
+  declared:
+    description: 'forwarded from the inner composite'
+    value: ${{ steps.inner-composite.outputs.declared }}
+runs:
+  using: composite
+  steps:
+    - id: inner-composite
+      uses: ./composite-undeclared-outputs/composite

--- a/pkg/runner/testdata/composite-undeclared-outputs/push.yml
+++ b/pkg/runner/testdata/composite-undeclared-outputs/push.yml
@@ -1,0 +1,25 @@
+name: composite-undeclared-outputs
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: plain
+        uses: ./composite-undeclared-outputs/composite
+      - name: a declared output is visible on the step that used the action
+        run: |
+          [ "${{ steps.plain.outputs.declared }}" = "declared-value" ]
+      - name: outputs the action does not declare stay scoped to the inner step
+        run: |
+          [ -z "${{ steps.plain.outputs.undeclared }}" ]
+          [ -z "${{ steps.plain.outputs['undeclared-legacy'] }}" ]
+
+      - id: nested
+        uses: ./composite-undeclared-outputs/nested
+      - name: the same holds one level of nesting deeper
+        run: |
+          [ "${{ steps.nested.outputs.declared }}" = "declared-value" ]
+          [ -z "${{ steps.nested.outputs.undeclared }}" ]
+          [ -z "${{ steps.nested.outputs['undeclared-legacy'] }}" ]

--- a/pkg/schema/workflow_schema.json
+++ b/pkg/schema/workflow_schema.json
@@ -1710,7 +1710,7 @@
       }
     },
     "steps-item": {
-      "one-of": ["run-step", "regular-step"]
+      "one-of": ["run-step", "regular-step", "wait-step", "wait-all-step", "cancel-step", "parallel-step"]
     },
     "run-step": {
       "mapping": {
@@ -1727,7 +1727,8 @@
           "continue-on-error": "step-continue-on-error",
           "env": "step-env",
           "working-directory": "string-steps-context",
-          "shell": "shell"
+          "shell": "shell",
+          "background": "step-background"
         }
       }
     },
@@ -1744,8 +1745,84 @@
             "required": true
           },
           "with": "step-with",
-          "env": "step-env"
+          "env": "step-env",
+          "background": "step-background"
         }
+      }
+    },
+    "step-background": {
+      "description": "Runs the step asynchronously so the job continues to the next step without waiting for it to finish. Use `wait`, `wait-all` or `cancel` steps to synchronize with or stop background steps. A maximum of 10 background steps run concurrently, additional background steps queue until a slot becomes available.",
+      "boolean": {}
+    },
+    "wait-step": {
+      "description": "Pauses the job until one or more background steps complete. Provide a single step id as a string or multiple ids as an array. After a `wait` step completes, the outputs of the referenced background steps become available to subsequent steps. A `wait` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait": {
+            "type": "step-wait-target",
+            "required": true
+          }
+        }
+      }
+    },
+    "step-wait-target": {
+      "one-of": ["non-empty-string", "step-wait-target-sequence"]
+    },
+    "step-wait-target-sequence": {
+      "sequence": {
+        "item-type": "non-empty-string"
+      }
+    },
+    "wait-all-step": {
+      "description": "Pauses the job until all active background steps complete. A `wait-all` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait-all": {
+            "type": "step-wait-all-value",
+            "required": true
+          }
+        }
+      }
+    },
+    "step-wait-all-value": {
+      "one-of": ["null", "boolean"]
+    },
+    "cancel-step": {
+      "description": "Gracefully terminates a running background step referenced by its id. A `cancel` step always runs and does not support the `if` conditional.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "cancel": {
+            "type": "non-empty-string",
+            "required": true
+          }
+        }
+      }
+    },
+    "parallel-step": {
+      "description": "Runs a group of steps in parallel: every step in the group runs as a background step, with an implicit `wait` at the end. Each step in the group is subject to the same 10-step concurrency limit as other background steps. You cannot use `parallel` inside a composite action.",
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "parallel": {
+            "type": "parallel-steps",
+            "required": true
+          }
+        }
+      }
+    },
+    "parallel-steps": {
+      "sequence": {
+        "item-type": "steps-item"
       }
     },
     "step-uses": {


### PR DESCRIPTION
Closes #6124.

GitHub shipped step level parallelism in June 2026. act rejects the keys as unknown properties, so a workflow using them cannot be run locally at all — the reporter of #6124 gets a schema error before anything executes.

> **Draft, because this is stacked.** The first three commits are #6153 and #6154, already open on their own. **Only the last commit, `598dd85`, is new here.** I will rebase and mark this ready once those two land. Opening it now so #6124 has something concrete attached to it.

## What it adds

```yaml
steps:
  - id: server
    run: npm start
    background: true        # job continues without waiting

  - run: npm test           # runs while the server is up

  - parallel:               # all at once, implicit wait after the group
      - run: npm run build:frontend
      - run: npm run build:backend

  - wait: server            # or a list, or `wait-all:` for everything
  - cancel: server          # graceful stop
```

`background: true` on run and regular steps; `wait` as string-or-sequence; `wait-all` as null-or-boolean; `cancel`; and `parallel`.

This is upstream GitHub syntax, not an act extension — `actions/languageservices` `workflow-v1.0.json` defines `steps-item` as the same six member one-of, with those exact value types. Composite actions still reject all of it, because GitHub's own `action-v1.0.json` does too; that is fidelity, not a gap.

## How it works

A per job registry tracks background steps behind a ten slot semaphore, matching GitHub's limit. `expandParallelStepGroups` desugars a `parallel:` block into background steps plus a synthesized `wait` for the group, so a group is not a second execution path — it is the same one, spelled shorter. A background step's failure is taken by the first `wait` that includes it; deliberately cancelled steps do not fail the job; anything still running when the job ends is stopped.

Steps now genuinely overlap, so the state they share needs guarding. Expression evaluators read env and step-result snapshots rather than the live maps, and log writers travel on the context instead of being swapped into the execution environment's single global writer slot.

**That last part is the subtle one.** Once context writers take precedence, `JobContainer.ReplaceLogWriter` silently stops having any effect. `newCompositeCommandExecutor` used it to install the handler that parses a composite action's inner `::set-output`, so without the matching change those outputs get attributed to the *outer* step. This PR moves that call site — and the two other capture sites in `expression.go` and `run_context.go` — onto `container.WithLogWriters`. I mention it because it is exactly the kind of change that looks unrelated in a diff and is not.

## Testing

`TestExpandParallelStepGroups` plus new cases for nesting rejection and for expansion not writing through to the job model. `background-steps-container` and a new `background-steps-matrix` fixture (two `parallel` groups and a loose background step across three matrix entries) are in the `TestRunEvent` table.

Verified before opening:

- The composite suite — `uses-composite`, `uses-nested-composite`, `composite-fail-with-output`, `act-composite-env-test`, `do-not-leak-step-env-in-composite`, `outputs`, `composite-undeclared-outputs` — all green under docker. This is the acceptance gate for the log-writer change.
- `go test -race ./pkg/runner/` in a linux container reports three races, all in `GoGitActionCache` (#6028) and all reproducing identically on a clean `master` checkout. Nothing in the code this PR adds.
- The `-short` failure set matches a `master` baseline exactly. `TestActionCache/Fetch_HEAD` and `Fetch_Sha` are flaky run to run on master as well.

## Notes for review

- **Not a fix for #2287.** A shell `&` inside a `run` step still dies with the exec. This is a different, opt-in mechanism that requires rewriting the workflow.
- The schema types `parallel` group members as `steps-item`, as GitHub does, which means a nested `parallel:` or a `wait:` inside a group *validates*. Since neither has a meaning as a background step, the expansion rejects them with a named error rather than dropping them silently. Happy to narrow the schema instead if you would rather it fail at validation time.
- `parallel-step` permits `name`/`id` where GitHub's permits only `parallel`. The synthesized wait step reuses the group's id, so matching GitHub exactly would need a second id scheme — I did not think that was worth it, but say the word.
- Auto-assigned ids for unnamed steps in a group follow act's existing `fmt.Sprintf("%d", i)` convention and land on the index the step ends up at.
