### PR TITLE
fix: isolate composite action inputs from environment

### DIFF
--- a/pkg/runner/action_composite.go
+++ b/pkg/runner/action_composite.go
@@ -10,17 +10,24 @@ import (
 	"github.com/nektos/act/pkg/model"
 )
 
-func evaluateCompositeInputAndEnv(ctx context.Context, parent *RunContext, step actionStep) map[string]string {
+func evaluateCompositeEnv(ctx context.Context, step actionStep) map[string]string {
 	env := make(map[string]string)
 	stepEnv := *step.getEnv()
 	for k, v := range stepEnv {
-		// do not set current inputs into composite action
-		// the required inputs are added in the second loop
 		if !strings.HasPrefix(k, "INPUT_") {
 			env[k] = v
 		}
 	}
+	gh := step.getGithubContext(ctx)
+	env["GITHUB_ACTION_REPOSITORY"] = gh.ActionRepository
+	env["GITHUB_ACTION_REF"] = gh.ActionRef
 
+	return env
+}
+
+func evaluateCompositeInputs(ctx context.Context, parent *RunContext, step actionStep) map[string]interface{} {
+	inputs := make(map[string]interface{})
+	stepEnv := *step.getEnv()
 	ee := parent.NewStepExpressionEvaluator(ctx, step)
 
 	for inputID, input := range step.getActionModel().Inputs {
@@ -31,21 +38,19 @@ func evaluateCompositeInputAndEnv(ctx context.Context, parent *RunContext, step 
 		// evaluated value from the environment
 		_, defined := step.getStepModel().With[inputID]
 		if value, ok := stepEnv[envKey]; defined && ok {
-			env[envKey] = value
+			inputs[strings.ToLower(inputID)] = value
 		} else {
 			// defaults could contain expressions
-			env[envKey] = ee.Interpolate(ctx, input.Default)
+			inputs[strings.ToLower(inputID)] = ee.Interpolate(ctx, input.Default)
 		}
 	}
-	gh := step.getGithubContext(ctx)
-	env["GITHUB_ACTION_REPOSITORY"] = gh.ActionRepository
-	env["GITHUB_ACTION_REF"] = gh.ActionRef
 
-	return env
+	return inputs
 }
 
 func newCompositeRunContext(ctx context.Context, parent *RunContext, step actionStep, actionPath string) *RunContext {
-	env := evaluateCompositeInputAndEnv(ctx, parent, step)
+	env := evaluateCompositeEnv(ctx, step)
+	inputs := evaluateCompositeInputs(ctx, parent, step)
 
 	// run with the global config but without secrets
 	configCopy := *(parent.Config)
@@ -69,6 +74,7 @@ func newCompositeRunContext(ctx context.Context, parent *RunContext, step action
 		JobContainer:     parent.JobContainer,
 		ActionPath:       actionPath,
 		Env:              env,
+		ActionInputs:     inputs,
 		GlobalEnv:        parent.GlobalEnv,
 		Masks:            parent.Masks,
 		ExtraPath:        parent.ExtraPath,
@@ -108,7 +114,7 @@ func execAsComposite(step actionStep) common.Executor {
 
 		rc.Masks = append(rc.Masks, compositeRC.Masks...)
 		rc.ExtraPath = compositeRC.ExtraPath
-		// compositeRC.Env is dirty, contains INPUT_ and merged step env, only rely on compositeRC.GlobalEnv
+		// compositeRC.Env contains merged step env, only rely on compositeRC.GlobalEnv
 		mergeIntoMap := mergeIntoMapCaseSensitive
 		if rc.JobContainer.IsEnvironmentCaseInsensitive() {
 			mergeIntoMap = mergeIntoMapCaseInsensitive

--- a/pkg/runner/action_composite_test.go
+++ b/pkg/runner/action_composite_test.go
@@ -1,0 +1,106 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nektos/act/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluateCompositeInputsAndEnvAreIsolated(t *testing.T) {
+	runContext := &RunContext{
+		Config: &Config{
+			Env: map[string]string{
+				"GITHUB_REF":        "refs/heads/main",
+				"GITHUB_REPOSITORY": "owner/repository",
+				"SHA_REF":           "0123456789abcdef0123456789abcdef01234567",
+			},
+			GitHubInstance: "github.com",
+			Workdir:        t.TempDir(),
+		},
+		Env: map[string]string{},
+		Run: &model.Run{
+			JobID: "test",
+			Workflow: &model.Workflow{
+				Name: "composite input context",
+				Jobs: map[string]*model.Job{"test": {}},
+			},
+		},
+		StepResults: map[string]*model.StepResult{},
+	}
+	step := &stepActionLocal{
+		Step: &model.Step{
+			Uses: "./composite",
+			With: map[string]string{"explicit": "from-workflow"},
+		},
+		RunContext: runContext,
+		action: &model.Action{
+			Inputs: map[string]model.Input{
+				"explicit": {Required: true},
+				"fallback": {Default: "fallback-value"},
+			},
+		},
+		env: map[string]string{
+			"INPUT_EXPLICIT": "from-workflow",
+			"JOB_ENV":        "preserved",
+		},
+	}
+
+	ctx := context.Background()
+	env := evaluateCompositeEnv(ctx, step)
+	inputs := evaluateCompositeInputs(ctx, runContext, step)
+
+	assert.Equal(t, "preserved", env["JOB_ENV"])
+	assert.NotContains(t, env, "INPUT_EXPLICIT")
+	assert.NotContains(t, env, "INPUT_FALLBACK")
+	assert.Equal(t, map[string]interface{}{
+		"explicit": "from-workflow",
+		"fallback": "fallback-value",
+	}, inputs)
+}
+
+func TestCompositeActionInputsStayInExpressionContext(t *testing.T) {
+	runContext := &RunContext{
+		ActionInputs: map[string]interface{}{
+			"parent": "parent-value",
+			"shared": "parent-shared",
+		},
+		Config: &Config{
+			Env: map[string]string{
+				"GITHUB_REF":        "refs/heads/main",
+				"GITHUB_REPOSITORY": "owner/repository",
+				"SHA_REF":           "0123456789abcdef0123456789abcdef01234567",
+			},
+			GitHubInstance: "github.com",
+			Workdir:        t.TempDir(),
+		},
+		Env: map[string]string{},
+		Run: &model.Run{
+			JobID: "test",
+			Workflow: &model.Workflow{
+				Name: "composite input context",
+				Jobs: map[string]*model.Job{"test": {}},
+			},
+		},
+		StepResults: map[string]*model.StepResult{},
+	}
+	step := &stepRun{
+		Step:       &model.Step{},
+		RunContext: runContext,
+		env:        map[string]string{},
+	}
+
+	evaluator := runContext.NewStepExpressionEvaluator(context.Background(), step)
+	assert.Equal(t, "parent-value", evaluator.Interpolate(context.Background(), "${{ inputs.parent }}"))
+	assert.NotContains(t, *step.getEnv(), "INPUT_PARENT")
+
+	step.env["INPUT_SHARED"] = "child-shared"
+	step.env["INPUT_CHILD"] = "child-value"
+	inputs := getEvaluatorInputs(context.Background(), runContext, step, &model.GithubContext{})
+	assert.Equal(t, map[string]interface{}{
+		"child":  "child-value",
+		"parent": "parent-value",
+		"shared": "child-shared",
+	}, inputs)
+}

--- a/pkg/runner/expression.go
+++ b/pkg/runner/expression.go
@@ -483,6 +483,9 @@ func getEvaluatorInputs(ctx context.Context, rc *RunContext, step step, ghc *mod
 	inputs := map[string]interface{}{}
 
 	setupWorkflowInputs(ctx, &inputs, rc)
+	for name, value := range rc.ActionInputs {
+		inputs[name] = value
+	}
 
 	var env map[string]string
 	if step != nil {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -36,6 +36,7 @@ type RunContext struct {
 	Run                 *model.Run
 	EventJSON           string
 	Env                 map[string]string
+	ActionInputs        map[string]interface{}
 	GlobalEnv           map[string]string // to pass env changes of GITHUB_ENV and set-env correctly, due to dirty Env field
 	ExtraPath           []string
 	CurrentStep         string

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -250,6 +250,7 @@ func TestRunEvent(t *testing.T) {
 		{workdir, "uses-composite-with-error", "push", "Job 'failing-composite-action' failed", platforms, secrets},
 		{workdir, "uses-composite-check-for-input-collision", "push", "", platforms, secrets},
 		{workdir, "uses-composite-check-for-input-shadowing", "push", "", platforms, secrets},
+		{workdir, "uses-composite-input-context", "push", "", platforms, secrets},
 		{workdir, "uses-nested-composite", "push", "", platforms, secrets},
 		{workdir, "remote-action-composite-js-pre-with-defaults", "push", "", platforms, secrets},
 		{workdir, "remote-action-composite-action-ref", "push", "", platforms, secrets},
@@ -583,6 +584,7 @@ func TestRunEventHostEnvironment(t *testing.T) {
 			{workdir, "windows-prepend-path-powershell-5", "push", "", platforms, secrets},
 			{workdir, "windows-add-env-powershell-5", "push", "", platforms, secrets},
 			{workdir, "windows-shell-cmd", "push", "", platforms, secrets},
+			{workdir, "uses-composite-input-context-windows", "push", "", platforms, secrets},
 		}...)
 	} else {
 		platforms := map[string]string{

--- a/pkg/runner/step_action_remote.go
+++ b/pkg/runner/step_action_remote.go
@@ -239,8 +239,8 @@ func (sar *stepActionRemote) getCompositeRunContext(ctx context.Context) *RunCon
 		// stages are executed. (e.g. the output of another action is the
 		// input for this action during the main stage, but the env
 		// was already created during the pre stage)
-		env := evaluateCompositeInputAndEnv(ctx, sar.RunContext, sar)
-		sar.compositeRunContext.Env = env
+		sar.compositeRunContext.Env = evaluateCompositeEnv(ctx, sar)
+		sar.compositeRunContext.ActionInputs = evaluateCompositeInputs(ctx, sar.RunContext, sar)
 		sar.compositeRunContext.ExtraPath = sar.RunContext.ExtraPath
 	}
 	return sar.compositeRunContext

--- a/pkg/runner/testdata/uses-composite-input-context-windows/push.yml
+++ b/pkg/runner/testdata/uses-composite-input-context-windows/push.yml
@@ -1,0 +1,46 @@
+name: composite input context on Windows
+on: push
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Create a local composite action
+        shell: pwsh
+        run: |
+          $action = @'
+          name: Composite input context
+          description: Validates composite input context and environment isolation
+          inputs:
+            explicit:
+              description: Explicit input
+              required: true
+            derived:
+              description: Input with a default value
+              default: fallback-value
+            enabled:
+              description: Enables the conditional step
+              default: "true"
+          runs:
+            using: composite
+            steps:
+              - name: Read inputs without automatic environment variables
+                shell: pwsh
+                env:
+                  RESOLVED_EXPLICIT: __EXPRESSION__ inputs.explicit }}
+                  RESOLVED_DERIVED: __EXPRESSION__ inputs.derived }}
+                run: |
+                  if ($env:RESOLVED_EXPLICIT -ne "from-workflow") { throw "unexpected explicit input" }
+                  if ($env:RESOLVED_DERIVED -ne "fallback-value") { throw "unexpected derived input" }
+                  if (Get-ChildItem Env: | Where-Object Name -Like "INPUT_*") {
+                    throw "composite inputs leaked into the process environment"
+                  }
+              - name: Evaluate inputs in a step condition
+                if: __EXPRESSION__ inputs.enabled == 'true' }}
+                shell: pwsh
+                run: if ("__EXPRESSION__ inputs.explicit }}" -ne "from-workflow") { exit 1 }
+          '@
+          $action.Replace('__EXPRESSION__', '$' + '{{') | Set-Content -Path action.yml
+      - uses: ./
+        with:
+          explicit: from-workflow

--- a/pkg/runner/testdata/uses-composite-input-context/composite/action.yml
+++ b/pkg/runner/testdata/uses-composite-input-context/composite/action.yml
@@ -1,0 +1,44 @@
+name: Composite input context
+description: Validates composite input context and environment isolation
+
+inputs:
+  explicit:
+    description: Explicit input
+    required: true
+  derived:
+    description: Input with a default value
+    default: fallback-value
+  enabled:
+    description: Enables the conditional step
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Read inputs without automatic environment variables
+      shell: sh
+      env:
+        RESOLVED_EXPLICIT: ${{ inputs.explicit }}
+        RESOLVED_DERIVED: ${{ inputs.derived }}
+      run: |
+        test "$RESOLVED_EXPLICIT" = "from-workflow"
+        test "$RESOLVED_DERIVED" = "fallback-value"
+        if env | grep -q '^INPUT_'; then
+          echo "composite inputs leaked into the process environment"
+          exit 1
+        fi
+
+    - name: Evaluate inputs in a step condition
+      if: inputs.enabled == 'true'
+      shell: sh
+      run: test "${{ inputs.explicit }}" = "from-workflow"
+
+    - name: Pass an input to a nested composite action
+      uses: ./uses-composite-input-context/nested
+      with:
+        nested_value: ${{ inputs.derived }}
+
+    - name: Preserve input environment variables for JavaScript actions
+      uses: ./uses-composite-input-context/javascript
+      with:
+        child_value: ${{ inputs.explicit }}

--- a/pkg/runner/testdata/uses-composite-input-context/javascript/action.yml
+++ b/pkg/runner/testdata/uses-composite-input-context/javascript/action.yml
@@ -1,0 +1,11 @@
+name: JavaScript input environment
+description: Validates input environment variables for JavaScript actions
+
+inputs:
+  child_value:
+    description: Value forwarded by the composite action
+    required: true
+
+runs:
+  using: node20
+  main: index.js

--- a/pkg/runner/testdata/uses-composite-input-context/javascript/index.js
+++ b/pkg/runner/testdata/uses-composite-input-context/javascript/index.js
@@ -1,0 +1,9 @@
+if (process.env.INPUT_CHILD_VALUE !== "from-workflow") {
+  throw new Error(`unexpected child input: ${process.env.INPUT_CHILD_VALUE}`);
+}
+
+for (const name of ["INPUT_EXPLICIT", "INPUT_DERIVED", "INPUT_ENABLED"]) {
+  if (name in process.env) {
+    throw new Error(`parent composite input leaked as ${name}`);
+  }
+}

--- a/pkg/runner/testdata/uses-composite-input-context/nested/action.yml
+++ b/pkg/runner/testdata/uses-composite-input-context/nested/action.yml
@@ -1,0 +1,21 @@
+name: Nested composite input context
+description: Validates nested composite input isolation
+
+inputs:
+  nested_value:
+    description: Value forwarded by the parent composite action
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Read the nested input from the inputs context
+      shell: sh
+      env:
+        RESOLVED_NESTED: ${{ inputs.nested_value }}
+      run: |
+        test "$RESOLVED_NESTED" = "fallback-value"
+        if env | grep -q '^INPUT_'; then
+          echo "nested composite inputs leaked into the process environment"
+          exit 1
+        fi

--- a/pkg/runner/testdata/uses-composite-input-context/push.yml
+++ b/pkg/runner/testdata/uses-composite-input-context/push.yml
@@ -1,0 +1,11 @@
+name: composite input context
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./uses-composite-input-context/composite
+        with:
+          explicit: from-workflow


### PR DESCRIPTION
Fixes #2874.

## What changed

- Keep composite-action inputs in the expression evaluator's `inputs` context instead of exporting them as automatic `INPUT_*` environment variables.
- Continue exposing explicit inputs to nested JavaScript actions, while preventing the parent composite action's inputs from leaking into child processes.
- Refresh both the environment and the resolved input context for remote composite actions between pre, main, and post stages.
- Add unit coverage plus Linux and Windows integration fixtures for explicit inputs, defaults, step conditions, nested composites, and JavaScript child actions.

This matches GitHub Actions behavior: composite actions read their own inputs through the `inputs` context, while JavaScript actions still receive their inputs through `INPUT_*` environment variables.

## Validation

- `go test ./pkg/runner -run '^(TestEvaluateCompositeInputsAndEnvAreIsolated|TestCompositeActionInputsStayInExpressionContext)$' -count=1`
- `go test ./pkg/runner -run '^TestRunEventHostEnvironment$/^uses-composite-input-context-windows$' -count=1`
- `go test ./pkg/runner -run '^$'`
- `go vet ./pkg/runner`
- Reproduced the failure against the exact base commit with the same Windows integration fixture.

AI assistance (OpenAI Codex) was used to research the issue, implement and review the change, and run the validation described above.
