### PR TITLE
Add opt-in host environment isolation

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -18,6 +18,7 @@ type Input struct {
 	secrets                            []string
 	vars                               []string
 	envs                               []string
+	noHostEnv                          bool
 	inputs                             []string
 	platforms                          []string
 	dryrun                             bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ func createRootCommand(ctx context.Context, input *Input, version string) *cobra
 	rootCmd.Flags().StringArrayVarP(&input.secrets, "secret", "s", []string{}, "secret to make available to actions with optional value (e.g. -s mysecret=foo or -s mysecret)")
 	rootCmd.Flags().StringArrayVar(&input.vars, "var", []string{}, "variable to make available to actions with optional value (e.g. --var myvar=foo or --var myvar)")
 	rootCmd.Flags().StringArrayVarP(&input.envs, "env", "", []string{}, "env to make available to actions with optional value (e.g. --env myenv=foo or --env myenv)")
+	rootCmd.Flags().BoolVar(&input.noHostEnv, "no-host-env", false, "don't inherit the parent process environment in host execution")
 	rootCmd.Flags().StringArrayVarP(&input.inputs, "input", "", []string{}, "action input to make available to actions (e.g. --input myinput=foo)")
 	rootCmd.Flags().StringArrayVarP(&input.platforms, "platform", "P", []string{}, "custom image to use per platform (e.g. -P ubuntu-18.04=nektos/act-environments-ubuntu:18.04)")
 	rootCmd.Flags().BoolVarP(&input.reuseContainers, "reuse", "r", false, "don't remove container(s) on successfully completed workflow(s) to maintain state between runs")
@@ -619,6 +620,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			JSONLogger:                         input.jsonLogger,
 			LogPrefixJobID:                     input.logPrefixJobID,
 			Env:                                envs,
+			NoHostEnv:                          input.noHostEnv,
 			Secrets:                            secrets,
 			Vars:                               vars,
 			Inputs:                             inputs,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -83,6 +83,15 @@ func TestFlags(t *testing.T) {
 	}
 }
 
+func TestNoHostEnvFlag(t *testing.T) {
+	input := &Input{}
+	rootCmd := createRootCommand(context.Background(), input, "")
+
+	err := rootCmd.Flags().Set("no-host-env", "true")
+	assert.NoError(t, err)
+	assert.True(t, input.noHostEnv)
+}
+
 func TestReadArgsFile(t *testing.T) {
 	tables := []struct {
 		path  string

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -229,11 +229,15 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 				rc.Env[fmt.Sprintf("RUNNER_%s", strings.ToUpper(k))] = v
 			}
 		}
-		for _, env := range os.Environ() {
-			if k, v, ok := strings.Cut(env, "="); ok {
-				// don't override
-				if _, ok := rc.Env[k]; !ok {
-					rc.Env[k] = v
+		if rc.Config.NoHostEnv {
+			rc.addHostShellEnvironment()
+		} else {
+			for _, env := range os.Environ() {
+				if k, v, ok := strings.Cut(env, "="); ok {
+					// don't override
+					if _, ok := rc.Env[k]; !ok {
+						rc.Env[k] = v
+					}
 				}
 			}
 		}
@@ -250,6 +254,38 @@ func (rc *RunContext) startHostEnvironment() common.Executor {
 			}),
 		)(ctx)
 	}
+}
+
+func (rc *RunContext) addHostShellEnvironment() {
+	pathName := rc.JobContainer.GetPathVariableName()
+	if !rc.addHostEnvVariable(pathName) {
+		if path := rc.JobContainer.DefaultPathVariable(); path != "" {
+			rc.Env[pathName] = path
+		}
+	}
+	if runtime.GOOS == "windows" {
+		rc.addHostEnvVariable("PATHEXT")
+	}
+}
+
+func (rc *RunContext) addHostEnvVariable(name string) bool {
+	isNameMatch := func(key string) bool {
+		return key == name || (rc.JobContainer.IsEnvironmentCaseInsensitive() && strings.EqualFold(key, name))
+	}
+
+	for k := range rc.Env {
+		if isNameMatch(k) {
+			return true
+		}
+	}
+
+	for _, env := range os.Environ() {
+		if k, v, ok := strings.Cut(env, "="); ok && isNameMatch(k) {
+			rc.Env[k] = v
+			return true
+		}
+	}
+	return false
 }
 
 func (rc *RunContext) startJobContainer() common.Executor {

--- a/pkg/runner/run_context_test.go
+++ b/pkg/runner/run_context_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/exprparser"
 	"github.com/nektos/act/pkg/model"
 
@@ -676,6 +677,52 @@ func TestRunContextGetEnv(t *testing.T) {
 			assert.EqualValues(t, test.want, envMap[test.targetEnv])
 		})
 	}
+}
+
+func TestRunContextStartHostEnvironmentNoParentEnv(t *testing.T) {
+	const parentOnly = "ACT_TEST_PARENT_ONLY"
+	t.Setenv(parentOnly, "parent")
+
+	rc := &RunContext{
+		Config: &Config{
+			ActionCacheDir: t.TempDir(),
+			NoHostEnv:      true,
+			Workdir:        t.TempDir(),
+		},
+		Env: map[string]string{
+			"EXPLICIT_ENV": "explicit",
+		},
+	}
+
+	err := rc.startHostEnvironment()(common.WithLogger(t.Context(), log.New()))
+	assert.NoError(t, err)
+	assert.NotContains(t, rc.Env, parentOnly)
+	assert.Equal(t, "explicit", rc.Env["EXPLICIT_ENV"])
+	var path string
+	for key, value := range rc.Env {
+		if strings.EqualFold(key, rc.JobContainer.GetPathVariableName()) {
+			path = value
+			break
+		}
+	}
+	assert.NotEmpty(t, path)
+}
+
+func TestRunContextStartHostEnvironmentDefaultInheritsParentEnv(t *testing.T) {
+	const parentOnly = "ACT_TEST_PARENT_ONLY"
+	t.Setenv(parentOnly, "parent")
+
+	rc := &RunContext{
+		Config: &Config{
+			ActionCacheDir: t.TempDir(),
+			Workdir:        t.TempDir(),
+		},
+		Env: map[string]string{},
+	}
+
+	err := rc.startHostEnvironment()(common.WithLogger(t.Context(), log.New()))
+	assert.NoError(t, err)
+	assert.Equal(t, "parent", rc.Env[parentOnly])
 }
 
 func TestSetRuntimeVariables(t *testing.T) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -35,6 +35,7 @@ type Config struct {
 	JSONLogger                         bool                         // use json or text logger
 	LogPrefixJobID                     bool                         // switches from the full job name to the job id
 	Env                                map[string]string            // env for containers
+	NoHostEnv                          bool                         // don't inherit the parent process environment in host execution
 	Inputs                             map[string]string            // manually passed action inputs
 	Secrets                            map[string]string            // list of secrets
 	Vars                               map[string]string            // list of vars

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -188,6 +188,7 @@ func (j *TestJobFileInfo) runTest(ctx context.Context, t *testing.T, cfg *Config
 		Platforms:             j.platforms,
 		ReuseContainers:       false,
 		Env:                   cfg.Env,
+		NoHostEnv:             cfg.NoHostEnv,
 		Secrets:               cfg.Secrets,
 		Inputs:                cfg.Inputs,
 		GitHubInstance:        "github.com",
@@ -605,6 +606,45 @@ func TestRunEventHostEnvironment(t *testing.T) {
 			table.runTest(ctx, t, &Config{})
 		})
 	}
+}
+
+func TestRunEventHostEnvironmentNoHostEnv(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	const parentOnly = "ACT_TEST_PARENT_ONLY"
+	t.Setenv(parentOnly, "parent")
+
+	table := TestJobFileInfo{
+		workdir:      workdir,
+		workflowPath: "host-env-explicit",
+		eventName:    "push",
+		platforms:    map[string]string{"self-hosted": "-self-hosted"},
+		secrets:      secrets,
+	}
+	table.runTest(context.Background(), t, &Config{NoHostEnv: true})
+}
+
+func TestRunEventHostEnvironmentNoHostEnvWithExplicitEnv(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	const parentOnly = "ACT_TEST_PARENT_ONLY"
+	t.Setenv(parentOnly, "parent")
+
+	table := TestJobFileInfo{
+		workdir:      workdir,
+		workflowPath: "host-env-explicit-env",
+		eventName:    "push",
+		platforms:    map[string]string{"self-hosted": "-self-hosted"},
+		secrets:      secrets,
+	}
+	table.runTest(context.Background(), t, &Config{
+		Env:       map[string]string{parentOnly: "explicit"},
+		NoHostEnv: true,
+	})
 }
 
 func TestDryrunEvent(t *testing.T) {

--- a/pkg/runner/testdata/host-env-explicit-env/push.yaml
+++ b/pkg/runner/testdata/host-env-explicit-env/push.yaml
@@ -1,0 +1,9 @@
+name: host-env-explicit-env
+on: push
+
+jobs:
+  test:
+    runs-on: self-hosted
+    steps:
+      - name: Verify explicitly supplied environment is preserved
+        run: node -e "if (process.env.ACT_TEST_PARENT_ONLY !== 'explicit' || !process.env.PATH || !process.env.RUNNER_OS) process.exit(1)"

--- a/pkg/runner/testdata/host-env-explicit/push.yaml
+++ b/pkg/runner/testdata/host-env-explicit/push.yaml
@@ -1,0 +1,9 @@
+name: host-env-explicit
+on: push
+
+jobs:
+  test:
+    runs-on: self-hosted
+    steps:
+      - name: Verify parent environment is not inherited
+        run: node -e "if (process.env.ACT_TEST_PARENT_ONLY !== undefined || !process.env.PATH || !process.env.RUNNER_OS) process.exit(1)"


### PR DESCRIPTION
Fixes #6159.

## Summary

Host execution currently inherits every variable from the process that launched
act. This can unintentionally expose unrelated credentials, configuration, and
session state to a workflow running directly on the host.

This change adds an opt-in `--no-host-env` mode for host execution:

- Parent-process environment variables are not inherited in explicit mode.
- Variables supplied through workflow/job/step `env`, `--env`, and
  `--env-file` remain available.
- Runner and GitHub context variables constructed by act remain available.
- The minimal host shell environment is preserved: `PATH` and, on Windows,
  `PATHEXT`.
- Existing behavior remains unchanged unless `--no-host-env` is selected.
- Container execution is unchanged.

This option controls environment selection only; host execution remains
non-sandboxed as before.

## Implementation

The flag is wired through the CLI input and runner configuration. The host
environment setup now uses an explicit allowlist for shell lookup variables
instead of merging all of `os.Environ()`. Environment-name matching follows
the existing platform-specific case-sensitivity behavior.

## Regression coverage

Added tests for:

- A parent-only variable being absent in explicit host mode.
- The same variable being preserved when supplied explicitly through act
  configuration.
- Default host execution continuing to inherit the parent environment.
- The `--no-host-env` CLI flag being parsed correctly.
- Host shell execution continuing to work on Windows.

## Validation

- `go test ./pkg/runner -run '^(TestRunContextStartHostEnvironmentNoParentEnv|TestRunContextStartHostEnvironmentDefaultInheritsParentEnv|TestRunEventHostEnvironment|TestRunEventHostEnvironmentNoHostEnv(WithExplicitEnv)?)$' -count=1`
- `go test ./cmd -run '^(TestFlags|TestNoHostEnvFlag)$' -count=1`
- `go vet ./pkg/runner ./cmd`
- `go test ./... -run '^$' -count=1`
- `go build ./...`
- `gofmt` and `git diff --check`

On the local Windows environment, the focused runner/CLI tests and build checks
pass. The broader short suite still reports unrelated existing Windows-specific
failures in path-separator expectations and the Docker JSON-logger fixture.