### PR TITLE
runner: expose effective container context and service ports

### DIFF
--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -201,6 +201,24 @@ func (cr *containerReference) GetContainerID() string {
 	return cr.id
 }
 
+func (cr *containerReference) GetContainerNetwork(ctx context.Context) (string, error) {
+	if cr.cli == nil || cr.id == "" {
+		return "", errors.New("container must be started before inspecting its network")
+	}
+	inspectResult, err := cr.cli.ContainerInspect(ctx, cr.id, client.ContainerInspectOptions{})
+	if err != nil {
+		return "", fmt.Errorf("inspect container network: %w", err)
+	}
+	if inspectResult.Container.HostConfig == nil {
+		return "", errors.New("inspect container network: missing host config")
+	}
+	networkName := inspectResult.Container.HostConfig.NetworkMode.NetworkName()
+	if networkName == "" {
+		return "", fmt.Errorf("inspect container network: invalid network mode %q", inspectResult.Container.HostConfig.NetworkMode)
+	}
+	return networkName, nil
+}
+
 func (cr *containerReference) GetPortBindings(ctx context.Context) (nat.PortMap, error) {
 	if cr.cli == nil || cr.id == "" {
 		return nil, errors.New("container must be started before inspecting port bindings")

--- a/pkg/container/docker_run.go
+++ b/pkg/container/docker_run.go
@@ -20,6 +20,7 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/Masterminds/semver"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/go-connections/nat"
 	"github.com/go-git/go-billy/v5/helper/polyfill"
@@ -196,6 +197,24 @@ func (cr *containerReference) GetHealth(ctx context.Context) Health {
 	return HealthUnHealthy
 }
 
+func (cr *containerReference) GetContainerID() string {
+	return cr.id
+}
+
+func (cr *containerReference) GetPortBindings(ctx context.Context) (nat.PortMap, error) {
+	if cr.cli == nil || cr.id == "" {
+		return nil, errors.New("container must be started before inspecting port bindings")
+	}
+	inspectResult, err := cr.cli.ContainerInspect(ctx, cr.id, client.ContainerInspectOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("inspect container port bindings: %w", err)
+	}
+	if inspectResult.Container.NetworkSettings == nil {
+		return nil, errors.New("inspect container port bindings: missing network settings")
+	}
+	return convertDockerPortMap(inspectResult.Container.NetworkSettings.Ports), nil
+}
+
 func (cr *containerReference) ReplaceLogWriter(stdout io.Writer, stderr io.Writer) (io.Writer, io.Writer) {
 	out := cr.input.Stdout
 	err := cr.input.Stderr
@@ -342,7 +361,12 @@ func (cr *containerReference) remove() common.Executor {
 			Force:         true,
 		})
 		if err != nil {
-			logger.Error(fmt.Errorf("failed to remove container: %w", err))
+			if cerrdefs.IsNotFound(err) {
+				logger.Debugf("Container already removed: %v", cr.id)
+				cr.id = ""
+				return nil
+			}
+			return fmt.Errorf("failed to remove container %s: %w", cr.id, err)
 		}
 
 		logger.Debugf("Removed container: %v", cr.id)
@@ -925,6 +949,30 @@ func convertPortSet(ps nat.PortSet) network.PortSet {
 		if err == nil {
 			result[np] = struct{}{}
 		}
+	}
+	return result
+}
+
+// convertDockerPortMap converts the Docker API representation returned by
+// ContainerInspect into the representation used by act's workflow model.
+func convertDockerPortMap(pm network.PortMap) nat.PortMap {
+	if pm == nil {
+		return nil
+	}
+	result := make(nat.PortMap, len(pm))
+	for p, bindings := range pm {
+		converted := make([]nat.PortBinding, len(bindings))
+		for i, binding := range bindings {
+			hostIP := ""
+			if binding.HostIP.IsValid() {
+				hostIP = binding.HostIP.String()
+			}
+			converted[i] = nat.PortBinding{
+				HostIP:   hostIP,
+				HostPort: binding.HostPort,
+			}
+		}
+		result[nat.Port(p.String())] = converted
 	}
 	return result
 }

--- a/pkg/container/service_ports_test.go
+++ b/pkg/container/service_ports_test.go
@@ -126,6 +126,35 @@ func TestGetPortBindingsConvertsInspectResponse(t *testing.T) {
 	}, got)
 }
 
+func TestGetContainerNetworkReflectsOptionsOverride(t *testing.T) {
+	const nominalNetwork = "act-job-network"
+	cr := &containerReference{
+		input: &NewContainerInput{
+			NetworkMode: nominalNetwork,
+			Options:     "--network host",
+		},
+	}
+	_, mergedHostConfig, err := cr.mergeContainerConfigs(
+		context.Background(),
+		&mobycontainer.Config{},
+		&mobycontainer.HostConfig{NetworkMode: mobycontainer.NetworkMode(nominalNetwork)},
+	)
+	require.NoError(t, err)
+	require.Equal(t, mobycontainer.NetworkMode("host"), mergedHostConfig.NetworkMode)
+
+	cr.cli = &servicePortDockerClient{
+		inspectResult: client.ContainerInspectResult{
+			Container: mobycontainer.InspectResponse{HostConfig: mergedHostConfig},
+		},
+	}
+	cr.id = "job-container-id"
+
+	got, err := cr.GetContainerNetwork(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "host", got)
+	require.Equal(t, nominalNetwork, cr.input.NetworkMode)
+}
+
 func TestRemoveRetainsContainerIDOnFailure(t *testing.T) {
 	removeErr := errors.New("remove failed")
 	cli := &servicePortDockerClient{removeErr: removeErr}

--- a/pkg/container/service_ports_test.go
+++ b/pkg/container/service_ports_test.go
@@ -1,0 +1,157 @@
+//go:build !(WITHOUT_DOCKER || !(linux || darwin || windows || netbsd))
+
+package container
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/docker/go-connections/nat"
+	mobycontainer "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/require"
+)
+
+type servicePortDockerClient struct {
+	client.APIClient
+	inspectResult client.ContainerInspectResult
+	inspectErr    error
+	removeResult  client.ContainerRemoveResult
+	removeErr     error
+	removeCalls   int
+}
+
+func (c *servicePortDockerClient) ContainerInspect(
+	context.Context,
+	string,
+	client.ContainerInspectOptions,
+) (client.ContainerInspectResult, error) {
+	return c.inspectResult, c.inspectErr
+}
+
+func (c *servicePortDockerClient) ContainerRemove(
+	context.Context,
+	string,
+	client.ContainerRemoveOptions,
+) (client.ContainerRemoveResult, error) {
+	c.removeCalls++
+	return c.removeResult, c.removeErr
+}
+
+func TestConvertDockerPortMap(t *testing.T) {
+	port, err := network.ParsePort("5432/tcp")
+	require.NoError(t, err)
+
+	got := convertDockerPortMap(network.PortMap{
+		port: {
+			{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "49153"},
+			{HostIP: netip.MustParseAddr("::1"), HostPort: "49153"},
+			{HostPort: "49154"},
+		},
+	})
+
+	require.Equal(t, nat.PortMap{
+		nat.Port("5432/tcp"): {
+			{HostIP: "127.0.0.1", HostPort: "49153"},
+			{HostIP: "::1", HostPort: "49153"},
+			{HostPort: "49154"},
+		},
+	}, got)
+}
+
+func TestConvertDockerPortMapNil(t *testing.T) {
+	require.Nil(t, convertDockerPortMap(nil))
+}
+
+func TestGetPortBindingsRequiresStartedContainer(t *testing.T) {
+	for _, cr := range []*containerReference{
+		{},
+		{cli: &servicePortDockerClient{}},
+	} {
+		_, err := cr.GetPortBindings(context.Background())
+		require.ErrorContains(t, err, "must be started")
+	}
+}
+
+func TestGetPortBindingsReportsInspectError(t *testing.T) {
+	inspectErr := errors.New("inspect failed")
+	cr := &containerReference{
+		cli: &servicePortDockerClient{inspectErr: inspectErr},
+		id:  "service-container-id",
+	}
+	_, err := cr.GetPortBindings(context.Background())
+	require.ErrorIs(t, err, inspectErr)
+	require.ErrorContains(t, err, "inspect container port bindings")
+}
+
+func TestGetPortBindingsRequiresNetworkSettings(t *testing.T) {
+	cr := &containerReference{
+		cli: &servicePortDockerClient{
+			inspectResult: client.ContainerInspectResult{
+				Container: mobycontainer.InspectResponse{},
+			},
+		},
+		id: "service-container-id",
+	}
+	_, err := cr.GetPortBindings(context.Background())
+	require.ErrorContains(t, err, "missing network settings")
+}
+
+func TestGetPortBindingsConvertsInspectResponse(t *testing.T) {
+	port, err := network.ParsePort("5432/tcp")
+	require.NoError(t, err)
+	cr := &containerReference{
+		cli: &servicePortDockerClient{
+			inspectResult: client.ContainerInspectResult{
+				Container: mobycontainer.InspectResponse{
+					NetworkSettings: &mobycontainer.NetworkSettings{
+						Ports: network.PortMap{
+							port: {{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "49153"}},
+						},
+					},
+				},
+			},
+		},
+		id: "service-container-id",
+	}
+
+	got, err := cr.GetPortBindings(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, nat.PortMap{
+		nat.Port("5432/tcp"): {{HostIP: "127.0.0.1", HostPort: "49153"}},
+	}, got)
+}
+
+func TestRemoveRetainsContainerIDOnFailure(t *testing.T) {
+	removeErr := errors.New("remove failed")
+	cli := &servicePortDockerClient{removeErr: removeErr}
+	cr := &containerReference{cli: cli, id: "service-container-id"}
+
+	err := cr.remove()(context.Background())
+	require.ErrorIs(t, err, removeErr)
+	require.Equal(t, "service-container-id", cr.id)
+	require.Equal(t, 1, cli.removeCalls)
+}
+
+func TestRemoveClearsContainerIDWhenGone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "removed"},
+		{name: "already absent", err: cerrdefs.ErrNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := &servicePortDockerClient{removeErr: tt.err}
+			cr := &containerReference{cli: cli, id: "service-container-id"}
+			require.NoError(t, cr.remove()(context.Background()))
+			require.Empty(t, cr.id)
+			require.Equal(t, 1, cli.removeCalls)
+		})
+	}
+}

--- a/pkg/exprparser/interpreter.go
+++ b/pkg/exprparser/interpreter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/nektos/act/pkg/model"
@@ -214,6 +215,8 @@ func (impl *interperterImpl) evaluateIndexAccess(indexAccessNode *actionlint.Ind
 				return nil, nil
 			}
 			return leftValue.Index(int(rightValue.Int())).Interface(), nil
+		case reflect.Map, reflect.Ptr, reflect.Struct:
+			return impl.getPropertyValue(leftValue, strconv.FormatInt(rightValue.Int(), 10))
 		default:
 			return nil, nil
 		}

--- a/pkg/exprparser/interpreter_test.go
+++ b/pkg/exprparser/interpreter_test.go
@@ -50,6 +50,7 @@ func TestOperators(t *testing.T) {
 		{"github.action[0]", nil, "string-index", ""},
 		{"github.action['0']", nil, "string-index", ""},
 		{"fromJSON('[0,1]')[1]", 1.0, "array-index", ""},
+		{"fromJSON('{\"5432\":\"49153\"}')[5432]", "49153", "numeric-object-index", ""},
 		{"fromJSON('[0,1]')[1.1]", nil, "array-index", ""},
 		// Disabled weird things are happening
 		// {"fromJSON('[0,1]')['1.1']", nil, "array-index", ""},

--- a/pkg/model/job_context.go
+++ b/pkg/model/job_context.go
@@ -6,7 +6,11 @@ type JobContext struct {
 		ID      string `json:"id"`
 		Network string `json:"network"`
 	} `json:"container"`
-	Services map[string]struct {
-		ID string `json:"id"`
-	} `json:"services"`
+	Services map[string]ServiceContext `json:"services"`
+}
+
+type ServiceContext struct {
+	ID      string            `json:"id"`
+	Network string            `json:"network"`
+	Ports   map[string]string `json:"ports"`
 }

--- a/pkg/model/job_context.go
+++ b/pkg/model/job_context.go
@@ -1,12 +1,14 @@
 package model
 
 type JobContext struct {
-	Status    string `json:"status"`
-	Container struct {
-		ID      string `json:"id"`
-		Network string `json:"network"`
-	} `json:"container"`
-	Services map[string]ServiceContext `json:"services"`
+	Status    string                    `json:"status"`
+	Container ContainerContext          `json:"container"`
+	Services  map[string]ServiceContext `json:"services"`
+}
+
+type ContainerContext struct {
+	ID      string `json:"id"`
+	Network string `json:"network"`
 }
 
 type ServiceContext struct {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -62,16 +62,16 @@ type RunContext struct {
 
 type serviceContainerMetadata struct {
 	contextName  string
-	networkName  string
 	exposedPorts nat.PortSet
 }
 
-type containerIDProvider interface {
+type containerContextInspector interface {
 	GetContainerID() string
+	GetContainerNetwork(context.Context) (string, error)
 }
 
 type serviceContainerInspector interface {
-	containerIDProvider
+	containerContextInspector
 	GetPortBindings(context.Context) (nat.PortMap, error)
 }
 
@@ -371,7 +371,6 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.ServiceContainers = append(rc.ServiceContainers, c)
 			rc.serviceContainerMetadata = append(rc.serviceContainerMetadata, serviceContainerMetadata{
 				contextName:  serviceID,
-				networkName:  networkName,
 				exposedPorts: exposedPorts,
 			})
 		}
@@ -451,7 +450,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.startServiceContainers(networkName),
 			rc.JobContainer.Create(rc.Config.ContainerCapAdd, rc.Config.ContainerCapDrop),
 			rc.JobContainer.Start(false),
-			rc.captureJobContainerContext(jobContainerNetwork).IfNot(common.Dryrun),
+			rc.captureJobContainerContext().IfNot(common.Dryrun),
 			rc.JobContainer.Copy(rc.JobContainer.GetActPath()+"/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0o644,
@@ -467,15 +466,19 @@ func (rc *RunContext) startJobContainer() common.Executor {
 	}
 }
 
-func (rc *RunContext) captureJobContainerContext(networkName string) common.Executor {
-	return func(_ context.Context) error {
-		provider, ok := rc.JobContainer.(containerIDProvider)
+func (rc *RunContext) captureJobContainerContext() common.Executor {
+	return func(ctx context.Context) error {
+		inspector, ok := rc.JobContainer.(containerContextInspector)
 		if !ok {
-			return errors.New("resolve job container context: container does not expose its ID")
+			return errors.New("resolve job container context: container does not support inspection")
 		}
-		containerID := provider.GetContainerID()
+		containerID := inspector.GetContainerID()
 		if containerID == "" {
 			return errors.New("resolve job container context: container ID is empty")
+		}
+		networkName, err := inspector.GetContainerNetwork(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve job container context: %w", err)
 		}
 
 		rc.serviceContextsMu.Lock()
@@ -778,17 +781,22 @@ func serviceContextAfterStartWithRetry(
 		inspected, err := inspector.GetPortBindings(inspectCtx)
 		if err == nil {
 			if servicePortBindingsReady(metadata.exposedPorts, inspected) {
-				ports, resolveErr := githubServicePorts(metadata.exposedPorts, inspected)
-				if resolveErr != nil {
-					return model.ServiceContext{}, fmt.Errorf("resolve service %s port bindings: %w", metadata.contextName, resolveErr)
+				networkName, networkErr := inspector.GetContainerNetwork(inspectCtx)
+				if networkErr == nil {
+					ports, resolveErr := githubServicePorts(metadata.exposedPorts, inspected)
+					if resolveErr != nil {
+						return model.ServiceContext{}, fmt.Errorf("resolve service %s port bindings: %w", metadata.contextName, resolveErr)
+					}
+					return model.ServiceContext{
+						ID:      containerID,
+						Network: networkName,
+						Ports:   ports,
+					}, nil
 				}
-				return model.ServiceContext{
-					ID:      containerID,
-					Network: metadata.networkName,
-					Ports:   ports,
-				}, nil
+				lastErr = networkErr
+			} else {
+				_, lastErr = githubServicePorts(metadata.exposedPorts, inspected)
 			}
-			_, lastErr = githubServicePorts(metadata.exposedPorts, inspected)
 		} else {
 			lastErr = err
 		}
@@ -803,7 +811,7 @@ func serviceContextAfterStartWithRetry(
 				}
 			}
 			return model.ServiceContext{}, fmt.Errorf(
-				"inspect service %s port bindings: %w",
+				"inspect service %s context: %w",
 				metadata.contextName,
 				errors.Join(inspectCtx.Err(), lastErr),
 			)
@@ -918,11 +926,32 @@ func (rc *RunContext) waitForServiceContainers() common.Executor {
 
 func (rc *RunContext) stopServiceContainers() common.Executor {
 	return func(ctx context.Context) error {
-		execs := []common.Executor{}
-		for _, c := range rc.ServiceContainers {
-			execs = append(execs, c.Remove().Finally(c.Close()))
+		type serviceCleanupResult struct {
+			removeErr error
+			closeErr  error
 		}
-		return common.NewParallelExecutor(len(execs), execs...)(ctx)
+		results := make([]serviceCleanupResult, len(rc.ServiceContainers))
+		var cleanup sync.WaitGroup
+		cleanup.Add(len(rc.ServiceContainers))
+		for i, c := range rc.ServiceContainers {
+			go func() {
+				defer cleanup.Done()
+				results[i].removeErr = c.Remove()(ctx)
+				results[i].closeErr = c.Close()(ctx)
+			}()
+		}
+		cleanup.Wait()
+
+		var cleanupErr error
+		for i, result := range results {
+			if err := result.removeErr; err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove service container %d: %w", i+1, err))
+			}
+			if err := result.closeErr; err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("close service container %d: %w", i+1, err))
+			}
+		}
+		return cleanupErr
 	}
 }
 

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -56,6 +56,7 @@ type RunContext struct {
 	Cancelled                bool
 	nodeToolFullPath         string
 	serviceContextsMu        sync.RWMutex
+	jobContainerContext      model.ContainerContext
 	serviceContexts          map[string]model.ServiceContext
 }
 
@@ -65,8 +66,12 @@ type serviceContainerMetadata struct {
 	exposedPorts nat.PortSet
 }
 
-type serviceContainerInspector interface {
+type containerIDProvider interface {
 	GetContainerID() string
+}
+
+type serviceContainerInspector interface {
+	containerIDProvider
 	GetPortBindings(context.Context) (nat.PortMap, error)
 }
 
@@ -434,6 +439,9 @@ func (rc *RunContext) startJobContainer() common.Executor {
 		if rc.JobContainer == nil {
 			return errors.New("Failed to create job container")
 		}
+		rc.serviceContextsMu.Lock()
+		rc.jobContainerContext = model.ContainerContext{}
+		rc.serviceContextsMu.Unlock()
 
 		setup := common.NewPipelineExecutor(
 			rc.pullServicesImages(rc.Config.ForcePull),
@@ -443,6 +451,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.startServiceContainers(networkName),
 			rc.JobContainer.Create(rc.Config.ContainerCapAdd, rc.Config.ContainerCapDrop),
 			rc.JobContainer.Start(false),
+			rc.captureJobContainerContext(jobContainerNetwork).IfNot(common.Dryrun),
 			rc.JobContainer.Copy(rc.JobContainer.GetActPath()+"/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0o644,
@@ -455,6 +464,27 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.waitForServiceContainers(),
 		)
 		return rc.cleanupContainerSetupFailure(setup)(ctx)
+	}
+}
+
+func (rc *RunContext) captureJobContainerContext(networkName string) common.Executor {
+	return func(_ context.Context) error {
+		provider, ok := rc.JobContainer.(containerIDProvider)
+		if !ok {
+			return errors.New("resolve job container context: container does not expose its ID")
+		}
+		containerID := provider.GetContainerID()
+		if containerID == "" {
+			return errors.New("resolve job container context: container ID is empty")
+		}
+
+		rc.serviceContextsMu.Lock()
+		defer rc.serviceContextsMu.Unlock()
+		rc.jobContainerContext = model.ContainerContext{
+			ID:      containerID,
+			Network: networkName,
+		}
+		return nil
 	}
 }
 
@@ -1138,11 +1168,23 @@ func (rc *RunContext) getJobContext() *model.JobContext {
 			}
 		}
 	}
+	containerContext := rc.jobContainerContextSnapshot()
 	services := rc.serviceContextsSnapshot()
 	return &model.JobContext{
-		Status:   jobStatus,
-		Services: services,
+		Status:    jobStatus,
+		Container: containerContext,
+		Services:  services,
 	}
+}
+
+func (rc *RunContext) jobContainerContextSnapshot() model.ContainerContext {
+	source := rc
+	for source.Parent != nil {
+		source = source.Parent
+	}
+	source.serviceContextsMu.RLock()
+	defer source.serviceContextsMu.RUnlock()
+	return source.jobContainerContext
 }
 
 func (rc *RunContext) serviceContextsSnapshot() map[string]model.ServiceContext {

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/go-connections/nat"
@@ -30,29 +31,43 @@ import (
 
 // RunContext contains info about current job
 type RunContext struct {
-	Name                string
-	Config              *Config
-	Matrix              map[string]interface{}
-	Run                 *model.Run
-	EventJSON           string
-	Env                 map[string]string
-	GlobalEnv           map[string]string // to pass env changes of GITHUB_ENV and set-env correctly, due to dirty Env field
-	ExtraPath           []string
-	CurrentStep         string
-	StepResults         map[string]*model.StepResult
-	IntraActionState    map[string]map[string]string
-	ExprEval            ExpressionEvaluator
-	JobContainer        container.ExecutionsEnvironment
-	ServiceContainers   []container.ExecutionsEnvironment
-	OutputMappings      map[MappableOutput]MappableOutput
-	JobName             string
-	ActionPath          string
-	Parent              *RunContext
-	Masks               []string
-	cleanUpJobContainer common.Executor
-	caller              *caller // job calling this RunContext (reusable workflows)
-	Cancelled           bool
-	nodeToolFullPath    string
+	Name                     string
+	Config                   *Config
+	Matrix                   map[string]interface{}
+	Run                      *model.Run
+	EventJSON                string
+	Env                      map[string]string
+	GlobalEnv                map[string]string // to pass env changes of GITHUB_ENV and set-env correctly, due to dirty Env field
+	ExtraPath                []string
+	CurrentStep              string
+	StepResults              map[string]*model.StepResult
+	IntraActionState         map[string]map[string]string
+	ExprEval                 ExpressionEvaluator
+	JobContainer             container.ExecutionsEnvironment
+	ServiceContainers        []container.ExecutionsEnvironment
+	serviceContainerMetadata []serviceContainerMetadata
+	OutputMappings           map[MappableOutput]MappableOutput
+	JobName                  string
+	ActionPath               string
+	Parent                   *RunContext
+	Masks                    []string
+	cleanUpJobContainer      common.Executor
+	caller                   *caller // job calling this RunContext (reusable workflows)
+	Cancelled                bool
+	nodeToolFullPath         string
+	serviceContextsMu        sync.RWMutex
+	serviceContexts          map[string]model.ServiceContext
+}
+
+type serviceContainerMetadata struct {
+	contextName  string
+	networkName  string
+	exposedPorts nat.PortSet
+}
+
+type serviceContainerInspector interface {
+	GetContainerID() string
+	GetPortBindings(context.Context) (nat.PortMap, error)
 }
 
 func (rc *RunContext) AddMask(mask string) {
@@ -349,38 +364,44 @@ func (rc *RunContext) startJobContainer() common.Executor {
 				PortBindings:   portBindings,
 			})
 			rc.ServiceContainers = append(rc.ServiceContainers, c)
+			rc.serviceContainerMetadata = append(rc.serviceContainerMetadata, serviceContainerMetadata{
+				contextName:  serviceID,
+				networkName:  networkName,
+				exposedPorts: exposedPorts,
+			})
 		}
 
 		rc.cleanUpJobContainer = func(ctx context.Context) error {
-			reuseJobContainer := func(_ context.Context) bool {
-				return rc.Config.ReuseContainers
+			var jobRemove common.Executor
+			volumeRemoves := make([]common.Executor, 0, 2)
+			if rc.JobContainer != nil {
+				jobRemove = rc.JobContainer.Remove()
+				volumeRemoves = append(volumeRemoves,
+					container.NewDockerVolumeRemoveExecutor(rc.jobContainerName(), false),
+					container.NewDockerVolumeRemoveExecutor(rc.jobContainerName()+"-env", false),
+				)
 			}
 
-			if rc.JobContainer != nil {
-				return rc.JobContainer.Remove().IfNot(reuseJobContainer).
-					Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName(), false)).IfNot(reuseJobContainer).
-					Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName()+"-env", false)).IfNot(reuseJobContainer).
-					Then(func(ctx context.Context) error {
-						if len(rc.ServiceContainers) > 0 {
-							logger.Infof("Cleaning up services for job %s", rc.JobName)
-							if err := rc.stopServiceContainers()(ctx); err != nil {
-								logger.Errorf("Error while cleaning services: %v", err)
-							}
-							if createAndDeleteNetwork {
-								// clean network if it has been created by act
-								// if using service containers
-								// it means that the network to which containers are connecting is created by `act_runner`,
-								// so, we should remove the network at last.
-								logger.Infof("Cleaning up network for job %s, and network name is: %s", rc.JobName, networkName)
-								if err := container.NewDockerNetworkRemoveExecutor(networkName)(ctx); err != nil {
-									logger.Errorf("Error while cleaning network: %v", err)
-								}
-							}
-						}
-						return nil
-					})(ctx)
+			var servicesRemove common.Executor
+			if len(rc.ServiceContainers) > 0 {
+				logger.Infof("Cleaning up services for job %s", rc.JobName)
+				servicesRemove = rc.stopServiceContainers()
 			}
-			return nil
+
+			var networkRemove common.Executor
+			if createAndDeleteNetwork {
+				logger.Infof("Cleaning up network for job %s, and network name is: %s", rc.JobName, networkName)
+				networkRemove = container.NewDockerNetworkRemoveExecutor(networkName)
+			}
+
+			return cleanupContainerResources(
+				ctx,
+				rc.Config.ReuseContainers,
+				jobRemove,
+				volumeRemoves,
+				servicesRemove,
+				networkRemove,
+			)
 		}
 
 		jobContainerNetwork := rc.Config.ContainerNetworkMode.NetworkName()
@@ -414,7 +435,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			return errors.New("Failed to create job container")
 		}
 
-		return common.NewPipelineExecutor(
+		setup := common.NewPipelineExecutor(
 			rc.pullServicesImages(rc.Config.ForcePull),
 			rc.JobContainer.Pull(rc.Config.ForcePull),
 			rc.stopJobContainer(),
@@ -432,7 +453,75 @@ func (rc *RunContext) startJobContainer() common.Executor {
 				Body: "",
 			}),
 			rc.waitForServiceContainers(),
-		)(ctx)
+		)
+		return rc.cleanupContainerSetupFailure(setup)(ctx)
+	}
+}
+
+type namedCleanupExecutor struct {
+	name     string
+	executor common.Executor
+}
+
+const containerSetupCleanupTimeout = 1500 * time.Millisecond
+
+func cleanupContainerResources(
+	ctx context.Context,
+	reuseJobContainer bool,
+	jobRemove common.Executor,
+	volumeRemoves []common.Executor,
+	servicesRemove common.Executor,
+	networkRemove common.Executor,
+) error {
+	steps := make([]namedCleanupExecutor, 0, 2+len(volumeRemoves))
+	if !reuseJobContainer {
+		steps = append(steps, namedCleanupExecutor{name: "remove job container", executor: jobRemove})
+		for i, remove := range volumeRemoves {
+			steps = append(steps, namedCleanupExecutor{
+				name:     fmt.Sprintf("remove job volume %d", i+1),
+				executor: remove,
+			})
+		}
+	}
+	steps = append(steps,
+		namedCleanupExecutor{name: "remove service containers", executor: servicesRemove},
+		namedCleanupExecutor{name: "remove service network", executor: networkRemove},
+	)
+
+	var cleanupErr error
+	for _, step := range steps {
+		if step.executor == nil {
+			continue
+		}
+		if err := step.executor(ctx); err != nil {
+			common.Logger(ctx).Errorf("Error while cleaning resources (%s): %v", step.name, err)
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("%s: %w", step.name, err))
+		}
+	}
+	return cleanupErr
+}
+
+func (rc *RunContext) cleanupContainerSetupFailure(setup common.Executor) common.Executor {
+	return func(ctx context.Context) error {
+		setupErr := setup(ctx)
+		if _, ok := setupErr.(common.Warning); ok {
+			common.Logger(ctx).Warning(setupErr.Error())
+			setupErr = nil
+		}
+		if setupErr == nil {
+			setupErr = ctx.Err()
+		}
+		if setupErr == nil {
+			return nil
+		}
+
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), containerSetupCleanupTimeout)
+		defer cancel()
+		cleanupErr := errors.Join(
+			rc.stopJobContainer()(cleanupCtx),
+			rc.closeContainer()(cleanupCtx),
+		)
+		return errors.Join(setupErr, cleanupErr)
 	}
 }
 
@@ -571,16 +660,182 @@ func (rc *RunContext) pullServicesImages(forcePull bool) common.Executor {
 
 func (rc *RunContext) startServiceContainers(_ string) common.Executor {
 	return func(ctx context.Context) error {
+		if len(rc.ServiceContainers) != len(rc.serviceContainerMetadata) {
+			return errors.New("service container metadata is inconsistent")
+		}
+		if !common.Dryrun(ctx) {
+			rc.serviceContextsMu.Lock()
+			rc.serviceContexts = nil
+			rc.serviceContextsMu.Unlock()
+		}
+
+		resolvedContexts := make(map[string]model.ServiceContext, len(rc.ServiceContainers))
+		var resolvedContextsMu sync.Mutex
 		execs := []common.Executor{}
-		for _, c := range rc.ServiceContainers {
+		for i, c := range rc.ServiceContainers {
+			metadata := rc.serviceContainerMetadata[i]
+			resolveContext := common.Executor(func(ctx context.Context) error {
+				serviceContext, err := serviceContextAfterStart(ctx, c, metadata)
+				if err != nil {
+					return err
+				}
+				resolvedContextsMu.Lock()
+				defer resolvedContextsMu.Unlock()
+				resolvedContexts[metadata.contextName] = serviceContext
+				return nil
+			}).IfNot(common.Dryrun)
 			execs = append(execs, common.NewPipelineExecutor(
 				c.Pull(false),
 				c.Create(rc.Config.ContainerCapAdd, rc.Config.ContainerCapDrop),
 				c.Start(false),
+				resolveContext,
 			))
 		}
-		return common.NewParallelExecutor(len(execs), execs...)(ctx)
+
+		if err := common.NewParallelExecutor(len(execs), execs...)(ctx); err != nil {
+			return err
+		}
+		if common.Dryrun(ctx) {
+			return nil
+		}
+
+		rc.serviceContextsMu.Lock()
+		defer rc.serviceContextsMu.Unlock()
+		rc.serviceContexts = resolvedContexts
+		return nil
 	}
+}
+
+const (
+	servicePortInspectTimeout = 2 * time.Second
+	servicePortInspectDelay   = 50 * time.Millisecond
+)
+
+func serviceContextAfterStart(
+	ctx context.Context,
+	service container.ExecutionsEnvironment,
+	metadata serviceContainerMetadata,
+) (model.ServiceContext, error) {
+	return serviceContextAfterStartWithRetry(
+		ctx,
+		service,
+		metadata,
+		servicePortInspectTimeout,
+		servicePortInspectDelay,
+	)
+}
+
+func serviceContextAfterStartWithRetry(
+	ctx context.Context,
+	service container.ExecutionsEnvironment,
+	metadata serviceContainerMetadata,
+	timeout time.Duration,
+	delay time.Duration,
+) (model.ServiceContext, error) {
+	inspector, ok := service.(serviceContainerInspector)
+	if !ok {
+		return model.ServiceContext{}, fmt.Errorf("resolve service %s context: container does not support port inspection", metadata.contextName)
+	}
+	containerID := inspector.GetContainerID()
+	if containerID == "" {
+		return model.ServiceContext{}, fmt.Errorf("resolve service %s context: container ID is empty", metadata.contextName)
+	}
+
+	inspectCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var lastErr error
+	for {
+		inspected, err := inspector.GetPortBindings(inspectCtx)
+		if err == nil {
+			if servicePortBindingsReady(metadata.exposedPorts, inspected) {
+				ports, resolveErr := githubServicePorts(metadata.exposedPorts, inspected)
+				if resolveErr != nil {
+					return model.ServiceContext{}, fmt.Errorf("resolve service %s port bindings: %w", metadata.contextName, resolveErr)
+				}
+				return model.ServiceContext{
+					ID:      containerID,
+					Network: metadata.networkName,
+					Ports:   ports,
+				}, nil
+			}
+			_, lastErr = githubServicePorts(metadata.exposedPorts, inspected)
+		} else {
+			lastErr = err
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-inspectCtx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return model.ServiceContext{}, fmt.Errorf(
+				"inspect service %s port bindings: %w",
+				metadata.contextName,
+				errors.Join(inspectCtx.Err(), lastErr),
+			)
+		case <-timer.C:
+		}
+	}
+}
+
+func servicePortBindingsReady(expected nat.PortSet, inspected nat.PortMap) bool {
+	for port := range expected {
+		values, ok := inspected[port]
+		if !ok || !hasPublishedHostPort(values) {
+			return false
+		}
+	}
+	return true
+}
+
+func githubServicePorts(expected nat.PortSet, inspected nat.PortMap) (map[string]string, error) {
+	for port := range expected {
+		values, ok := inspected[port]
+		if !ok || !hasPublishedHostPort(values) {
+			return nil, fmt.Errorf("declared port %s has no published binding", port)
+		}
+	}
+
+	ports := make(map[string]string, len(inspected))
+	for port, values := range inspected {
+		numericPort := port.Port()
+		var resolved string
+		for _, binding := range values {
+			if binding.HostPort == "" {
+				continue
+			}
+			hostPort, err := strconv.Atoi(binding.HostPort)
+			if err != nil || hostPort < 1 || hostPort > 65535 {
+				return nil, fmt.Errorf("published port %s has invalid host port %q", port, binding.HostPort)
+			}
+			canonical := strconv.Itoa(hostPort)
+			if resolved != "" && resolved != canonical {
+				return nil, fmt.Errorf("published port %s has ambiguous host ports %s and %s", port, resolved, canonical)
+			}
+			resolved = canonical
+		}
+		if resolved == "" {
+			continue
+		}
+		if previous, exists := ports[numericPort]; exists && previous != resolved {
+			return nil, fmt.Errorf("container port %s has ambiguous protocol bindings %s and %s", numericPort, previous, resolved)
+		}
+		ports[numericPort] = resolved
+	}
+	return ports, nil
+}
+
+func hasPublishedHostPort(bindings []nat.PortBinding) bool {
+	for _, binding := range bindings {
+		if binding.HostPort != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (rc *RunContext) waitForServiceContainer(c container.ExecutionsEnvironment) common.Executor {
@@ -591,10 +846,24 @@ func (rc *RunContext) waitForServiceContainer(c container.ExecutionsEnvironment)
 		delay := time.Second
 		for i := 0; ; i++ {
 			health = c.GetHealth(sctx)
+			if err := sctx.Err(); err != nil {
+				return err
+			}
 			if health != container.HealthStarting || i > 30 {
 				break
 			}
-			time.Sleep(delay)
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-sctx.Done():
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return sctx.Err()
+			}
 			delay *= 2
 			if delay > 10*time.Second {
 				delay = 10 * time.Second
@@ -869,9 +1138,30 @@ func (rc *RunContext) getJobContext() *model.JobContext {
 			}
 		}
 	}
+	services := rc.serviceContextsSnapshot()
 	return &model.JobContext{
-		Status: jobStatus,
+		Status:   jobStatus,
+		Services: services,
 	}
+}
+
+func (rc *RunContext) serviceContextsSnapshot() map[string]model.ServiceContext {
+	source := rc
+	for source.Parent != nil {
+		source = source.Parent
+	}
+	source.serviceContextsMu.RLock()
+	defer source.serviceContextsMu.RUnlock()
+	services := make(map[string]model.ServiceContext, len(source.serviceContexts))
+	for serviceID, serviceContext := range source.serviceContexts {
+		ports := make(map[string]string, len(serviceContext.Ports))
+		for containerPort, hostPort := range serviceContext.Ports {
+			ports[containerPort] = hostPort
+		}
+		serviceContext.Ports = ports
+		services[serviceID] = serviceContext
+	}
+	return services
 }
 
 func (rc *RunContext) getStepsContext() map[string]*model.StepResult {

--- a/pkg/runner/service_ports_test.go
+++ b/pkg/runner/service_ports_test.go
@@ -1,0 +1,585 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/container"
+	"github.com/nektos/act/pkg/exprparser"
+	"github.com/nektos/act/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGithubServicePorts(t *testing.T) {
+	tests := []struct {
+		name      string
+		expected  nat.PortSet
+		inspected nat.PortMap
+		want      map[string]string
+		wantErr   string
+	}{
+		{
+			name:     "dynamic tcp with dual stack bindings",
+			expected: nat.PortSet{nat.Port("5432/tcp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): {
+					{HostIP: "0.0.0.0", HostPort: "49153"},
+					{HostIP: "::", HostPort: "49153"},
+				},
+			},
+			want: map[string]string{"5432": "49153"},
+		},
+		{
+			name: "multiple declared ports",
+			expected: nat.PortSet{
+				nat.Port("5432/tcp"): {},
+				nat.Port("9187/tcp"): {},
+			},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): {{HostPort: "49153"}},
+				nat.Port("9187/tcp"): {{HostPort: "49154"}},
+			},
+			want: map[string]string{"5432": "49153", "9187": "49154"},
+		},
+		{
+			name:     "explicit mapping",
+			expected: nat.PortSet{nat.Port("5432/tcp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): {{HostIP: "127.0.0.1", HostPort: "15432"}},
+			},
+			want: map[string]string{"5432": "15432"},
+		},
+		{
+			name:     "option-published port is included",
+			expected: nat.PortSet{nat.Port("5432/tcp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): {{HostPort: "49153"}},
+				nat.Port("9187/tcp"): {{HostPort: "49154"}},
+			},
+			want: map[string]string{"5432": "49153", "9187": "49154"},
+		},
+		{
+			name:     "partial dual stack binding",
+			expected: nat.PortSet{nat.Port("5432/tcp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): {{HostIP: "::"}, {HostIP: "0.0.0.0", HostPort: "49153"}},
+			},
+			want: map[string]string{"5432": "49153"},
+		},
+		{
+			name:      "no declared ports",
+			expected:  nat.PortSet{},
+			inspected: nat.PortMap{},
+			want:      map[string]string{},
+		},
+		{
+			name:     "missing binding",
+			expected: nat.PortSet{nat.Port("5432/tcp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): nil,
+			},
+			wantErr: "has no published binding",
+		},
+		{
+			name:     "invalid binding",
+			expected: nat.PortSet{nat.Port("5432/tcp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): {{HostPort: "not-a-port"}},
+			},
+			wantErr: "invalid host port",
+		},
+		{
+			name:     "ambiguous host bindings",
+			expected: nat.PortSet{nat.Port("5432/tcp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("5432/tcp"): {{HostPort: "49153"}, {HostPort: "49154"}},
+			},
+			wantErr: "ambiguous host ports",
+		},
+		{
+			name:     "protocol ambiguity",
+			expected: nat.PortSet{nat.Port("53/tcp"): {}, nat.Port("53/udp"): {}},
+			inspected: nat.PortMap{
+				nat.Port("53/tcp"): {{HostPort: "49153"}},
+				nat.Port("53/udp"): {{HostPort: "49154"}},
+			},
+			wantErr: "ambiguous protocol bindings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := githubServicePorts(tt.expected, tt.inspected)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type serviceContainerWithoutInspection struct {
+	container.ExecutionsEnvironment
+}
+
+func TestServiceContextRequiresPrivateInspectionCapability(t *testing.T) {
+	_, err := serviceContextAfterStart(
+		context.Background(),
+		&serviceContainerWithoutInspection{},
+		serviceContainerMetadata{contextName: "postgres"},
+	)
+	require.ErrorContains(t, err, "does not support port inspection")
+}
+
+type serviceContainerFake struct {
+	container.ExecutionsEnvironment
+	id            string
+	bindings      nat.PortMap
+	inspectErr    error
+	bindingsAfter int
+	inspectCalls  int
+	startCalled   bool
+	removeCalled  bool
+	removeErr     error
+	closeCalled   bool
+}
+
+func (c *serviceContainerFake) Pull(bool) common.Executor {
+	return func(context.Context) error { return nil }
+}
+
+func (c *serviceContainerFake) Create([]string, []string) common.Executor {
+	return func(context.Context) error { return nil }
+}
+
+func (c *serviceContainerFake) Start(bool) common.Executor {
+	return func(context.Context) error {
+		c.startCalled = true
+		return nil
+	}
+}
+
+func (c *serviceContainerFake) GetContainerID() string {
+	return c.id
+}
+
+func (c *serviceContainerFake) GetPortBindings(context.Context) (nat.PortMap, error) {
+	c.inspectCalls++
+	if !c.startCalled {
+		return nil, errors.New("inspected before start")
+	}
+	if c.inspectErr != nil {
+		return nil, c.inspectErr
+	}
+	if c.inspectCalls <= c.bindingsAfter {
+		return nat.PortMap{}, nil
+	}
+	return c.bindings, nil
+}
+
+func (c *serviceContainerFake) Remove() common.Executor {
+	return func(context.Context) error {
+		c.removeCalled = true
+		return c.removeErr
+	}
+}
+
+func (c *serviceContainerFake) Close() common.Executor {
+	return func(context.Context) error {
+		c.closeCalled = true
+		return nil
+	}
+}
+
+func (c *serviceContainerFake) GetHealth(context.Context) container.Health {
+	return container.HealthStarting
+}
+
+func TestWaitForServiceContainerCancellationInterruptsBackoff(t *testing.T) {
+	rc := &RunContext{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	err := rc.waitForServiceContainer(&serviceContainerFake{})(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, time.Since(started), 500*time.Millisecond)
+}
+
+func TestStartServiceContainersPublishesContextAfterStart(t *testing.T) {
+	postgres := &serviceContainerFake{
+		id: "postgres-container-id",
+		bindings: nat.PortMap{
+			nat.Port("5432/tcp"): {{HostPort: "49153"}},
+		},
+	}
+	redis := &serviceContainerFake{
+		id: "redis-container-id",
+		bindings: nat.PortMap{
+			nat.Port("6379/tcp"): {{HostPort: "49154"}},
+		},
+	}
+	rc := &RunContext{
+		Config:            &Config{},
+		ServiceContainers: []container.ExecutionsEnvironment{postgres, redis},
+		serviceContainerMetadata: []serviceContainerMetadata{
+			{contextName: "postgres", networkName: "act-test-network", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
+			{contextName: "redis", networkName: "act-test-network", exposedPorts: nat.PortSet{nat.Port("6379/tcp"): {}}},
+		},
+		StepResults: map[string]*model.StepResult{},
+	}
+
+	require.NoError(t, rc.startServiceContainers("")(context.Background()))
+	job := rc.getJobContext()
+	require.Equal(t, "postgres-container-id", job.Services["postgres"].ID)
+	require.Equal(t, "act-test-network", job.Services["postgres"].Network)
+	require.Equal(t, "49153", job.Services["postgres"].Ports["5432"])
+	require.Equal(t, "redis-container-id", job.Services["redis"].ID)
+	require.Equal(t, "49154", job.Services["redis"].Ports["6379"])
+}
+
+func TestStartServiceContainersFailsClosedOnInvalidBinding(t *testing.T) {
+	postgres := &serviceContainerFake{
+		id: "postgres-container-id",
+		bindings: nat.PortMap{
+			nat.Port("5432/tcp"): {{HostPort: "not-a-port"}},
+		},
+	}
+	rc := &RunContext{
+		Config:            &Config{},
+		ServiceContainers: []container.ExecutionsEnvironment{postgres},
+		serviceContainerMetadata: []serviceContainerMetadata{
+			{contextName: "postgres", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
+		},
+	}
+
+	err := rc.startServiceContainers("")(context.Background())
+	require.ErrorContains(t, err, "resolve service postgres port bindings")
+	require.ErrorContains(t, err, "invalid host port")
+	require.Empty(t, rc.serviceContexts)
+}
+
+func TestServiceContextAfterStartRetriesInspectErrors(t *testing.T) {
+	postgres := &serviceContainerFake{
+		id:          "postgres-container-id",
+		inspectErr:  errors.New("inspect unavailable"),
+		startCalled: true,
+	}
+	_, err := serviceContextAfterStartWithRetry(
+		context.Background(),
+		postgres,
+		serviceContainerMetadata{contextName: "postgres", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
+		20*time.Millisecond,
+		time.Millisecond,
+	)
+	require.ErrorContains(t, err, "inspect service postgres port bindings")
+	require.ErrorContains(t, err, "inspect unavailable")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Greater(t, postgres.inspectCalls, 1)
+}
+
+func TestServiceContextAfterStartPreservesParentCancellation(t *testing.T) {
+	postgres := &serviceContainerFake{
+		id:          "postgres-container-id",
+		inspectErr:  errors.New("inspect unavailable"),
+		startCalled: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := serviceContextAfterStartWithRetry(
+		ctx,
+		postgres,
+		serviceContainerMetadata{contextName: "postgres", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
+		time.Second,
+		time.Millisecond,
+	)
+	require.ErrorContains(t, err, "inspect unavailable")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestServiceContextAfterStartRetriesPendingBindings(t *testing.T) {
+	postgres := &serviceContainerFake{
+		id:            "postgres-container-id",
+		bindingsAfter: 2,
+		startCalled:   true,
+		bindings: nat.PortMap{
+			nat.Port("5432/tcp"): {{HostPort: "49153"}},
+		},
+	}
+	serviceContext, err := serviceContextAfterStart(context.Background(), postgres, serviceContainerMetadata{
+		contextName:  "postgres",
+		networkName:  "act-test-network",
+		exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, postgres.inspectCalls)
+	require.Equal(t, "49153", serviceContext.Ports["5432"])
+}
+
+func TestStartServiceContainersDryrunSkipsInspection(t *testing.T) {
+	postgres := &serviceContainerFake{id: "postgres-container-id"}
+	rc := &RunContext{
+		Config:            &Config{},
+		ServiceContainers: []container.ExecutionsEnvironment{postgres},
+		serviceContainerMetadata: []serviceContainerMetadata{
+			{contextName: "postgres", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
+		},
+	}
+
+	ctx := common.WithDryrun(context.Background(), true)
+	require.NoError(t, rc.startServiceContainers("")(ctx))
+	require.Zero(t, postgres.inspectCalls)
+	require.Empty(t, rc.serviceContexts)
+}
+
+func TestContainerSetupFailureCleansPartiallyStartedServices(t *testing.T) {
+	postgres := &serviceContainerFake{
+		id: "postgres-container-id",
+		bindings: nat.PortMap{
+			nat.Port("5432/tcp"): {{HostPort: "49153"}},
+		},
+	}
+	redis := &serviceContainerFake{
+		id: "redis-container-id",
+		bindings: nat.PortMap{
+			nat.Port("6379/tcp"): {{HostPort: "not-a-port"}},
+		},
+	}
+	jobRemoveErr := errors.New("job remove failed")
+	job := &serviceContainerFake{id: "job-container-id", removeErr: jobRemoveErr}
+	rc := &RunContext{
+		Config:            &Config{},
+		JobContainer:      job,
+		ServiceContainers: []container.ExecutionsEnvironment{postgres, redis},
+		serviceContainerMetadata: []serviceContainerMetadata{
+			{contextName: "postgres", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
+			{contextName: "redis", exposedPorts: nat.PortSet{nat.Port("6379/tcp"): {}}},
+		},
+		serviceContexts: map[string]model.ServiceContext{
+			"stale": {ID: "stale-container-id"},
+		},
+	}
+	networkRemoved := false
+	rc.cleanUpJobContainer = func(ctx context.Context) error {
+		return cleanupContainerResources(
+			ctx,
+			false,
+			job.Remove(),
+			nil,
+			rc.stopServiceContainers(),
+			func(context.Context) error {
+				networkRemoved = true
+				return nil
+			},
+		)
+	}
+
+	err := rc.cleanupContainerSetupFailure(rc.startServiceContainers(""))(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid host port")
+	require.ErrorIs(t, err, jobRemoveErr)
+	require.True(t, postgres.startCalled)
+	require.True(t, redis.startCalled)
+	require.True(t, postgres.removeCalled)
+	require.True(t, redis.removeCalled)
+	require.True(t, postgres.closeCalled)
+	require.True(t, redis.closeCalled)
+	require.True(t, job.removeCalled)
+	require.True(t, job.closeCalled)
+	require.True(t, networkRemoved)
+	require.Empty(t, rc.serviceContexts)
+}
+
+func TestContainerSetupFailurePreservesSetupAndCleanupErrors(t *testing.T) {
+	setupErr := errors.New("setup failed")
+	cleanupErr := errors.New("cleanup failed")
+
+	for _, tt := range []struct {
+		name       string
+		cleanupErr error
+	}{
+		{name: "cleanup succeeds"},
+		{name: "cleanup fails", cleanupErr: cleanupErr},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanupCalled := false
+			rc := &RunContext{
+				cleanUpJobContainer: func(ctx context.Context) error {
+					cleanupCalled = true
+					require.NoError(t, ctx.Err())
+					return tt.cleanupErr
+				},
+			}
+
+			err := rc.cleanupContainerSetupFailure(func(context.Context) error {
+				return setupErr
+			})(context.Background())
+
+			require.True(t, cleanupCalled)
+			require.ErrorIs(t, err, setupErr)
+			if tt.cleanupErr != nil {
+				require.ErrorIs(t, err, tt.cleanupErr)
+			}
+		})
+	}
+
+	t.Run("warning keeps upstream success semantics", func(t *testing.T) {
+		cleanupCalled := false
+		rc := &RunContext{
+			cleanUpJobContainer: func(context.Context) error {
+				cleanupCalled = true
+				return nil
+			},
+		}
+
+		err := rc.cleanupContainerSetupFailure(func(context.Context) error {
+			return common.Warning{Message: "setup warning"}
+		})(context.Background())
+
+		require.NoError(t, err)
+		require.False(t, cleanupCalled)
+	})
+}
+
+func TestContainerSetupFailureOnCancellationAfterSuccessfulSetupStillCleans(t *testing.T) {
+	type cleanupContextKey struct{}
+	const contextValue = "preserved"
+
+	parent, cancel := context.WithCancel(context.WithValue(
+		context.Background(),
+		cleanupContextKey{},
+		contextValue,
+	))
+	cleanupCalled := false
+	rc := &RunContext{
+		cleanUpJobContainer: func(ctx context.Context) error {
+			cleanupCalled = true
+			require.NoError(t, ctx.Err())
+			require.Equal(t, contextValue, ctx.Value(cleanupContextKey{}))
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			remaining := time.Until(deadline)
+			require.Positive(t, remaining)
+			require.LessOrEqual(t, remaining, containerSetupCleanupTimeout)
+			return nil
+		},
+	}
+
+	err := rc.cleanupContainerSetupFailure(func(context.Context) error {
+		cancel()
+		return nil
+	})(parent)
+
+	require.True(t, cleanupCalled)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCleanupContainerResourcesContinuesAfterErrors(t *testing.T) {
+	jobErr := errors.New("job removal failed")
+	networkErr := errors.New("network removal failed")
+	calls := make([]string, 0, 5)
+	step := func(name string, err error) common.Executor {
+		return func(context.Context) error {
+			calls = append(calls, name)
+			return err
+		}
+	}
+
+	err := cleanupContainerResources(
+		context.Background(),
+		false,
+		step("job", jobErr),
+		[]common.Executor{step("volume-1", nil), step("volume-2", nil)},
+		step("services", nil),
+		step("network", networkErr),
+	)
+
+	require.ErrorIs(t, err, jobErr)
+	require.ErrorIs(t, err, networkErr)
+	require.Equal(t, []string{"job", "volume-1", "volume-2", "services", "network"}, calls)
+}
+
+func TestCleanupContainerResourcesReuseStillCleansServicesAndNetwork(t *testing.T) {
+	calls := make([]string, 0, 2)
+	step := func(name string) common.Executor {
+		return func(context.Context) error {
+			calls = append(calls, name)
+			return nil
+		}
+	}
+
+	require.NoError(t, cleanupContainerResources(
+		context.Background(),
+		true,
+		step("job"),
+		[]common.Executor{step("volume")},
+		step("services"),
+		step("network"),
+	))
+	require.Equal(t, []string{"services", "network"}, calls)
+}
+
+func TestGetJobContextIncludesIndependentServiceSnapshot(t *testing.T) {
+	rc := &RunContext{
+		serviceContexts: map[string]model.ServiceContext{
+			"postgres": {
+				ID:      "postgres-container-id",
+				Network: "act-test-network",
+				Ports:   map[string]string{"5432": "49153"},
+			},
+		},
+		StepResults: map[string]*model.StepResult{},
+	}
+
+	job := rc.getJobContext()
+	require.Equal(t, "success", job.Status)
+	require.Equal(t, "postgres-container-id", job.Services["postgres"].ID)
+	require.Equal(t, "act-test-network", job.Services["postgres"].Network)
+	require.Equal(t, "49153", job.Services["postgres"].Ports["5432"])
+
+	job.Services["postgres"].Ports["5432"] = "1"
+	require.Equal(t, "49153", rc.serviceContexts["postgres"].Ports["5432"])
+}
+
+func TestCompositeRunContextInheritsServiceSnapshot(t *testing.T) {
+	parent := &RunContext{
+		serviceContexts: map[string]model.ServiceContext{
+			"postgres": {
+				ID:      "postgres-container-id",
+				Network: "act-test-network",
+				Ports:   map[string]string{"5432": "49153"},
+			},
+		},
+	}
+	child := &RunContext{Parent: parent, StepResults: map[string]*model.StepResult{}}
+	job := child.getJobContext()
+	require.Equal(t, "49153", job.Services["postgres"].Ports["5432"])
+	job.Services["postgres"].Ports["5432"] = "1"
+	require.Equal(t, "49153", parent.serviceContexts["postgres"].Ports["5432"])
+}
+
+func TestServicePortExpressionUsesNumericIndex(t *testing.T) {
+	rc := createRunContext(t)
+	rc.serviceContexts = map[string]model.ServiceContext{
+		"postgres": {
+			ID:      "postgres-container-id",
+			Network: "act-test-network",
+			Ports:   map[string]string{"5432": "49153"},
+		},
+	}
+
+	ctx := context.Background()
+	evaluator := rc.NewExpressionEvaluator(ctx)
+	got, err := evaluator.evaluate(ctx, "job.services.postgres.ports[5432]", exprparser.DefaultStatusCheckNone)
+	require.NoError(t, err)
+	require.Equal(t, "49153", got)
+	require.Equal(t, "127.0.0.1:49153", evaluator.Interpolate(ctx, "127.0.0.1:${{ job.services.postgres.ports[5432] }}"))
+}

--- a/pkg/runner/service_ports_test.go
+++ b/pkg/runner/service_ports_test.go
@@ -141,14 +141,18 @@ func TestServiceContextRequiresPrivateInspectionCapability(t *testing.T) {
 type serviceContainerFake struct {
 	container.ExecutionsEnvironment
 	id            string
+	network       string
+	networkErr    error
 	bindings      nat.PortMap
 	inspectErr    error
 	bindingsAfter int
 	inspectCalls  int
+	networkCalls  int
 	startCalled   bool
 	removeCalled  bool
 	removeErr     error
 	closeCalled   bool
+	closeErr      error
 }
 
 func (c *serviceContainerFake) Pull(bool) common.Executor {
@@ -168,6 +172,11 @@ func (c *serviceContainerFake) Start(bool) common.Executor {
 
 func (c *serviceContainerFake) GetContainerID() string {
 	return c.id
+}
+
+func (c *serviceContainerFake) GetContainerNetwork(context.Context) (string, error) {
+	c.networkCalls++
+	return c.network, c.networkErr
 }
 
 func (c *serviceContainerFake) GetPortBindings(context.Context) (nat.PortMap, error) {
@@ -194,7 +203,7 @@ func (c *serviceContainerFake) Remove() common.Executor {
 func (c *serviceContainerFake) Close() common.Executor {
 	return func(context.Context) error {
 		c.closeCalled = true
-		return nil
+		return c.closeErr
 	}
 }
 
@@ -216,13 +225,15 @@ func TestWaitForServiceContainerCancellationInterruptsBackoff(t *testing.T) {
 
 func TestStartServiceContainersPublishesContextAfterStart(t *testing.T) {
 	postgres := &serviceContainerFake{
-		id: "postgres-container-id",
+		id:      "postgres-container-id",
+		network: "act-test-network",
 		bindings: nat.PortMap{
 			nat.Port("5432/tcp"): {{HostPort: "49153"}},
 		},
 	}
 	redis := &serviceContainerFake{
-		id: "redis-container-id",
+		id:      "redis-container-id",
+		network: "act-test-network",
 		bindings: nat.PortMap{
 			nat.Port("6379/tcp"): {{HostPort: "49154"}},
 		},
@@ -231,8 +242,8 @@ func TestStartServiceContainersPublishesContextAfterStart(t *testing.T) {
 		Config:            &Config{},
 		ServiceContainers: []container.ExecutionsEnvironment{postgres, redis},
 		serviceContainerMetadata: []serviceContainerMetadata{
-			{contextName: "postgres", networkName: "act-test-network", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
-			{contextName: "redis", networkName: "act-test-network", exposedPorts: nat.PortSet{nat.Port("6379/tcp"): {}}},
+			{contextName: "postgres", exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}}},
+			{contextName: "redis", exposedPorts: nat.PortSet{nat.Port("6379/tcp"): {}}},
 		},
 		StepResults: map[string]*model.StepResult{},
 	}
@@ -249,32 +260,62 @@ func TestStartServiceContainersPublishesContextAfterStart(t *testing.T) {
 func TestCaptureJobContainerContext(t *testing.T) {
 	t.Run("requires ID capability", func(t *testing.T) {
 		rc := &RunContext{JobContainer: &serviceContainerWithoutInspection{}}
-		err := rc.captureJobContainerContext("act-test-network")(context.Background())
-		require.ErrorContains(t, err, "does not expose its ID")
+		err := rc.captureJobContainerContext()(context.Background())
+		require.ErrorContains(t, err, "does not support inspection")
 	})
 
 	t.Run("requires non-empty ID", func(t *testing.T) {
 		rc := &RunContext{JobContainer: &serviceContainerFake{}}
-		err := rc.captureJobContainerContext("act-test-network")(context.Background())
+		err := rc.captureJobContainerContext()(context.Background())
 		require.ErrorContains(t, err, "container ID is empty")
 	})
 
-	t.Run("publishes ID and network", func(t *testing.T) {
+	t.Run("preserves network inspection error", func(t *testing.T) {
+		inspectErr := errors.New("network inspect failed")
+		rc := &RunContext{JobContainer: &serviceContainerFake{
+			id:         "job-container-id",
+			networkErr: inspectErr,
+		}}
+		err := rc.captureJobContainerContext()(context.Background())
+		require.ErrorIs(t, err, inspectErr)
+		require.Empty(t, rc.jobContainerContext)
+	})
+
+	t.Run("publishes ID and inspected network override", func(t *testing.T) {
 		rc := &RunContext{
-			JobContainer: &serviceContainerFake{id: "job-container-id"},
+			JobContainer: &serviceContainerFake{id: "job-container-id", network: "host"},
 			StepResults:  map[string]*model.StepResult{},
 		}
-		require.NoError(t, rc.captureJobContainerContext("act-test-network")(context.Background()))
+		require.NoError(t, rc.captureJobContainerContext()(context.Background()))
 
 		job := rc.getJobContext()
 		require.Equal(t, "job-container-id", job.Container.ID)
-		require.Equal(t, "act-test-network", job.Container.Network)
+		require.Equal(t, "host", job.Container.Network)
 	})
+}
+
+func TestServiceContextUsesInspectedNetworkOverride(t *testing.T) {
+	postgres := &serviceContainerFake{
+		id:          "postgres-container-id",
+		network:     "host",
+		startCalled: true,
+		bindings: nat.PortMap{
+			nat.Port("5432/tcp"): {{HostPort: "49153"}},
+		},
+	}
+	serviceContext, err := serviceContextAfterStart(context.Background(), postgres, serviceContainerMetadata{
+		contextName:  "postgres",
+		exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "host", serviceContext.Network)
+	require.Equal(t, "49153", serviceContext.Ports["5432"])
 }
 
 func TestStartServiceContainersFailsClosedOnInvalidBinding(t *testing.T) {
 	postgres := &serviceContainerFake{
-		id: "postgres-container-id",
+		id:      "postgres-container-id",
+		network: "act-test-network",
 		bindings: nat.PortMap{
 			nat.Port("5432/tcp"): {{HostPort: "not-a-port"}},
 		},
@@ -306,7 +347,7 @@ func TestServiceContextAfterStartRetriesInspectErrors(t *testing.T) {
 		20*time.Millisecond,
 		time.Millisecond,
 	)
-	require.ErrorContains(t, err, "inspect service postgres port bindings")
+	require.ErrorContains(t, err, "inspect service postgres context")
 	require.ErrorContains(t, err, "inspect unavailable")
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Greater(t, postgres.inspectCalls, 1)
@@ -334,6 +375,7 @@ func TestServiceContextAfterStartPreservesParentCancellation(t *testing.T) {
 func TestServiceContextAfterStartRetriesPendingBindings(t *testing.T) {
 	postgres := &serviceContainerFake{
 		id:            "postgres-container-id",
+		network:       "act-test-network",
 		bindingsAfter: 2,
 		startCalled:   true,
 		bindings: nat.PortMap{
@@ -342,7 +384,6 @@ func TestServiceContextAfterStartRetriesPendingBindings(t *testing.T) {
 	}
 	serviceContext, err := serviceContextAfterStart(context.Background(), postgres, serviceContainerMetadata{
 		contextName:  "postgres",
-		networkName:  "act-test-network",
 		exposedPorts: nat.PortSet{nat.Port("5432/tcp"): {}},
 	})
 	require.NoError(t, err)
@@ -363,18 +404,21 @@ func TestStartServiceContainersDryrunSkipsInspection(t *testing.T) {
 	ctx := common.WithDryrun(context.Background(), true)
 	require.NoError(t, rc.startServiceContainers("")(ctx))
 	require.Zero(t, postgres.inspectCalls)
+	require.Zero(t, postgres.networkCalls)
 	require.Empty(t, rc.serviceContexts)
 }
 
 func TestContainerSetupFailureCleansPartiallyStartedServices(t *testing.T) {
 	postgres := &serviceContainerFake{
-		id: "postgres-container-id",
+		id:      "postgres-container-id",
+		network: "act-test-network",
 		bindings: nat.PortMap{
 			nat.Port("5432/tcp"): {{HostPort: "49153"}},
 		},
 	}
 	redis := &serviceContainerFake{
-		id: "redis-container-id",
+		id:      "redis-container-id",
+		network: "act-test-network",
 		bindings: nat.PortMap{
 			nat.Port("6379/tcp"): {{HostPort: "not-a-port"}},
 		},
@@ -531,6 +575,26 @@ func TestCleanupContainerResourcesContinuesAfterErrors(t *testing.T) {
 	require.ErrorIs(t, err, jobErr)
 	require.ErrorIs(t, err, networkErr)
 	require.Equal(t, []string{"job", "volume-1", "volume-2", "services", "network"}, calls)
+}
+
+func TestStopServiceContainersPreservesAllRemoveAndCloseErrors(t *testing.T) {
+	removeErr1 := errors.New("postgres remove failed")
+	closeErr1 := errors.New("postgres close failed")
+	removeErr2 := errors.New("redis remove failed")
+	closeErr2 := errors.New("redis close failed")
+	postgres := &serviceContainerFake{removeErr: removeErr1, closeErr: closeErr1}
+	redis := &serviceContainerFake{removeErr: removeErr2, closeErr: closeErr2}
+	rc := &RunContext{ServiceContainers: []container.ExecutionsEnvironment{postgres, redis}}
+
+	err := rc.stopServiceContainers()(context.Background())
+
+	for _, want := range []error{removeErr1, closeErr1, removeErr2, closeErr2} {
+		require.ErrorIs(t, err, want)
+	}
+	require.True(t, postgres.removeCalled)
+	require.True(t, postgres.closeCalled)
+	require.True(t, redis.removeCalled)
+	require.True(t, redis.closeCalled)
 }
 
 func TestCleanupContainerResourcesReuseStillCleansServicesAndNetwork(t *testing.T) {

--- a/pkg/runner/service_ports_test.go
+++ b/pkg/runner/service_ports_test.go
@@ -246,6 +246,32 @@ func TestStartServiceContainersPublishesContextAfterStart(t *testing.T) {
 	require.Equal(t, "49154", job.Services["redis"].Ports["6379"])
 }
 
+func TestCaptureJobContainerContext(t *testing.T) {
+	t.Run("requires ID capability", func(t *testing.T) {
+		rc := &RunContext{JobContainer: &serviceContainerWithoutInspection{}}
+		err := rc.captureJobContainerContext("act-test-network")(context.Background())
+		require.ErrorContains(t, err, "does not expose its ID")
+	})
+
+	t.Run("requires non-empty ID", func(t *testing.T) {
+		rc := &RunContext{JobContainer: &serviceContainerFake{}}
+		err := rc.captureJobContainerContext("act-test-network")(context.Background())
+		require.ErrorContains(t, err, "container ID is empty")
+	})
+
+	t.Run("publishes ID and network", func(t *testing.T) {
+		rc := &RunContext{
+			JobContainer: &serviceContainerFake{id: "job-container-id"},
+			StepResults:  map[string]*model.StepResult{},
+		}
+		require.NoError(t, rc.captureJobContainerContext("act-test-network")(context.Background()))
+
+		job := rc.getJobContext()
+		require.Equal(t, "job-container-id", job.Container.ID)
+		require.Equal(t, "act-test-network", job.Container.Network)
+	})
+}
+
 func TestStartServiceContainersFailsClosedOnInvalidBinding(t *testing.T) {
 	postgres := &serviceContainerFake{
 		id: "postgres-container-id",
@@ -551,6 +577,10 @@ func TestGetJobContextIncludesIndependentServiceSnapshot(t *testing.T) {
 
 func TestCompositeRunContextInheritsServiceSnapshot(t *testing.T) {
 	parent := &RunContext{
+		jobContainerContext: model.ContainerContext{
+			ID:      "job-container-id",
+			Network: "act-test-network",
+		},
 		serviceContexts: map[string]model.ServiceContext{
 			"postgres": {
 				ID:      "postgres-container-id",
@@ -561,6 +591,8 @@ func TestCompositeRunContextInheritsServiceSnapshot(t *testing.T) {
 	}
 	child := &RunContext{Parent: parent, StepResults: map[string]*model.StepResult{}}
 	job := child.getJobContext()
+	require.Equal(t, "job-container-id", job.Container.ID)
+	require.Equal(t, "act-test-network", job.Container.Network)
 	require.Equal(t, "49153", job.Services["postgres"].Ports["5432"])
 	job.Services["postgres"].Ports["5432"] = "1"
 	require.Equal(t, "49153", parent.serviceContexts["postgres"].Ports["5432"])
@@ -568,6 +600,10 @@ func TestCompositeRunContextInheritsServiceSnapshot(t *testing.T) {
 
 func TestServicePortExpressionUsesNumericIndex(t *testing.T) {
 	rc := createRunContext(t)
+	rc.jobContainerContext = model.ContainerContext{
+		ID:      "job-container-id",
+		Network: "act-test-network",
+	}
 	rc.serviceContexts = map[string]model.ServiceContext{
 		"postgres": {
 			ID:      "postgres-container-id",
@@ -582,4 +618,6 @@ func TestServicePortExpressionUsesNumericIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "49153", got)
 	require.Equal(t, "127.0.0.1:49153", evaluator.Interpolate(ctx, "127.0.0.1:${{ job.services.postgres.ports[5432] }}"))
+	require.Equal(t, "job-container-id", evaluator.Interpolate(ctx, "${{ job.container.id }}"))
+	require.Equal(t, "act-test-network", evaluator.Interpolate(ctx, "${{ job.container.network }}"))
 }


### PR DESCRIPTION
## Summary

- publish `job.container.id` and the effective inspected container network after Docker option merging
- publish service container IDs, effective networks, and inspected host-port mappings, including dynamic ports
- support numeric expression indexing such as `job.services.postgres.ports[5432]`
- make delayed port inspection cancellation-aware and fail closed on invalid or ambiguous mappings
- preserve every partial-cleanup failure while still attempting all container cleanup operations

## Upstream coordination

This intentionally incorporates and supersedes #5927, with credit to @eakoli for identifying the missing `job.container.network` context. #5927 publishes the nominal act network; this implementation publishes Docker’s inspected post-options network for both job and service containers and also covers IDs, service ports, retries, cancellation, and cleanup. If maintainers prefer, I am happy to coordinate attribution or split the narrower network change into #5927 rather than duplicate it silently.

Related to #5885, #2126, and #2138. This PR deliberately does not auto-close an issue.

## Validation

- focused expression, container, model, and runner suites passed
- focused container and runner race suites passed
- `go vet ./...` passed
- `go build -tags WITHOUT_DOCKER ./...` passed
- causal mutants for effective network publication, numeric indexing, and multi-error cleanup were killed
- broad `go test ./...` is blocked here by the unavailable Docker socket; the same 17 Docker-dependent failures reproduce on pristine current master
- independent adversarial review: ACCEPT on exact head `4bccf2e46f7e69a045be257c63a91c44bcf3c41f`

No live container service or deployment was changed while recovering and validating this work.