### PR TITLE
Add --systemd flag for job containers that need real service management

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -31,6 +31,7 @@ type Input struct {
 	insecureSecrets                    bool
 	defaultBranch                      string
 	privileged                         bool
+	systemd                            bool
 	usernsMode                         string
 	containerArchitecture              string
 	containerDaemonSocket              string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,7 @@ func createRootCommand(ctx context.Context, input *Input, version string) *cobra
 	rootCmd.Flags().StringVarP(&input.eventPath, "eventpath", "e", "", "path to event JSON file")
 	rootCmd.Flags().StringVar(&input.defaultBranch, "defaultbranch", "", "the name of the main branch")
 	rootCmd.Flags().BoolVar(&input.privileged, "privileged", false, "use privileged mode")
+	rootCmd.Flags().BoolVar(&input.systemd, "systemd", false, "start job containers with systemd (/sbin/init) as PID 1 instead of `tail -f /dev/null`, for steps that use systemctl (implies --privileged and a host cgroup namespace/mount)")
 	rootCmd.Flags().StringVar(&input.usernsMode, "userns", "", "user namespace to use")
 	rootCmd.Flags().BoolVar(&input.useGitIgnore, "use-gitignore", true, "Controls whether paths specified in .gitignore should be copied into container")
 	rootCmd.Flags().StringArrayVarP(&input.containerCapAdd, "container-cap-add", "", []string{}, "kernel capabilities to add to the workflow containers (e.g. --container-cap-add SYS_PTRACE)")
@@ -626,6 +627,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			InsecureSecrets:                    input.insecureSecrets,
 			Platforms:                          input.newPlatforms(),
 			Privileged:                         input.privileged,
+			Systemd:                            input.systemd,
 			UsernsMode:                         input.usernsMode,
 			ContainerArchitecture:              input.containerArchitecture,
 			ContainerDaemonSocket:              input.containerDaemonSocket,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -390,9 +390,23 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			jobContainerNetwork = "host"
 		}
 
+		entrypoint := []string{"tail", "-f", "/dev/null"}
+		privileged := rc.Config.Privileged
+		options := rc.options(ctx)
+		if rc.Config.Systemd {
+			// systemd needs to run as PID 1, plus privileged mode and its own
+			// cgroup namespace/mount to manage services (e.g. via systemctl).
+			// /run is pre-mounted as tmpfs so systemd finds it already the
+			// right fs type and skips its own remount, which would otherwise
+			// shadow act's volume mount at /var/run/act (act's ActPath).
+			entrypoint = []string{"/sbin/init"}
+			privileged = true
+			options = strings.TrimSpace(options + " --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run")
+		}
+
 		rc.JobContainer = container.NewContainer(&container.NewContainerInput{
 			Cmd:            nil,
-			Entrypoint:     []string{"tail", "-f", "/dev/null"},
+			Entrypoint:     entrypoint,
 			WorkingDir:     ext.ToContainerPath(rc.Config.Workdir),
 			Image:          image,
 			Username:       username,
@@ -405,10 +419,10 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			Binds:          binds,
 			Stdout:         logWriter,
 			Stderr:         logWriter,
-			Privileged:     rc.Config.Privileged,
+			Privileged:     privileged,
 			UsernsMode:     rc.Config.UsernsMode,
 			Platform:       rc.Config.ContainerArchitecture,
-			Options:        rc.options(ctx),
+			Options:        options,
 		})
 		if rc.JobContainer == nil {
 			return errors.New("Failed to create job container")
@@ -422,6 +436,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.startServiceContainers(networkName),
 			rc.JobContainer.Create(rc.Config.ContainerCapAdd, rc.Config.ContainerCapDrop),
 			rc.JobContainer.Start(false),
+			rc.waitForSystemdBoot(),
 			rc.JobContainer.Copy(rc.JobContainer.GetActPath()+"/", &container.FileEntry{
 				Name: "workflow/event.json",
 				Mode: 0o644,
@@ -433,6 +448,33 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			}),
 			rc.waitForServiceContainers(),
 		)(ctx)
+	}
+}
+
+// waitForSystemdBoot blocks until systemd finishes its startup jobs. Without
+// this, files act copies into the container right after Start (e.g. step
+// scripts under /var/run/act) can be shadowed once systemd mounts its own
+// tmpfs over /run during boot.
+func (rc *RunContext) waitForSystemdBoot() common.Executor {
+	return func(ctx context.Context) error {
+		if !rc.Config.Systemd {
+			return nil
+		}
+		// Immediately after Start, systemd may not have created its private
+		// D-Bus socket yet, so the first is-system-running call can fail
+		// with "Failed to connect to bus" rather than actually waiting.
+		// Retry until it connects (empty stdout means it never connected);
+		// once connected, --wait blocks until a final state is reached, and
+		// "degraded" (e.g. no network-online.target) is an expected final
+		// state, not a reason to keep retrying or fail the job.
+		_ = rc.JobContainer.Exec([]string{"bash", "-c",
+			`for i in $(seq 1 60); do
+				state=$(systemctl is-system-running --wait 2>/dev/null)
+				[ -n "$state" ] && exit 0
+				sleep 0.5
+			done`,
+		}, map[string]string{}, "", "")(ctx)
+		return nil
 	}
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -42,6 +42,7 @@ type Config struct {
 	InsecureSecrets                    bool                         // switch hiding output when printing to terminal
 	Platforms                          map[string]string            // list of platforms
 	Privileged                         bool                         // use privileged mode
+	Systemd                            bool                         // start job containers with systemd (/sbin/init) as PID 1 instead of `tail -f /dev/null`; implies Privileged and a host cgroup namespace/mount
 	UsernsMode                         string                       // user namespace to use
 	ContainerArchitecture              string                       // Desired OS/architecture platform for running containers
 	ContainerDaemonSocket              string                       // Path to Docker daemon socket


### PR DESCRIPTION
Fixes #6166

Job containers normally start with `tail -f /dev/null` as PID 1, so steps that rely on `systemctl` (e.g. starting a preinstalled service like MySQL, replicating a GitHub-hosted-runner image) fail with "System has not been booted with systemd as init system." This has been reported before (#547, #548, #952, #1410) and closed stale without a fix.

`--systemd` starts the job container with `/sbin/init` instead:

- forces privileged mode (no need to also pass `--privileged`)
- adds a host cgroup namespace/mount (`--cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw`) so systemd can manage services
- pre-mounts `/run` as tmpfs so systemd's own boot-time remount doesn't shadow act's `/var/run/act` volume
- waits for systemd to finish booting (`systemctl is-system-running --wait`, tolerating the brief window before its D-Bus socket exists) before act copies step scripts into the container

Behavior is unchanged when `--systemd` is not passed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/... ./pkg/runner/...`
- [x] Manual run against [`wg-vn/github-actions-runner-image`](https://github.com/wg-vn/github-actions-runner-image) (`catthehacker/ubuntu:act-latest` base with `mysql-server` preinstalled): `act -j mysql --systemd -P ubuntu-latest=ghcr.io/wg-vn/github-actions-runner-image:act-latest-mysql` running a step with `systemctl start mysql && systemctl is-active mysql && mysqladmin ping` — systemd booted, `mysql` reported `active`, `mysqladmin ping` returned `mysqld is alive`, job succeeded.

