### PR TITLE
Warn when github.repository falls back to the nektos/act placeholder

### DIFF
--- a/pkg/model/github_context.go
+++ b/pkg/model/github_context.go
@@ -169,7 +169,7 @@ func (ghc *GithubContext) SetRepositoryAndOwner(ctx context.Context, githubInsta
 	if ghc.Repository == "" {
 		repo, err := git.FindGithubRepo(ctx, repoPath, githubInstance, remoteName)
 		if err != nil {
-			common.Logger(ctx).Debugf("unable to get git repo (githubInstance: %v; remoteName: %v, repoPath: %v): %v", githubInstance, remoteName, repoPath, err)
+			common.Logger(ctx).Warningf("unable to determine github.repository from git remote (githubInstance: %v; remoteName: %v, repoPath: %v): %v - falling back to placeholder 'nektos/act'; set GITHUB_REPOSITORY to override", githubInstance, remoteName, repoPath, err)
 			// nektos/act is used as a default action, so why not a repo?
 			ghc.Repository = "nektos/act"
 			ghc.RepositoryOwner = strings.Split(ghc.Repository, "/")[0]


### PR DESCRIPTION
## Summary
- `SetRepositoryAndOwner` silently falls back to the hardcoded `nektos/act` placeholder whenever it can't detect the repo from the local git remote, and only logged the failure at debug level.
- This makes the failure mode very confusing downstream: anything keyed on `github.repository` (image tags, GHCR pushes, etc.) breaks with an error that gives no hint the repo was never actually detected from git.
- Bumps the log to a warning and names both the placeholder value and the `GITHUB_REPOSITORY` override, so it's diagnosable without `--verbose`.

## Context
One common way to hit this: go-git's config parser rejects a `.git/config` `[branch "x"]` section whose `merge` value isn't under `refs/heads/*` (e.g. `merge = refs/pull/179/head`, which real git creates without complaint when checking out a PR ref into a local branch). That's tracked upstream in go-git/go-git#530 and was fixed in go-git/go-git#1872, but only on the unreleased v6 line — not backported to the v5.x series act depends on. Until that lands, this repo-detection failure is easy to hit silently, so surfacing it clearly here seems worth doing independently of the go-git fix.

## Test plan
- [x] `go build ./...`
- [x] Reproduced locally: a repo with a `[branch "x"] merge = refs/pull/N/head` entry now prints a `level=warning` line naming the fallback and `GITHUB_REPOSITORY`, instead of only showing up with `--verbose`.