### PR TITLE
feat: add per-platform container options

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -20,6 +20,7 @@ type Input struct {
 	envs                               []string
 	inputs                             []string
 	platforms                          []string
+	platformOptions                    []string
 	dryrun                             bool
 	forcePull                          bool
 	forceRebuild                       bool

--- a/cmd/platforms.go
+++ b/cmd/platforms.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"strings"
+
+	"github.com/nektos/act/pkg/runner"
 )
 
 func (i *Input) newPlatforms() map[string]string {
@@ -19,4 +21,21 @@ func (i *Input) newPlatforms() map[string]string {
 		}
 	}
 	return platforms
+}
+
+func (i *Input) newPlatformOptions() map[string]runner.PlatformOptions {
+	platformOptions := make(map[string]runner.PlatformOptions, len(i.platformOptions))
+	for _, option := range i.platformOptions {
+		optionParts := strings.SplitN(option, "=", 2)
+		if len(optionParts) == 2 {
+			platformName := optionParts[0]
+			appendOptions := strings.HasSuffix(platformName, "+")
+			platformName = strings.TrimSuffix(platformName, "+")
+			platformOptions[strings.ToLower(platformName)] = runner.PlatformOptions{
+				Options: optionParts[1],
+				Append:  appendOptions,
+			}
+		}
+	}
+	return platformOptions
 }

--- a/cmd/platforms_test.go
+++ b/cmd/platforms_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/nektos/act/pkg/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPlatformOptions(t *testing.T) {
+	t.Run("replace", func(t *testing.T) {
+		input := &Input{
+			platformOptions: []string{"big-cpu-runner=--cpus 16"},
+		}
+
+		assert.Equal(t, map[string]runner.PlatformOptions{
+			"big-cpu-runner": {
+				Options: "--cpus 16",
+			},
+		}, input.newPlatformOptions())
+	})
+
+	t.Run("append", func(t *testing.T) {
+		input := &Input{
+			platformOptions: []string{"gpu-runner+=--gpus all"},
+		}
+
+		assert.Equal(t, map[string]runner.PlatformOptions{
+			"gpu-runner": {
+				Options: "--gpus all",
+				Append:  true,
+			},
+		}, input.newPlatformOptions())
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ func createRootCommand(ctx context.Context, input *Input, version string) *cobra
 	rootCmd.Flags().StringArrayVarP(&input.envs, "env", "", []string{}, "env to make available to actions with optional value (e.g. --env myenv=foo or --env myenv)")
 	rootCmd.Flags().StringArrayVarP(&input.inputs, "input", "", []string{}, "action input to make available to actions (e.g. --input myinput=foo)")
 	rootCmd.Flags().StringArrayVarP(&input.platforms, "platform", "P", []string{}, "custom image to use per platform (e.g. -P ubuntu-18.04=nektos/act-environments-ubuntu:18.04)")
+	rootCmd.Flags().StringArrayVarP(&input.platformOptions, "platform-options", "", []string{}, "custom docker container options to use per platform (e.g. --platform-options big-cpu-runner='--cpus 16' to override or --platform-options gpu-runner+='--gpus all' to append)")
 	rootCmd.Flags().BoolVarP(&input.reuseContainers, "reuse", "r", false, "don't remove container(s) on successfully completed workflow(s) to maintain state between runs")
 	rootCmd.Flags().BoolVarP(&input.bindWorkdir, "bind", "b", false, "bind working directory to container, rather than copy")
 	rootCmd.Flags().BoolVarP(&input.forcePull, "pull", "p", true, "pull docker image(s) even if already present")
@@ -625,6 +626,7 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			Token:                              secrets["GITHUB_TOKEN"],
 			InsecureSecrets:                    input.insecureSecrets,
 			Platforms:                          input.newPlatforms(),
+			PlatformOptions:                    input.newPlatformOptions(),
 			Privileged:                         input.privileged,
 			UsernsMode:                         input.usernsMode,
 			ContainerArchitecture:              input.containerArchitecture,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -110,7 +110,13 @@ func TestReadArgsFile(t *testing.T) {
 		{
 			path:  path.Join("testdata", "split.actrc"),
 			split: true,
-			args:  []string{"--container-options", "--volume /foo:/bar --volume /baz:/qux --volume /tmp:/tmp"},
+			args: []string{
+				"--container-options", "--volume /foo:/bar --volume /baz:/qux --volume /tmp:/tmp",
+				"--platform", "big-cpu-runner=node:16-buster-slim",
+				"--platform", "gpu-runner=node:16-buster-slim",
+				"--platform-options", "big-cpu-runner=--cpus 16",
+				"--platform-options", "gpu-runner+=--gpus all",
+			},
 		},
 	}
 	for _, table := range tables {

--- a/cmd/testdata/split.actrc
+++ b/cmd/testdata/split.actrc
@@ -1,1 +1,5 @@
 --container-options --volume /foo:/bar --volume /baz:/qux --volume /tmp:/tmp
+--platform big-cpu-runner=node:16-buster-slim
+--platform gpu-runner=node:16-buster-slim
+--platform-options big-cpu-runner=--cpus 16
+--platform-options gpu-runner+=--gpus all

--- a/pkg/runner/action.go
+++ b/pkg/runner/action.go
@@ -433,7 +433,7 @@ func newStepContainer(ctx context.Context, step step, image string, cmd []string
 		Privileged:  rc.Config.Privileged,
 		UsernsMode:  rc.Config.UsernsMode,
 		Platform:    rc.Config.ContainerArchitecture,
-		Options:     rc.Config.ContainerOptions,
+		Options:     rc.containerOptions(ctx),
 	})
 	return stepContainer
 }

--- a/pkg/runner/platform_options_test.go
+++ b/pkg/runner/platform_options_test.go
@@ -1,0 +1,43 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nektos/act/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerOptions(t *testing.T) {
+	platformOptions := map[string]PlatformOptions{
+		"big-cpu-runner": {
+			Options: "--cpus 16",
+		},
+		"gpu-runner": {
+			Options: "--gpus all",
+			Append:  true,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		job      string
+		expected string
+	}{
+		{"platform replacement", `runs-on: [self-hosted, big-cpu-runner]`, "--cpus 16"},
+		{"platform append", `runs-on: [self-hosted, gpu-runner]`, "--cpus 4 --gpus all"},
+		{"global fallback", `runs-on: [self-hosted, cpu-runner]`, "--cpus 4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := createIfTestRunContext(map[string]*model.Job{
+				"job1": createJob(t, tt.job, ""),
+			})
+			rc.Config.ContainerOptions = "--cpus 4"
+			rc.Config.PlatformOptions = platformOptions
+
+			assert.Equal(t, tt.expected, rc.containerOptions(context.Background()))
+		})
+	}
+}

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -787,6 +787,22 @@ func (rc *RunContext) options(ctx context.Context) string {
 		return rc.ExprEval.Interpolate(ctx, c.Options)
 	}
 
+	return rc.containerOptions(ctx)
+}
+
+func (rc *RunContext) containerOptions(ctx context.Context) string {
+	for _, platformName := range rc.runsOnPlatformNames(ctx) {
+		if options, ok := rc.Config.PlatformOptions[strings.ToLower(platformName)]; ok {
+			if !options.Append || rc.Config.ContainerOptions == "" {
+				return options.Options
+			}
+			if options.Options == "" {
+				return rc.Config.ContainerOptions
+			}
+			return rc.Config.ContainerOptions + " " + options.Options
+		}
+	}
+
 	return rc.Config.ContainerOptions
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -18,6 +18,12 @@ type Runner interface {
 	NewPlanExecutor(plan *model.Plan) common.Executor
 }
 
+// PlatformOptions defines container options for a platform.
+type PlatformOptions struct {
+	Options string // docker container options
+	Append  bool   // append to the global container options instead of replacing them
+}
+
 // Config contains the config for a new runner
 type Config struct {
 	Actor                              string                       // the user that triggered the event
@@ -41,6 +47,7 @@ type Config struct {
 	Token                              string                       // GitHub token
 	InsecureSecrets                    bool                         // switch hiding output when printing to terminal
 	Platforms                          map[string]string            // list of platforms
+	PlatformOptions                    map[string]PlatformOptions   // container options per platform
 	Privileged                         bool                         // use privileged mode
 	UsernsMode                         string                       // user namespace to use
 	ContainerArchitecture              string                       // Desired OS/architecture platform for running containers


### PR DESCRIPTION
Add the --platform-options cli option to support mixed runner types.

* Keep `--container-options` as the global default options for platform containers.
* Override global defaults with `--platform-options platform-name='options'`
* Append global defaults with `--platform-options platform-name+='options'`

Given the options:
```sh
--container-options '--cpus 4'
--platform-options big-cpu-runner='--cpus 16'
--platform-options gpu-runner+='--gpus all'
```
* `big-cpu-runner` will run with `--cpus 16`
* `gpu-runner` will run with `--cpus 4 --gpus all`
* all other platform runners will default to running with `--cpus 4`

Fixes #6171
