### PR TITLE
fix: coerce a string to a number by parsing it, not by evaluating it as an expression

### DIFF
--- a/pkg/exprparser/interpreter.go
+++ b/pkg/exprparser/interpreter.go
@@ -2,9 +2,11 @@ package exprparser
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/nektos/act/pkg/model"
@@ -435,22 +437,123 @@ func (impl *interperterImpl) coerceToNumber(value reflect.Value) reflect.Value {
 		}
 
 	case reflect.String:
-		if value.String() == "" {
-			return reflect.ValueOf(0)
-		}
-
-		// try to parse the string as a number
-		evaluated, err := impl.Evaluate(value.String(), DefaultStatusCheckNone)
-		if err != nil {
-			return reflect.ValueOf(math.NaN())
-		}
-
-		if value := reflect.ValueOf(evaluated); impl.isNumber(value) {
-			return value
-		}
+		return reflect.ValueOf(parseNumber(value.String()))
 	}
 
 	return reflect.ValueOf(math.NaN())
+}
+
+// parseNumber converts a string to a number the way the GitHub Actions runner
+// does. See ExpressionUtility.ParseNumber in actions/runner, which documents its
+// intent as "follow Javascript rules for coercing a string into a number for
+// comparison. That is, the Number() function in Javascript.":
+//
+//	trim, then "" -> 0, a decimal literal, 0x<hex>, 0o<octal>, "Infinity",
+//	"-Infinity", and anything else -> NaN.
+func parseNumber(str string) float64 {
+	str = strings.TrimSpace(str)
+
+	switch {
+	case str == "":
+		return 0
+
+	case isDecimalLiteral(str):
+		// ParseFloat also accepts forms the runner does not ("inf", "nan",
+		// hexadecimal floats), which is why the input is validated first.
+		// A value too large for float64 overflows to ±Inf, as it does in
+		// JavaScript, so ErrRange is not a failure here.
+		f, err := strconv.ParseFloat(str, 64)
+		if err == nil || errors.Is(err, strconv.ErrRange) {
+			return f
+		}
+
+	case hasRadixPrefix(str, 'x') && isDigitsOfBase(str[2:], 16):
+		// The runner parses these into an Int32, so out-of-range is NaN.
+		if i, err := strconv.ParseInt(str[2:], 16, 32); err == nil {
+			return float64(i)
+		}
+
+	case hasRadixPrefix(str, 'o') && isDigitsOfBase(str[2:], 8):
+		if i, err := strconv.ParseInt(str[2:], 8, 32); err == nil {
+			return float64(i)
+		}
+
+	case str == "Infinity":
+		return math.Inf(1)
+
+	case str == "-Infinity":
+		return math.Inf(-1)
+	}
+
+	return math.NaN()
+}
+
+// isDecimalLiteral reports whether str is [+-]?(digits[.digits?]|.digits)([eE][+-]?digits)?,
+// the set of decimal forms the runner accepts (a leading sign, a decimal point
+// and an exponent).
+func isDecimalLiteral(str string) bool {
+	i := 0
+	if i < len(str) && (str[i] == '+' || str[i] == '-') {
+		i++
+	}
+
+	mantissa := 0
+	for ; i < len(str) && isASCIIDigit(str[i]); i++ {
+		mantissa++
+	}
+	if i < len(str) && str[i] == '.' {
+		for i++; i < len(str) && isASCIIDigit(str[i]); i++ {
+			mantissa++
+		}
+	}
+	if mantissa == 0 {
+		return false
+	}
+
+	if i < len(str) && (str[i] == 'e' || str[i] == 'E') {
+		i++
+		if i < len(str) && (str[i] == '+' || str[i] == '-') {
+			i++
+		}
+		exponent := 0
+		for ; i < len(str) && isASCIIDigit(str[i]); i++ {
+			exponent++
+		}
+		if exponent == 0 {
+			return false
+		}
+	}
+
+	return i == len(str)
+}
+
+// hasRadixPrefix reports whether str starts with a "0" followed by the given
+// lower-case radix letter and at least one more character. The runner matches
+// the letter case-sensitively, so "0X11" is not a hexadecimal literal.
+func hasRadixPrefix(str string, radix byte) bool {
+	return len(str) > 2 && str[0] == '0' && str[1] == radix
+}
+
+// isDigitsOfBase reports whether every character of str is a digit of the given
+// base. strconv would additionally accept a sign and underscores.
+func isDigitsOfBase(str string, base int) bool {
+	for i := 0; i < len(str); i++ {
+		if strings.IndexByte("0123456789abcdef"[:base], lowerASCII(str[i])) < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func lowerASCII(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + ('a' - 'A')
+	}
+	return c
 }
 
 func (impl *interperterImpl) coerceToString(value reflect.Value) reflect.Value {

--- a/pkg/exprparser/interpreter_test.go
+++ b/pkg/exprparser/interpreter_test.go
@@ -141,6 +141,11 @@ func TestOperatorsCompare(t *testing.T) {
 		{`fromJSON('{}') < 2 }}`, false, "object-with-less"},
 		{`fromJSON('{}') < fromJSON('[]') }}`, false, "object/arr-with-lt"},
 		{`fromJSON('{}') > fromJSON('[]') }}`, false, "object/arr-with-gt"},
+		{`' ' == 0 }}`, true, "string-whitespace-coercion"},
+		{`'007' == 7 }}`, true, "string-leading-zeros-coercion"},
+		{`'+3' == 3 }}`, true, "string-leading-sign-coercion"},
+		{`'3000000000' > 1 }}`, true, "string-above-int32-coercion"},
+		{`'0 || 5' == 5 }}`, false, "string-is-not-an-expression"},
 	}
 
 	env := &EvaluationEnvironment{
@@ -155,6 +160,66 @@ func TestOperatorsCompare(t *testing.T) {
 			assert.Nil(t, err)
 
 			assert.Equal(t, tt.expected, output)
+		})
+	}
+}
+
+func TestParseNumber(t *testing.T) {
+	table := []struct {
+		input    string
+		expected float64
+		name     string
+	}{
+		{"", 0, "empty"},
+		{"   ", 0, "whitespace-only"},
+		{"\t\n", 0, "whitespace-only-control"},
+		{"  1  ", 1, "surrounding-whitespace"},
+		{"0", 0, "zero"},
+		{"-1", -1, "negative"},
+		{"+1", 1, "leading-plus"},
+		{".5", 0.5, "leading-decimal-point"},
+		{"1.", 1, "trailing-decimal-point"},
+		{"007", 7, "leading-zeros"},
+		{"1e3", 1000, "exponent"},
+		{"1e+3", 1000, "exponent-signed"},
+		{"3000000000", 3000000000, "above-int32"},
+		{"0x11", 17, "hexadecimal"},
+		{"0o17", 15, "octal"},
+		{"Infinity", math.Inf(1), "infinity"},
+		{"-Infinity", math.Inf(-1), "negative-infinity"},
+
+		// The runner matches the radix prefix case-sensitively and knows no
+		// binary literal.
+		{"0X11", math.NaN(), "uppercase-hexadecimal"},
+		{"0b11", math.NaN(), "binary"},
+		{"-0x10", math.NaN(), "signed-hexadecimal"},
+		{"0xfffffffff", math.NaN(), "hexadecimal-above-int32"},
+
+		// Forms strconv.ParseFloat would accept but the runner does not.
+		{"inf", math.NaN(), "go-infinity-spelling"},
+		{"infinity", math.NaN(), "go-infinity-spelling-long"},
+		{"0x1p-2", math.NaN(), "hexadecimal-float"},
+
+		{"1,000", math.NaN(), "thousands-separator"},
+		{"1.2.3", math.NaN(), "two-decimal-points"},
+		{"1e", math.NaN(), "empty-exponent"},
+		{"abc", math.NaN(), "word"},
+		{"true", math.NaN(), "boolean-spelling"},
+
+		// A string is a number or it is NaN; it is never an expression to run.
+		{"(1)", math.NaN(), "parenthesised-expression"},
+		{"0 || 5", math.NaN(), "logical-expression"},
+		{"fromJSON('3')", math.NaN(), "function-call"},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := parseNumber(tt.input)
+			if math.IsNaN(tt.expected) {
+				assert.True(t, math.IsNaN(actual), "expected NaN, got %v", actual)
+				return
+			}
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
`coerceToNumber` handled a string by calling `Evaluate()` on the string's own contents, so a string was only recognised as a number when it also happened to be a valid expression that produced one. Two consequences, both silent inside an `if:`:

* Values the runner coerces fine came back `NaN` — `" "`, `"+1"`, `".5"`, `"007"`, `"1e+3"`, `"-Infinity"`, and **anything above int32**, so `${{ '1700000000000' > 0 }}` was `false`. `env.*` and `inputs.*` are always strings, so that is the ordinary path into this function.
* Strings that happen to be expressions were run: `${{ '0 || 5' == 5 }}` was `true`.

`parseNumber` now follows [`ExpressionUtility.ParseNumber`](https://github.com/actions/runner/blob/main/src/Sdk/DTExpressions2/Expressions2/Sdk/ExpressionUtility.cs) in `actions/runner`, whose own doc comment states the intent: *"The rules here attempt to follow Javascript rules for coercing a string into a number for comparison. That is, the Number() function in Javascript."* — trim, `""` → 0, a decimal literal, `0x<hex>`, `0o<octal>`, `Infinity`, `-Infinity`, otherwise NaN.

Two things a reviewer cannot get from the diff:

* **The naive version does not work.** `strconv.ParseFloat` alone passes most of the table but loses `'0x11'` and `'0o17'`, which act handles today, and picks up Go's own spellings `inf` / `infinity` and hex floats like `0x1p-2`. The test pins all five.
* **Residual, deliberately kept:** the runner parses hex and octal into an `Int32`, so `'0xffffffff'` is out of range there and stays NaN here. I did not try to reproduce .NET's `AllowHexSpecifier` two's-complement result for that case. There is a test row for it.

Checked against `@actions/expressions` 0.3.61 (GitHub's own implementation, from `actions/languageservices`) over 17,524 generated expressions: 1,412 divergences before, 840 after. 703 of the 840 are the parser refusing an uppercase `0X` *literal*, which is a lexer difference in `actionlint` rather than this function — and the runner also rejects an uppercase `0X` inside a *string*, which this patch matches.

Ran: `go test ./pkg/exprparser/... ./pkg/model/... ./pkg/workflowpattern/... ./pkg/common/... ./pkg/filecollector/... ./pkg/schema/...` and `golangci-lint run ./pkg/exprparser/...` (v2.6.2), all clean. No Docker on this machine, so `pkg/runner` and `pkg/container` were not exercised.

Written with Claude Code (Claude Opus 5, `claude-opus-5`); the oracle comparison and every command above were run before opening this.
