### PR TITLE
feat(runner): inject an optional docker-in-docker service container

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -35,6 +35,8 @@ type Input struct {
 	containerArchitecture              string
 	containerDaemonSocket              string
 	containerOptions                   string
+	dockerDaemonService                bool
+	dockerDaemonServiceImage           string
 	noWorkflowRecurse                  bool
 	useGitIgnore                       bool
 	githubInstance                     string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,6 +113,8 @@ func createRootCommand(ctx context.Context, input *Input, version string) *cobra
 	rootCmd.PersistentFlags().StringVarP(&input.containerArchitecture, "container-architecture", "", "", "Architecture which should be used to run containers, e.g.: linux/amd64. If not specified, will use host default architecture. Requires Docker server API Version 1.41+. Ignored on earlier Docker server platforms.")
 	rootCmd.PersistentFlags().StringVarP(&input.containerDaemonSocket, "container-daemon-socket", "", "", "URI to Docker Engine socket (e.g.: unix://~/.docker/run/docker.sock or - to disable bind mounting the socket)")
 	rootCmd.PersistentFlags().StringVarP(&input.containerOptions, "container-options", "", "", "Custom docker container options for the job container without an options property in the job definition")
+	rootCmd.PersistentFlags().BoolVarP(&input.dockerDaemonService, "docker-daemon-service", "", false, "Start a Docker-in-Docker service container (network alias 'docker') alongside the job container so builds have a Docker daemon without mounting the host socket. Sets DOCKER_HOST/DOCKER_TLS_VERIFY/DOCKER_CERT_PATH in the job container and disables the host socket bind.")
+	rootCmd.PersistentFlags().StringVarP(&input.dockerDaemonServiceImage, "docker-daemon-service-image", "", "docker:dind", "Image to use for the docker-in-docker service container.")
 	rootCmd.PersistentFlags().StringVarP(&input.githubInstance, "github-instance", "", "github.com", "GitHub instance to use. Only use this when using GitHub Enterprise Server.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerPath, "artifact-server-path", "", "", "Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified the artifact server will not start.")
 	rootCmd.PersistentFlags().StringVarP(&input.artifactServerAddr, "artifact-server-addr", "", common.GetOutboundIP().String(), "Defines the address to which the artifact server binds.")
@@ -406,6 +408,10 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			return listOptions(cmd)
 		}
 
+		if err := validateDockerDaemonServiceFlags(input, cmd.Flag("container-daemon-socket").Changed); err != nil {
+			return err
+		}
+
 		if ret, err := container.GetSocketAndHost(input.containerDaemonSocket); err != nil {
 			log.Warnf("Couldn't get a valid docker connection: %+v", err)
 		} else {
@@ -630,6 +636,8 @@ func newRunCommand(ctx context.Context, input *Input) func(*cobra.Command, []str
 			ContainerArchitecture:              input.containerArchitecture,
 			ContainerDaemonSocket:              input.containerDaemonSocket,
 			ContainerOptions:                   input.containerOptions,
+			DockerDaemonService:                input.dockerDaemonService,
+			DockerDaemonServiceImage:           input.dockerDaemonServiceImage,
 			UseGitIgnore:                       input.useGitIgnore,
 			GitHubInstance:                     input.githubInstance,
 			ContainerCapAdd:                    input.containerCapAdd,
@@ -802,5 +810,41 @@ func watchAndRun(ctx context.Context, fn common.Executor) error {
 		}
 	}
 
+	return nil
+}
+
+// validateDockerDaemonServiceFlags enforces the exclusivity between
+// --docker-daemon-service and --container-daemon-socket. When the dind
+// service is on, the host socket must not be bind-mounted, since the
+// injected dockerd shares its own unix socket via a per-job named volume.
+//
+// socketFlagChanged reports whether --container-daemon-socket was
+// explicitly set on the command line (Cobra's flag.Changed). We treat the
+// two cases differently so the common invocation stays terse:
+//
+//	--docker-daemon-service alone
+//	    auto-forces containerDaemonSocket to "-" (suppress the default
+//	    host-socket bind). Convenient default.
+//
+//	--docker-daemon-service --container-daemon-socket=-
+//	    explicit form, accepted as-is.
+//
+//	--docker-daemon-service --container-daemon-socket=<anything-else>
+//	    hard error: the user asked for two incompatible things, quoting
+//	    the offending value so the mistake is obvious.
+//
+// The check has no effect when --docker-daemon-service is off.
+func validateDockerDaemonServiceFlags(input *Input, socketFlagChanged bool) error {
+	if !input.dockerDaemonService {
+		return nil
+	}
+	if socketFlagChanged {
+		if input.containerDaemonSocket != "-" {
+			return fmt.Errorf("--docker-daemon-service is incompatible with --container-daemon-socket=%q; the injected dind service shares its socket via a named volume, so the host socket must not be bound (pass --container-daemon-socket=- or omit it)", input.containerDaemonSocket)
+		}
+		return nil
+	}
+	// Not explicitly set: suppress the default host-socket bind.
+	input.containerDaemonSocket = "-"
 	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -83,6 +83,115 @@ func TestFlags(t *testing.T) {
 	}
 }
 
+func TestValidateDockerDaemonServiceFlags(t *testing.T) {
+	cases := []struct {
+		name              string
+		dockerDaemon      bool
+		socketIn          string
+		socketFlagChanged bool
+		wantErr           bool
+		wantErrContains   string
+		wantSocketOut     string
+	}{
+		{
+			// dind off, socket untouched: no-op.
+			name:          "dind off / socket unset -> passthrough",
+			wantSocketOut: "",
+		},
+		{
+			// dind off, user picked a socket: leave it alone, no error.
+			name:              "dind off / socket set to path -> passthrough",
+			socketIn:          "unix:///var/run/docker.sock",
+			socketFlagChanged: true,
+			wantSocketOut:     "unix:///var/run/docker.sock",
+		},
+		{
+			// dind off, user disabled the bind: leave it alone.
+			name:              "dind off / socket set to '-' -> passthrough",
+			socketIn:          "-",
+			socketFlagChanged: true,
+			wantSocketOut:     "-",
+		},
+		{
+			// Common convenience case: --docker-daemon-service alone
+			// auto-forces the socket to "-" so no host bind is added.
+			name:          "dind on / socket unset -> auto '-'",
+			dockerDaemon:  true,
+			wantSocketOut: "-",
+		},
+		{
+			// dind on, socket left at default "" but explicitly by the
+			// user (shell-quoting mishap, --container-daemon-socket=).
+			// Empty is not "-", so this is a conflict.
+			name:              "dind on / socket explicitly empty -> error",
+			dockerDaemon:      true,
+			socketIn:          "",
+			socketFlagChanged: true,
+			wantErr:           true,
+			wantErrContains:   `--container-daemon-socket=""`,
+			wantSocketOut:     "",
+		},
+		{
+			// dind on, explicit "-": accepted, no rewrite.
+			name:              "dind on / socket explicitly '-' -> accepted",
+			dockerDaemon:      true,
+			socketIn:          "-",
+			socketFlagChanged: true,
+			wantSocketOut:     "-",
+		},
+		{
+			// dind on with a URI: hard error, value quoted in message.
+			name:              "dind on / socket set to unix URI -> error",
+			dockerDaemon:      true,
+			socketIn:          "unix:///var/run/docker.sock",
+			socketFlagChanged: true,
+			wantErr:           true,
+			wantErrContains:   `--container-daemon-socket="unix:///var/run/docker.sock"`,
+			wantSocketOut:     "unix:///var/run/docker.sock",
+		},
+		{
+			// dind on with tcp URI: same hard error.
+			name:              "dind on / socket set to tcp URI -> error",
+			dockerDaemon:      true,
+			socketIn:          "tcp://127.0.0.1:2375",
+			socketFlagChanged: true,
+			wantErr:           true,
+			wantErrContains:   `--container-daemon-socket="tcp://127.0.0.1:2375"`,
+			wantSocketOut:     "tcp://127.0.0.1:2375",
+		},
+		{
+			// dind on with a bare filesystem path: same hard error.
+			name:              "dind on / socket set to bare path -> error",
+			dockerDaemon:      true,
+			socketIn:          "/var/run/docker.sock",
+			socketFlagChanged: true,
+			wantErr:           true,
+			wantErrContains:   `--container-daemon-socket="/var/run/docker.sock"`,
+			wantSocketOut:     "/var/run/docker.sock",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := &Input{
+				dockerDaemonService:   tc.dockerDaemon,
+				containerDaemonSocket: tc.socketIn,
+			}
+			err := validateDockerDaemonServiceFlags(in, tc.socketFlagChanged)
+			if tc.wantErr {
+				assert.Error(t, err)
+				if tc.wantErrContains != "" && err != nil {
+					assert.Contains(t, err.Error(), tc.wantErrContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantSocketOut, in.containerDaemonSocket,
+				"containerDaemonSocket after validation")
+		})
+	}
+}
+
 func TestReadArgsFile(t *testing.T) {
 	tables := []struct {
 		path  string

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -361,7 +361,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 
 		if rc.useDockerDaemonService() {
 			rc.ServiceContainers = append(rc.ServiceContainers,
-				rc.buildDockerDaemonServiceContainer(logWriter, networkName))
+				rc.buildDockerDaemonServiceContainer(logWriter, networkName, binds, mounts))
 		}
 
 		rc.cleanUpJobContainer = func(ctx context.Context) error {
@@ -370,30 +370,38 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			}
 
 			if rc.JobContainer != nil {
+				stopServicesAndNetwork := func(ctx context.Context) error {
+					if len(rc.ServiceContainers) > 0 {
+						logger.Infof("Cleaning up services for job %s", rc.JobName)
+						if err := rc.stopServiceContainers()(ctx); err != nil {
+							logger.Errorf("Error while cleaning services: %v", err)
+						}
+						if createAndDeleteNetwork {
+							// clean network if it has been created by act
+							// if using service containers
+							// it means that the network to which containers are connecting is created by `act_runner`,
+							// so, we should remove the network at last.
+							logger.Infof("Cleaning up network for job %s, and network name is: %s", rc.JobName, networkName)
+							if err := container.NewDockerNetworkRemoveExecutor(networkName)(ctx); err != nil {
+								logger.Errorf("Error while cleaning network: %v", err)
+							}
+						}
+					}
+					return nil
+				}
+
+				// Stop the job container and every service container BEFORE
+				// removing any named volumes. The injected dind service (and
+				// any user-declared service) mirrors the job's binds/mounts,
+				// so it still holds references to those volumes until it is
+				// stopped; removing them earlier fails with "volume is in
+				// use".
 				return rc.JobContainer.Remove().IfNot(reuseJobContainer).
+					Then(stopServicesAndNetwork).IfNot(reuseJobContainer).
 					Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName(), false)).IfNot(reuseJobContainer).
 					Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName()+"-env", false)).IfNot(reuseJobContainer).
 					Then(container.NewDockerVolumeRemoveExecutor(rc.dockerDaemonServiceSocketVolume(), false)).
-					IfBool(rc.useDockerDaemonService()).IfNot(reuseJobContainer).
-					Then(func(ctx context.Context) error {
-						if len(rc.ServiceContainers) > 0 {
-							logger.Infof("Cleaning up services for job %s", rc.JobName)
-							if err := rc.stopServiceContainers()(ctx); err != nil {
-								logger.Errorf("Error while cleaning services: %v", err)
-							}
-							if createAndDeleteNetwork {
-								// clean network if it has been created by act
-								// if using service containers
-								// it means that the network to which containers are connecting is created by `act_runner`,
-								// so, we should remove the network at last.
-								logger.Infof("Cleaning up network for job %s, and network name is: %s", rc.JobName, networkName)
-								if err := container.NewDockerNetworkRemoveExecutor(networkName)(ctx); err != nil {
-									logger.Errorf("Error while cleaning network: %v", err)
-								}
-							}
-						}
-						return nil
-					})(ctx)
+					IfBool(rc.useDockerDaemonService()).IfNot(reuseJobContainer)(ctx)
 			}
 			return nil
 		}
@@ -1247,7 +1255,15 @@ func (rc *RunContext) dockerDaemonServiceImage() string {
 // container mounts the same volume and reaches the daemon via that socket
 // (plus a /var/run/docker.sock symlink dropped after start). TLS is
 // disabled because the socket never leaves the shared volume.
-func (rc *RunContext) buildDockerDaemonServiceContainer(logWriter io.Writer, networkName string) container.ExecutionsEnvironment {
+//
+// The job container's binds and mounts are mirrored onto the dind container
+// so paths resolve identically on both sides. GitHub-hosted runners share a
+// single filesystem between dockerd and the job; workflows rely on that when
+// they run `docker run -v $GITHUB_WORKSPACE:/x`, when testcontainers passes
+// host paths through the daemon, or when actions bind-mount /opt/hosted
+// toolcache into helper containers. Without mirroring, dockerd would reject
+// those paths as "no such file or directory".
+func (rc *RunContext) buildDockerDaemonServiceContainer(logWriter io.Writer, networkName string, jobBinds []string, jobMounts map[string]string) container.ExecutionsEnvironment {
 	name := createContainerName(rc.jobContainerName(), dockerDaemonServiceAlias)
 	sockPath := dockerDaemonServiceSocketDir + "/docker.sock"
 	// docker:dind's default entrypoint enables TLS when DOCKER_TLS_CERTDIR
@@ -1257,14 +1273,21 @@ func (rc *RunContext) buildDockerDaemonServiceContainer(logWriter io.Writer, net
 		"DOCKER_TLS_CERTDIR=",
 		"DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS=",
 	}
-	mounts := map[string]string{
-		rc.dockerDaemonServiceSocketVolume(): dockerDaemonServiceSocketDir,
+	// Shallow-copy the job's binds/mounts so callers keep ownership of the
+	// originals. jobMounts already contains the shared socket volume entry
+	// (added by GetBindsAndMounts when the dind service is enabled), so
+	// dind sees the same /var/run/act-dind path it writes docker.sock into.
+	binds := append([]string(nil), jobBinds...)
+	mounts := make(map[string]string, len(jobMounts))
+	for k, v := range jobMounts {
+		mounts[k] = v
 	}
 	return container.NewContainer(&container.NewContainerInput{
 		Name:           name,
 		Image:          rc.dockerDaemonServiceImage(),
 		Cmd:            []string{"dockerd", "--host=unix://" + sockPath},
 		Env:            env,
+		Binds:          binds,
 		Mounts:         mounts,
 		Stdout:         logWriter,
 		Stderr:         logWriter,

--- a/pkg/runner/run_context.go
+++ b/pkg/runner/run_context.go
@@ -132,7 +132,7 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 	}
 
 	binds := []string{}
-	if rc.Config.ContainerDaemonSocket != "-" {
+	if rc.Config.ContainerDaemonSocket != "-" && !rc.useDockerDaemonService() {
 		daemonPath := getDockerDaemonSocketMountPath(rc.Config.ContainerDaemonSocket)
 		binds = append(binds, fmt.Sprintf("%s:%s", daemonPath, "/var/run/docker.sock"))
 	}
@@ -178,6 +178,14 @@ func (rc *RunContext) GetBindsAndMounts() ([]string, map[string]string) {
 		binds = append(binds, fmt.Sprintf("%s:%s%s", rc.Config.Workdir, ext.ToContainerPath(rc.Config.Workdir), bindModifiers))
 	} else {
 		mounts[name] = ext.ToContainerPath(rc.Config.Workdir)
+	}
+
+	if rc.useDockerDaemonService() {
+		// Share the injected dind's unix socket with the job container via
+		// a per-job named volume. A post-start step drops a
+		// /var/run/docker.sock symlink so workflows that hardcode the
+		// GitHub-hosted path keep working.
+		mounts[rc.dockerDaemonServiceSocketVolume()] = dockerDaemonServiceSocketDir
 	}
 
 	return binds, mounts
@@ -351,6 +359,11 @@ func (rc *RunContext) startJobContainer() common.Executor {
 			rc.ServiceContainers = append(rc.ServiceContainers, c)
 		}
 
+		if rc.useDockerDaemonService() {
+			rc.ServiceContainers = append(rc.ServiceContainers,
+				rc.buildDockerDaemonServiceContainer(logWriter, networkName))
+		}
+
 		rc.cleanUpJobContainer = func(ctx context.Context) error {
 			reuseJobContainer := func(_ context.Context) bool {
 				return rc.Config.ReuseContainers
@@ -360,6 +373,8 @@ func (rc *RunContext) startJobContainer() common.Executor {
 				return rc.JobContainer.Remove().IfNot(reuseJobContainer).
 					Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName(), false)).IfNot(reuseJobContainer).
 					Then(container.NewDockerVolumeRemoveExecutor(rc.jobContainerName()+"-env", false)).IfNot(reuseJobContainer).
+					Then(container.NewDockerVolumeRemoveExecutor(rc.dockerDaemonServiceSocketVolume(), false)).
+					IfBool(rc.useDockerDaemonService()).IfNot(reuseJobContainer).
 					Then(func(ctx context.Context) error {
 						if len(rc.ServiceContainers) > 0 {
 							logger.Infof("Cleaning up services for job %s", rc.JobName)
@@ -432,6 +447,7 @@ func (rc *RunContext) startJobContainer() common.Executor {
 				Body: "",
 			}),
 			rc.waitForServiceContainers(),
+			rc.linkDockerDaemonServiceSocket().IfBool(rc.useDockerDaemonService()),
 		)(ctx)
 	}
 }
@@ -1155,7 +1171,7 @@ func (rc *RunContext) GetServiceBindsAndMounts(svcVolumes []string) ([]string, m
 		rc.Config.ContainerDaemonSocket = "/var/run/docker.sock"
 	}
 	binds := []string{}
-	if rc.Config.ContainerDaemonSocket != "-" {
+	if rc.Config.ContainerDaemonSocket != "-" && !rc.useDockerDaemonService() {
 		daemonPath := getDockerDaemonSocketMountPath(rc.Config.ContainerDaemonSocket)
 		binds = append(binds, fmt.Sprintf("%s:%s", daemonPath, "/var/run/docker.sock"))
 	}
@@ -1174,4 +1190,122 @@ func (rc *RunContext) GetServiceBindsAndMounts(svcVolumes []string) ([]string, m
 	}
 
 	return binds, mounts
+}
+
+// dockerDaemonServiceAlias is the network alias/service name used for the
+// injected docker-in-docker service container. It is not resolvable from the
+// job container (the socket-sharing model doesn't need DNS); it just gives
+// the container a stable, discoverable name in `docker ps` output.
+const dockerDaemonServiceAlias = "docker"
+
+// dockerDaemonServiceSocketDir is the in-container mount point of the shared
+// named volume that holds the dind unix socket. Same path in both the dind
+// service container (dockerd writes docker.sock here) and the job container
+// (which sees docker.sock and gets a /var/run/docker.sock symlink pointing
+// at it).
+const dockerDaemonServiceSocketDir = "/var/run/act-dind"
+
+// useDockerDaemonService reports whether the runner should attach an
+// injected docker-in-docker service container to this job. Skipped if the
+// workflow already declares a service with the reserved alias so the
+// user-defined service wins.
+func (rc *RunContext) useDockerDaemonService() bool {
+	if rc == nil || rc.Config == nil || !rc.Config.DockerDaemonService {
+		return false
+	}
+	if rc.Run == nil {
+		return false
+	}
+	job := rc.Run.Job()
+	if job == nil {
+		return false
+	}
+	if _, exists := job.Services[dockerDaemonServiceAlias]; exists {
+		return false
+	}
+	return true
+}
+
+// dockerDaemonServiceSocketVolume returns the per-job named volume that
+// shuttles the dind unix socket to the job container. Scoped per job so
+// parallel jobs never collide.
+func (rc *RunContext) dockerDaemonServiceSocketVolume() string {
+	return rc.jobContainerName() + "-dind-sock"
+}
+
+// dockerDaemonServiceImage returns the image for the injected dind service
+// container, defaulting to docker:dind when unset.
+func (rc *RunContext) dockerDaemonServiceImage() string {
+	if img := rc.Config.DockerDaemonServiceImage; img != "" {
+		return img
+	}
+	return "docker:dind"
+}
+
+// buildDockerDaemonServiceContainer constructs the dind service container.
+// dockerd listens on a unix socket inside a shared named volume; the job
+// container mounts the same volume and reaches the daemon via that socket
+// (plus a /var/run/docker.sock symlink dropped after start). TLS is
+// disabled because the socket never leaves the shared volume.
+func (rc *RunContext) buildDockerDaemonServiceContainer(logWriter io.Writer, networkName string) container.ExecutionsEnvironment {
+	name := createContainerName(rc.jobContainerName(), dockerDaemonServiceAlias)
+	sockPath := dockerDaemonServiceSocketDir + "/docker.sock"
+	// docker:dind's default entrypoint enables TLS when DOCKER_TLS_CERTDIR
+	// is non-empty. Blank it out so we get a plain unix socket, and tell
+	// dockerd where to put it.
+	env := []string{
+		"DOCKER_TLS_CERTDIR=",
+		"DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS=",
+	}
+	mounts := map[string]string{
+		rc.dockerDaemonServiceSocketVolume(): dockerDaemonServiceSocketDir,
+	}
+	return container.NewContainer(&container.NewContainerInput{
+		Name:           name,
+		Image:          rc.dockerDaemonServiceImage(),
+		Cmd:            []string{"dockerd", "--host=unix://" + sockPath},
+		Env:            env,
+		Mounts:         mounts,
+		Stdout:         logWriter,
+		Stderr:         logWriter,
+		Privileged:     true, // dockerd requires privileged
+		UsernsMode:     rc.Config.UsernsMode,
+		Platform:       rc.Config.ContainerArchitecture,
+		NetworkMode:    networkName,
+		NetworkAliases: []string{dockerDaemonServiceAlias},
+	})
+}
+
+// linkDockerDaemonServiceSocket waits for dockerd to create its socket in
+// the shared volume, then drops a /var/run/docker.sock symlink inside the
+// job container so workflows that hardcode the GitHub-hosted path keep
+// working without a DOCKER_HOST env var.
+func (rc *RunContext) linkDockerDaemonServiceSocket() common.Executor {
+	return func(ctx context.Context) error {
+		sockPath := dockerDaemonServiceSocketDir + "/docker.sock"
+		logger := common.Logger(ctx)
+		// Poll for the socket to appear. dind's entrypoint creates it soon
+		// after startup but we don't have a healthcheck any more, so bound
+		// the wait ourselves.
+		wctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer cancel()
+		delay := 200 * time.Millisecond
+		waitCmd := []string{"sh", "-c", fmt.Sprintf("test -S %s", sockPath)}
+		for {
+			if err := rc.JobContainer.Exec(waitCmd, nil, "root", "/")(wctx); err == nil {
+				break
+			}
+			select {
+			case <-wctx.Done():
+				return fmt.Errorf("timed out waiting for docker daemon socket at %s", sockPath)
+			case <-time.After(delay):
+			}
+			if delay < 2*time.Second {
+				delay *= 2
+			}
+		}
+		logger.Debugf("dind socket ready at %s, linking /var/run/docker.sock", sockPath)
+		linkCmd := []string{"sh", "-c", fmt.Sprintf("ln -sf %s /var/run/docker.sock", sockPath)}
+		return rc.JobContainer.Exec(linkCmd, nil, "root", "/")(ctx)
+	}
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -46,6 +46,8 @@ type Config struct {
 	ContainerArchitecture              string                       // Desired OS/architecture platform for running containers
 	ContainerDaemonSocket              string                       // Path to Docker daemon socket
 	ContainerOptions                   string                       // Options for the job container
+	DockerDaemonService                bool                         // start a docker-in-docker service container
+	DockerDaemonServiceImage           string                       // image for the docker-in-docker service container
 	UseGitIgnore                       bool                         // controls if paths in .gitignore should not be copied into container, default true
 	GitHubInstance                     string                       // GitHub instance to use, default "github.com"
 	ContainerCapAdd                    []string                     // list of kernel capabilities to add to the containers

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -386,6 +386,8 @@ func TestRunEventDockerDaemonService(t *testing.T) {
 	tables := []TestJobFileInfo{
 		// The injected dockerd is reachable at /var/run/docker.sock.
 		{workdir, "docker-daemon-service", "push", "", platforms, secrets},
+		// dind and the job container share the workspace filesystem.
+		{workdir, "docker-daemon-service-shared-fs", "push", "", platforms, secrets},
 	}
 
 	for _, table := range tables {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -368,6 +368,65 @@ func TestRunEvent(t *testing.T) {
 	}
 }
 
+// TestRunEventDockerDaemonService exercises the injected docker-in-docker
+// service container end-to-end. Each subtest runs a workflow inside a
+// docker:cli job container, with --docker-daemon-service on and the host
+// socket bind suppressed (ContainerDaemonSocket == "-"), and verifies the
+// job can reach the injected dockerd at the canonical socket path.
+//
+// Requires a working outer Docker daemon that permits --privileged
+// containers (dind cannot run otherwise). Skipped under -short.
+func TestRunEventDockerDaemonService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	tables := []TestJobFileInfo{
+		// The injected dockerd is reachable at /var/run/docker.sock.
+		{workdir, "docker-daemon-service", "push", "", platforms, secrets},
+	}
+
+	for _, table := range tables {
+		t.Run(table.workflowPath, func(t *testing.T) {
+			workdirAbs, err := filepath.Abs(table.workdir)
+			assert.Nil(t, err, workdirAbs)
+			fullWorkflowPath := filepath.Join(workdirAbs, table.workflowPath)
+
+			cfg := &Config{
+				Workdir:                  workdirAbs,
+				BindWorkdir:              false,
+				EventName:                table.eventName,
+				Platforms:                table.platforms,
+				ReuseContainers:          false,
+				Secrets:                  table.secrets,
+				GitHubInstance:           "github.com",
+				ContainerDaemonSocket:    "-",
+				DockerDaemonService:      true,
+				DockerDaemonServiceImage: "docker:dind",
+			}
+
+			runner, err := New(cfg)
+			assert.Nil(t, err, table.workflowPath)
+
+			planner, err := model.NewWorkflowPlanner(fullWorkflowPath, true, false)
+			assert.Nil(t, err, fullWorkflowPath)
+
+			plan, err := planner.PlanEvent(table.eventName)
+			assert.Nil(t, err)
+			assert.NotNil(t, plan)
+
+			err = runner.NewPlanExecutor(plan)(ctx)
+			if table.errorMessage == "" {
+				assert.Nil(t, err, fullWorkflowPath)
+			} else {
+				assert.Error(t, err, table.errorMessage)
+			}
+		})
+	}
+}
+
 type captureJobLoggerFactory struct {
 	buffer bytes.Buffer
 }

--- a/pkg/runner/testdata/docker-daemon-service-shared-fs/push.yml
+++ b/pkg/runner/testdata/docker-daemon-service-shared-fs/push.yml
@@ -1,0 +1,63 @@
+name: docker-daemon-service-shared-fs
+on: push
+jobs:
+  # Proves that the injected dind service sees the same filesystem as the
+  # job container: a file written to $GITHUB_WORKSPACE from inside the job
+  # must be readable when dockerd bind-mounts that path into a helper
+  # container. This mirrors the GitHub-hosted runners' single-filesystem
+  # contract that testcontainers, `docker run -v $GITHUB_WORKSPACE:/x`, and
+  # `docker cp` all rely on.
+  shared-workspace:
+    runs-on: ubuntu-latest
+    container:
+      image: docker:cli
+    steps:
+      - name: seed a marker in the workspace from the job container
+        run: |
+          echo hello-shared-fs > "$GITHUB_WORKSPACE/marker.txt"
+          ls -la "$GITHUB_WORKSPACE/marker.txt"
+      - name: read the marker through the injected dind daemon
+        run: |
+          out=$(docker run --rm -v "$GITHUB_WORKSPACE":/w alpine:3.20 cat /w/marker.txt)
+          echo "got: $out"
+          test "$out" = hello-shared-fs
+
+  # Proves that extra volumes declared under `container.volumes` are also
+  # mirrored onto the dind service, not just the default workspace: both
+  # an anonymous named volume (mount) and a host-path bind must resolve
+  # to the same storage from the job container and from a container
+  # launched via the injected dockerd.
+  extra-volumes:
+    runs-on: ubuntu-latest
+    container:
+      image: docker:cli
+      volumes:
+        # Named volume: `mounts` codepath in GetBindsAndMounts.
+        - act-dind-shared-fs-vol:/shared-vol
+        # Host-path bind: `binds` codepath. /tmp exists on every runner
+        # and inside every reasonable container image, and act creates
+        # missing bind sources on demand.
+        - /tmp/act-dind-shared-fs-bind:/shared-bind
+    steps:
+      - name: seed markers on both extra volumes from the job container
+        run: |
+          echo hello-vol > /shared-vol/marker.txt
+          echo hello-bind > /shared-bind/marker.txt
+          ls -la /shared-vol/marker.txt /shared-bind/marker.txt
+      - name: read the named-volume marker through the injected dind daemon
+        run: |
+          out=$(docker run --rm -v /shared-vol:/x alpine:3.20 cat /x/marker.txt)
+          echo "got: $out"
+          test "$out" = hello-vol
+      - name: read the host-bind marker through the injected dind daemon
+        run: |
+          out=$(docker run --rm -v /shared-bind:/x alpine:3.20 cat /x/marker.txt)
+          echo "got: $out"
+          test "$out" = hello-bind
+      - name: clean up bind-mount contents so the host dir can be re-created
+        # Files written above are owned by root inside the container, so
+        # remove them from inside the container while we still can. The
+        # empty /tmp/act-dind-shared-fs-bind dir on the host is fine to
+        # leave behind (act re-uses it on subsequent runs).
+        if: always()
+        run: rm -f /shared-bind/marker.txt

--- a/pkg/runner/testdata/docker-daemon-service/push.yml
+++ b/pkg/runner/testdata/docker-daemon-service/push.yml
@@ -1,0 +1,17 @@
+name: docker-daemon-service
+on: push
+jobs:
+  # Proves that when act is started with --docker-daemon-service, the job
+  # container can talk to the injected dockerd via the canonical
+  # /var/run/docker.sock without any DOCKER_HOST plumbing.
+  dind-available:
+    runs-on: ubuntu-latest
+    container:
+      image: docker:cli
+    steps:
+      - name: docker socket must exist at the GitHub-hosted path
+        run: test -S /var/run/docker.sock
+      - name: docker version must reach the injected daemon
+        run: docker version
+      - name: run a container through the injected daemon
+        run: docker run --rm alpine:3.20 echo hello-from-dind


### PR DESCRIPTION
## Summary

Adds an opt-in Docker-in-Docker (dind) service that runs alongside every job's container when the workflow does not declare its own `docker` service, so steps can run `docker build`, `docker compose`, testcontainers, etc. **without bind-mounting the host's Docker socket** into the job container.

Off by default — existing runs are byte-identical.

Closes #2139

## Usage

```sh
# simplest: just turn it on
act --docker-daemon-service

# override the dind image
act --docker-daemon-service --docker-daemon-service-image=docker:27-dind
```

Inside the job container:

```sh
ls -l /var/run/docker.sock          # exists, symlinked to the shared socket
docker version                      # talks to the injected dockerd
docker run --rm -v "$GITHUB_WORKSPACE:/w" alpine cat /w/marker
```

No `DOCKER_HOST` needed. Workflows that hardcode `/var/run/docker.sock` keep working.

## Why not just mount `/var/run/docker.sock` from the host?

That's what `act` does today by default, and it's what #2139 explicitly wants to avoid: any workflow step can then root the host, and paths handed to dockerd resolve on the host filesystem, not the workflow's. This change gives users a per-run daemon whose lifecycle is bounded by the job and whose filesystem view matches the job container.

## Design

Two commits:

### 1. `feat(runner): inject optional docker-in-docker service container`

- Two new CLI flags plumbed through `cmd.Input` into `runner.Config`:
  - `--docker-daemon-service` (bool, default off)
  - `--docker-daemon-service-image` (string, default `docker:dind`)
- **Socket-sharing, not TCP.** dind runs with `DOCKER_TLS_CERTDIR=""` and `dockerd --host=unix:///var/run/act-dind/docker.sock`. A per-job named volume `<jobcontainer>-dind-sock` is mounted at `/var/run/act-dind` in both containers. Mirrors GitHub-hosted runners, which expose a plain unix socket with no `DOCKER_HOST`. No forced bridge network (`--network host` is preserved), no TLS-cert bootstrap.
- **`/var/run/docker.sock` symlink.** After dind is up, a post-start step polls for the socket (bounded, exponential backoff, 2 min cap) and drops `/var/run/docker.sock -> /var/run/act-dind/docker.sock` inside the job container. GitHub-identical path; nothing else needs `DOCKER_HOST`.
- **Injection stays out of the workflow model.** The dind container is only appended to `rc.ServiceContainers` at runtime, never to `rc.Run.Job().Services`. `${{ job.services }}` therefore reflects only what the user wrote in YAML, preserving compatibility with expressions, reusable-workflow outputs, and downstream tooling. `useDockerDaemonService()` returns false when the workflow already declares a service literally named `docker`, so a user-defined service always wins.
- **Lifecycle reuses existing plumbing.** dind flows through `pullServicesImages` / `startServiceContainers` / `waitForServiceContainers` / `stopServiceContainers` unchanged. Cleanup removes the per-job socket volume too (skipped under `--reuse`).
- **Mutually exclusive with `--container-daemon-socket`**, extracted into `validateDockerDaemonServiceFlags` so it's unit-testable:
  - not explicitly set → auto-forced to `-` so the default host-socket bind is suppressed;
  - explicitly `-` → accepted;
  - anything else → hard error with the offending value quoted.

### 2. `feat(runner): mirror job binds/mounts onto the dind service container`

GitHub-hosted runners run dockerd on the same filesystem as the job. `docker run -v $GITHUB_WORKSPACE:/x`, testcontainers volume mounts, `docker cp` between job and helper containers, and actions that bind `/opt/hostedtoolcache` into sidecars all resolve identically on both sides. Passes the job container's binds/mounts through to the dind container:

- workdir bind (when `BindWorkdir` on) or anonymous workdir volume (when off) attached to dind at the same in-container path;
- named volumes (`act-toolcache`, `<name>-env`, user-declared `job.container.volumes`) shared with dind;
- the shared socket volume is already in the mount map.

Also fixes a latent cleanup-ordering bug this makes deterministic: we were removing named volumes before stopping service containers, so any service holding a workdir/toolcache volume (dind, or a user-declared service that mounts the workdir) failed with `volume is in use`. Now the pipeline stops the job container, stops all service containers and the ad-hoc network, and *then* removes the volumes.

## Compatibility

- Flag off (default): no code path changes, no new containers, no new volumes. Full test suite unchanged.
- Flag on + workflow declares `services.docker`: user's service wins, no injection.
- Flag on + no user `docker` service: dind is injected, `job.services` context is untouched.
- Embedders (Gitea/Forgejo `act_runner`) that consume `runner.Config` only see two new opt-in fields — additive, no semver break.

## Tests

Unit:
- `cmd.TestValidateDockerDaemonServiceFlags` — 9 subtests covering the full matrix of `dockerDaemonService × containerDaemonSocket × flag.Changed`, asserting both the error (with substring match on the quoted offending value) and the resulting socket value.

Integration (`pkg/runner.TestRunEventDockerDaemonService`, skipped under `-short`, needs a real Docker daemon that permits `--privileged`):

- `testdata/docker-daemon-service/push.yml` — verifies `/var/run/docker.sock` exists at the GitHub-hosted path, `docker version` reaches the injected daemon, and `docker run alpine` succeeds through it.
- `testdata/docker-daemon-service-shared-fs/push.yml` — writes a marker to `$GITHUB_WORKSPACE`, then starts an `alpine` container via the injected dockerd with `-v $GITHUB_WORKSPACE:/w` and reads the marker back, proving the shared-filesystem invariant.

Verified on Docker 29.7.2:

```
--- PASS: TestRunEventDockerDaemonService (19.49s)
    --- PASS: TestRunEventDockerDaemonService/docker-daemon-service (8.88s)
    --- PASS: TestRunEventDockerDaemonService/docker-daemon-service-shared-fs (10.61s)
ok  github.com/nektos/act/cmd         22.552s
ok  github.com/nektos/act/pkg/runner   5.835s
```

## Out of scope

- Rootless / Podman: dind requires `--privileged` on the outer daemon. Rootless setups should keep using `--container-daemon-socket=-` and run their own dind sidecar out-of-band.
- Per-job dind image pinning via workflow syntax — image is a CLI/config concern, not a workflow concern.

## Disclaimer

This change was developed with AI assistance (pair-programming with a large language model). I drove the design decisions, reviewed every diff, and ran the full unit and integration test suites locally on Docker 29.7.2 before pushing. Any bugs are mine, not the model's.