### PR TITLE
fix: map Go's arm64 to ARM64 in host environment runner arch

### DIFF
--- a/pkg/container/host_environment.go
+++ b/pkg/container/host_environment.go
@@ -427,6 +427,7 @@ func goArchToActionArch(arch string) string {
 		"x86_64":  "X64",
 		"386":     "X86",
 		"aarch64": "ARM64",
+		"arm64":   "ARM64",
 	}
 	if arch, ok := archMapper[arch]; ok {
 		return arch


### PR DESCRIPTION
## Summary

When running `act` with `-P ubuntu-latest=-self-hosted` on an ARM64 host, `RUNNER_ARCH` and `runner.arch` were set to `arm64` (lowercase) instead of `ARM64`, violating the [GitHub Actions spec](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context) which defines the valid values as `X86`, `X64`, `ARM`, `ARM64` (always uppercase).

**Root cause:** `goArchToActionArch()` in `pkg/container/host_environment.go` had a mapping for `"aarch64" -> "ARM64"` but was missing `"arm64"`, which is what Go's `runtime.GOARCH` returns on ARM64 hosts. The value fell through the mapper and was returned verbatim in lowercase.

The Docker container path (`docker_run.go`) already handled `"arm64"` correctly - this aligns `host_environment.go` with the same mapping.

## Change

One line added to `goArchToActionArch()` in `pkg/container/host_environment.go`:

```go
"arm64": "ARM64",
```

Fixes #6181